### PR TITLE
Don't link with gcc_s when compiling for Android

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,6 +105,19 @@ SET_ARCH([$build_cpu],[build_arch])
 SET_ARCH([$host_cpu],[host_arch])
 SET_ARCH([$target_cpu],[target_arch])
 
+# Check for Android
+AC_MSG_CHECKING([for Android])
+android="no"
+case "$host_os" in
+  *android*)
+    android="yes"
+    AC_MSG_RESULT([yes])
+    ;;
+  *)
+    AC_MSG_RESULT([no])
+    ;;
+esac
+
 AC_ARG_ENABLE(coredump,
 	AS_HELP_STRING([--enable-coredump],[building libunwind-coredump library]),,
         [AS_CASE([$host_arch], [aarch64*|arm*|mips*|sh*|x86*|tile*], [enable_coredump=yes], [enable_coredump=no])]
@@ -319,7 +332,7 @@ else
     LDFLAGS_NOSTARTFILES="-XCClinker -nostartfiles"
 fi
 
-if test x$GCC = xyes -a x$intel_compiler != xyes -a x$qcc_compiler != xyes; then
+if test x$GCC = xyes -a x$intel_compiler != xyes -a x$qcc_compiler != xyes -a x$android != xyes; then
   LIBCRTS="-lgcc_s"
 fi
 


### PR DESCRIPTION
Currently libunwind fails to compile out of the box for Android because it will link with libgcc_s. That library doesn't exist on Android, so linking will fail.

With this change, you can cross-compile libunwind for Android using the NDK toolchain and sysroot:

```
./autogen.sh
./configure CC=$CC --with-sysroot=$SYSROOT --host=aarch64-linux-androideabi --target=aarch64-linux-androideabi --disable-tests --disable-coredump
```

with `$CC` set to `[toolchain]bin/aarch64-linux-android-clang` and `$SYSROOT` set to `[toolchain]sysroot/`.