### PR TITLE
Thread safe find eh_frame

### DIFF
--- a/src/elfxx.h
+++ b/src/elfxx.h
@@ -54,6 +54,8 @@ extern int elf_w (get_proc_name_in_image) (unw_addr_space_t as,
                                            unw_word_t ip,
                                            char *buf, size_t buf_len, unw_word_t *offp);
 
+extern Elf_W (Shdr)* elf_w (find_section) (struct elf_image *ei, const char* secname);
+
 static inline int
 elf_w (valid_object) (struct elf_image *ei)
 {


### PR DESCRIPTION
Instead of just removing the 'static' from sec_hdrs, I decided to make code from elfxx.h re-usable to find any EFL section.