### PR TITLE
Bring back support for UNW_CACHE_PER_THREAD.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -298,7 +298,16 @@ fi
 AC_SUBST([LIBLZMA])
 AM_CONDITIONAL(HAVE_LZMA, test x$enable_minidebuginfo = xyes)
 
-LIBUNWIND___THREAD
+AC_MSG_CHECKING([whether to support UNW_CACHE_PER_THREAD])
+AC_ARG_ENABLE([per-thread-cache],
+AS_HELP_STRING([--enable-per-thread-cache], [build with support for UNW_CACHE_PER_THREAD (which imposes a hight TLS memory usage) (default: disabled)]))
+AC_MSG_RESULT([$enable_per_thread_cache])
+AS_IF([test x$enable_per_thread_cache = xyes], [
+  LIBUNWIND___THREAD
+  AS_IF([test x$libc_cv_gcc___thread = xno], [
+    AC_MSG_FAILURE([UNW_CACHE_PER_THREAD requires __thread])
+  ])
+])
 
 AC_MSG_CHECKING([for Intel compiler])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[#ifndef __INTEL_COMPILER

--- a/configure.ac
+++ b/configure.ac
@@ -309,6 +309,13 @@ AS_IF([test x$enable_per_thread_cache = xyes], [
   ])
 ])
 
+AC_LANG_PUSH([C])
+unw_cflags_save=${CFLAGS}
+CFLAGS=""
+AC_OPENMP
+CFLAGS=${unw_cflags_save}
+AC_LANG_POP([C])
+
 AC_MSG_CHECKING([for Intel compiler])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[#ifndef __INTEL_COMPILER
 #error choke me

--- a/include/dwarf.h
+++ b/include/dwarf.h
@@ -37,13 +37,6 @@ struct elf_dyn_info;
 # include "config.h"
 #endif
 
-#ifdef HAVE___THREAD
-  /* For now, turn off per-thread caching.  It uses up too much TLS
-     memory per thread even when the thread never uses libunwind at
-     all.  */
-# undef HAVE___THREAD
-#endif
-
 #ifndef UNW_REMOTE_ONLY
   #if defined(HAVE_LINK_H)
     #include <link.h>

--- a/include/libunwind_i.h
+++ b/include/libunwind_i.h
@@ -37,11 +37,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "compiler.h"
 
-#ifdef HAVE___THREAD
-  /* For now, turn off per-thread caching.  It uses up too much TLS
-     memory per thread even when the thread never uses libunwind at
-     all.  */
-# undef HAVE___THREAD
+#if defined(HAVE___THREAD) && HAVE___THREAD
+#define UNWI_DEFAULT_CACHING_POLICY UNW_CACHE_PER_THREAD
+#else
+#define UNWI_DEFAULT_CACHING_POLICY UNW_CACHE_GLOBAL
 #endif
 
 /* Platform-independent libunwind-internal declarations.  */

--- a/include/tdep-tilegx/libunwind_i.h
+++ b/include/tdep-tilegx/libunwind_i.h
@@ -36,10 +36,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "mempool.h"
 #include "dwarf.h"
 
-#ifdef HAVE___THREAD
-# undef HAVE___THREAD
-#endif
-
 typedef struct
 {
   /* no Tilegx-specific fast trace */

--- a/src/aarch64/Ginit.c
+++ b/src/aarch64/Ginit.c
@@ -172,7 +172,7 @@ HIDDEN void
 aarch64_local_addr_space_init (void)
 {
   memset (&local_addr_space, 0, sizeof (local_addr_space));
-  local_addr_space.caching_policy = UNW_CACHE_GLOBAL;
+  local_addr_space.caching_policy = UNWI_DEFAULT_CACHING_POLICY;
   local_addr_space.acc.find_proc_info = dwarf_find_proc_info;
   local_addr_space.acc.put_unwind_info = put_unwind_info;
   local_addr_space.acc.get_dyn_info_list_addr = get_dyn_info_list_addr;

--- a/src/aarch64/Gtrace.c
+++ b/src/aarch64/Gtrace.c
@@ -70,7 +70,7 @@ trace_cache_free (void *arg)
   }
   tls_cache_destroyed = 1;
   tls_cache = NULL;
-  munmap (cache->frames, (1u << cache->log_size) * sizeof(unw_tdep_frame_t));
+  mi_munmap (cache->frames, (1u << cache->log_size) * sizeof(unw_tdep_frame_t));
   mempool_free (&trace_cache_pool, cache);
   Debug(5, "freed cache %p\n", cache);
 }
@@ -152,7 +152,7 @@ trace_cache_expand (unw_trace_cache_t *cache)
   }
 
   Debug(5, "expanded cache from 2^%lu to 2^%lu buckets\n", cache->log_size, new_log_size);
-  munmap(cache->frames, old_size * sizeof(unw_tdep_frame_t));
+  mi_munmap(cache->frames, old_size * sizeof(unw_tdep_frame_t));
   cache->frames = new_frames;
   cache->log_size = new_log_size;
   cache->used = 0;

--- a/src/arm/Ginit.c
+++ b/src/arm/Ginit.c
@@ -220,7 +220,7 @@ HIDDEN void
 arm_local_addr_space_init (void)
 {
   memset (&local_addr_space, 0, sizeof (local_addr_space));
-  local_addr_space.caching_policy = UNW_CACHE_GLOBAL;
+  local_addr_space.caching_policy = UNWI_DEFAULT_CACHING_POLICY;
   local_addr_space.acc.find_proc_info = arm_find_proc_info;
   local_addr_space.acc.put_unwind_info = arm_put_unwind_info;
   local_addr_space.acc.get_dyn_info_list_addr = get_dyn_info_list_addr;

--- a/src/arm/Gtrace.c
+++ b/src/arm/Gtrace.c
@@ -70,7 +70,7 @@ trace_cache_free (void *arg)
   }
   tls_cache_destroyed = 1;
   tls_cache = NULL;
-  munmap (cache->frames, (1u << cache->log_size) * sizeof(unw_tdep_frame_t));
+  mi_munmap (cache->frames, (1u << cache->log_size) * sizeof(unw_tdep_frame_t));
   mempool_free (&trace_cache_pool, cache);
   Debug(5, "freed cache %p\n", cache);
 }
@@ -153,7 +153,7 @@ trace_cache_expand (unw_trace_cache_t *cache)
 
   Debug(5, "expanded cache from 2^%u to 2^%u buckets\n", cache->log_size,
         new_log_size);
-  munmap(cache->frames, old_size * sizeof(unw_tdep_frame_t));
+  mi_munmap(cache->frames, old_size * sizeof(unw_tdep_frame_t));
   cache->frames = new_frames;
   cache->log_size = new_log_size;
   cache->used = 0;

--- a/src/coredump/_UCD_elf_map_image.c
+++ b/src/coredump/_UCD_elf_map_image.c
@@ -49,7 +49,7 @@ CD_elf_map_image(struct UCD_info *ui, coredump_phdr_t *phdr)
       if (remainder_len > 0)
         {
           void *remainder_base = (char*) ei->image + phdr->p_filesz;
-          munmap(remainder_base, remainder_len);
+          mi_munmap(remainder_base, remainder_len);
         }
     } else {
       /* We have a backing file for this segment.
@@ -72,7 +72,7 @@ CD_elf_map_image(struct UCD_info *ui, coredump_phdr_t *phdr)
   /* Check ELF header for sanity */
   if (!elf_w(valid_object)(ei))
     {
-      munmap(ei->image, ei->size);
+      mi_munmap(ei->image, ei->size);
       ei->image = NULL;
       ei->size = 0;
       return NULL;

--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -108,7 +108,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local)
   if (!shdr ||
       (shdr->sh_offset + shdr->sh_size > ei.size))
     {
-      munmap(ei.image, ei.size);
+      mi_munmap(ei.image, ei.size);
       return 1;
     }
 
@@ -120,7 +120,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local)
   Debug (4, "read %zd bytes of .debug_frame from offset %zd\n",
 	 *bufsize, shdr->sh_offset);
 
-  munmap(ei.image, ei.size);
+  mi_munmap(ei.image, ei.size);
   return 0;
 }
 
@@ -448,7 +448,7 @@ dwarf_find_eh_frame_section(struct dl_phdr_info *info)
          eh_frame);
 
 out:
-  munmap (ei.image, ei.size);
+  mi_munmap (ei.image, ei.size);
 
   return eh_frame;
 }

--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -537,11 +537,11 @@ dwarf_flush_rs_cache (struct dwarf_rs_cache *cache)
     cache->log_size = DWARF_DEFAULT_LOG_UNW_CACHE_SIZE;
   } else {
     if (cache->hash && cache->hash != cache->default_hash)
-      munmap(cache->hash, DWARF_UNW_HASH_SIZE(cache->prev_log_size)
-                           * sizeof (cache->hash[0]));
+      mi_munmap(cache->hash, DWARF_UNW_HASH_SIZE(cache->prev_log_size)
+                              * sizeof (cache->hash[0]));
     if (cache->buckets && cache->buckets != cache->default_buckets)
-      munmap(cache->buckets, DWARF_UNW_CACHE_SIZE(cache->prev_log_size)
-	                      * sizeof (cache->buckets[0]));
+      mi_munmap(cache->buckets, DWARF_UNW_CACHE_SIZE(cache->prev_log_size)
+	                         * sizeof (cache->buckets[0]));
     GET_MEMORY(cache->hash, DWARF_UNW_HASH_SIZE(cache->log_size)
                              * sizeof (cache->hash[0]));
     GET_MEMORY(cache->buckets, DWARF_UNW_CACHE_SIZE(cache->log_size)

--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -580,7 +580,17 @@ get_rs_cache (unw_addr_space_t as, intrmask_t *saved_maskp)
   if (caching == UNW_CACHE_NONE)
     return NULL;
 
+#if defined(HAVE___THREAD) && HAVE___THREAD
+  if (likely (caching == UNW_CACHE_PER_THREAD))
+    {
+      static __thread struct dwarf_rs_cache tls_cache __attribute__((tls_model("initial-exec")));
+      Debug (16, "using TLS cache\n");
+      cache = &tls_cache;
+    }
+  else
+#else
   if (likely (caching == UNW_CACHE_GLOBAL))
+#endif
     {
       Debug (16, "acquiring lock\n");
       lock_acquire (&cache->lock, *saved_maskp);
@@ -589,6 +599,8 @@ get_rs_cache (unw_addr_space_t as, intrmask_t *saved_maskp)
   if ((atomic_read (&as->cache_generation) != atomic_read (&cache->generation))
        || !cache->hash)
     {
+      /* cache_size is only set in the global_cache, copy it over before flushing */
+      cache->log_size = as->global_cache.log_size;
       if (dwarf_flush_rs_cache (cache) < 0)
         return NULL;
       cache->generation = as->cache_generation;

--- a/src/elfxx.c
+++ b/src/elfxx.c
@@ -248,7 +248,7 @@ elf_w (extract_minidebuginfo) (struct elf_image *ei, struct elf_image *mdi)
   if (lret != LZMA_OK)
     {
       Debug (1, "LZMA decompression failed: %d\n", lret);
-      munmap (mdi->image, mdi->size);
+      mi_munmap (mdi->image, mdi->size);
       return 0;
     }
 
@@ -295,7 +295,7 @@ elf_w (get_proc_name_in_image) (unw_addr_space_t as, struct elf_image *ei,
           ret = ret_mdi;
         }
 
-      munmap (mdi.image, mdi.size);
+      mi_munmap (mdi.image, mdi.size);
     }
 
   if (min_dist >= ei->size)
@@ -324,7 +324,7 @@ elf_w (get_proc_name) (unw_addr_space_t as, pid_t pid, unw_word_t ip,
 
   ret = elf_w (get_proc_name_in_image) (as, &ei, segbase, mapoff, ip, buf, buf_len, offp);
 
-  munmap (ei.image, ei.size);
+  mi_munmap (ei.image, ei.size);
   ei.image = NULL;
 
   return ret;
@@ -420,7 +420,7 @@ elf_w (load_debuglink) (const char* file, struct elf_image *ei, int is_local)
       if (memchr (linkbuf, 0, shdr->sh_size) == NULL)
 	return 0;
 
-      munmap (ei->image, ei->size);
+      mi_munmap (ei->image, ei->size);
       ei->image = NULL;
 
       Debug(1, "Found debuglink section, following %s\n", linkbuf);

--- a/src/elfxx.h
+++ b/src/elfxx.h
@@ -93,7 +93,7 @@ elf_map_image (struct elf_image *ei, const char *path)
 
   if (!elf_w (valid_object) (ei))
   {
-    munmap(ei->image, ei->size);
+    mi_munmap(ei->image, ei->size);
     return -1;
   }
 

--- a/src/hppa/Ginit.c
+++ b/src/hppa/Ginit.c
@@ -179,7 +179,7 @@ HIDDEN void
 hppa_local_addr_space_init (void)
 {
   memset (&local_addr_space, 0, sizeof (local_addr_space));
-  local_addr_space.caching_policy = UNW_CACHE_GLOBAL;
+  local_addr_space.caching_policy = UNWI_DEFAULT_CACHING_POLICY;
   local_addr_space.acc.find_proc_info = dwarf_find_proc_info;
   local_addr_space.acc.put_unwind_info = put_unwind_info;
   local_addr_space.acc.get_dyn_info_list_addr = get_dyn_info_list_addr;

--- a/src/ia64/Ginit.c
+++ b/src/ia64/Ginit.c
@@ -361,7 +361,7 @@ ia64_local_addr_space_init (void)
 #elif defined(__hpux)
   local_addr_space.abi = ABI_HPUX;
 #endif
-  local_addr_space.caching_policy = UNW_CACHE_GLOBAL;
+  local_addr_space.caching_policy = UNWI_DEFAULT_CACHING_POLICY;
   local_addr_space.acc.find_proc_info = tdep_find_proc_info;
   local_addr_space.acc.put_unwind_info = put_unwind_info;
   local_addr_space.acc.get_dyn_info_list_addr = get_dyn_info_list_addr;

--- a/src/ia64/Gscript.c
+++ b/src/ia64/Gscript.c
@@ -45,7 +45,7 @@ enum ia64_script_insn_opcode
     IA64_INSN_MOVE_SCRATCH_NO_NAT /* like above, but clear NaT info */
   };
 
-#ifdef HAVE___THREAD
+#if defined(HAVE___THREAD) && HAVE___THREAD
 static __thread struct ia64_script_cache ia64_per_thread_cache =
   {
 #ifdef HAVE_ATOMIC_OPS_H
@@ -105,7 +105,7 @@ get_script_cache (unw_addr_space_t as, intrmask_t *saved_maskp)
   if (!spin_trylock_irqsave (&cache->busy, *saved_maskp))
     return NULL;
 #else
-# ifdef HAVE___THREAD
+# if defined(HAVE___THREAD) && HAVE___THREAD
   if (as->caching_policy == UNW_CACHE_PER_THREAD)
     cache = &ia64_per_thread_cache;
 # endif

--- a/src/mi/Gset_caching_policy.c
+++ b/src/mi/Gset_caching_policy.c
@@ -31,7 +31,7 @@ unw_set_caching_policy (unw_addr_space_t as, unw_caching_policy_t policy)
   if (!tdep_init_done)
     tdep_init ();
 
-#ifndef HAVE___THREAD
+#if !(defined(HAVE___THREAD) && HAVE___THREAD)
   if (policy == UNW_CACHE_PER_THREAD)
     policy = UNW_CACHE_GLOBAL;
 #endif

--- a/src/mips/Ginit.c
+++ b/src/mips/Ginit.c
@@ -195,7 +195,7 @@ mips_local_addr_space_init (void)
 # error Unsupported ABI
 #endif
   local_addr_space.addr_size = sizeof (void *);
-  local_addr_space.caching_policy = UNW_CACHE_GLOBAL;
+  local_addr_space.caching_policy = UNWI_DEFAULT_CACHING_POLICY;
   local_addr_space.acc.find_proc_info = dwarf_find_proc_info;
   local_addr_space.acc.put_unwind_info = put_unwind_info;
   local_addr_space.acc.get_dyn_info_list_addr = get_dyn_info_list_addr;

--- a/src/os-freebsd.c
+++ b/src/os-freebsd.c
@@ -46,7 +46,7 @@ get_mem(size_t sz)
 static void
 free_mem(void *ptr, size_t sz)
 {
-  munmap(ptr, sz);
+  mi_munmap(ptr, sz);
 }
 
 static int

--- a/src/os-linux.h
+++ b/src/os-linux.h
@@ -289,7 +289,7 @@ maps_close (struct map_iterator *mi)
   mi->fd = -1;
   if (mi->buf)
     {
-      munmap (mi->buf_end - mi->buf_size, mi->buf_size);
+      mi_munmap (mi->buf_end - mi->buf_size, mi->buf_size);
       mi->buf = mi->buf_end = NULL;
     }
 }

--- a/src/ppc32/Ginit.c
+++ b/src/ppc32/Ginit.c
@@ -201,7 +201,7 @@ HIDDEN void
 ppc32_local_addr_space_init (void)
 {
   memset (&local_addr_space, 0, sizeof (local_addr_space));
-  local_addr_space.caching_policy = UNW_CACHE_GLOBAL;
+  local_addr_space.caching_policy = UNWI_DEFAULT_CACHING_POLICY;
   local_addr_space.acc.find_proc_info = dwarf_find_proc_info;
   local_addr_space.acc.put_unwind_info = put_unwind_info;
   local_addr_space.acc.get_dyn_info_list_addr = get_dyn_info_list_addr;

--- a/src/ppc64/Ginit.c
+++ b/src/ppc64/Ginit.c
@@ -214,7 +214,7 @@ ppc64_local_addr_space_init (void)
 #else
   local_addr_space.abi = UNW_PPC64_ABI_ELFv1;
 #endif
-  local_addr_space.caching_policy = UNW_CACHE_GLOBAL;
+  local_addr_space.caching_policy = UNWI_DEFAULT_CACHING_POLICY;
   local_addr_space.acc.find_proc_info = dwarf_find_proc_info;
   local_addr_space.acc.put_unwind_info = put_unwind_info;
   local_addr_space.acc.get_dyn_info_list_addr = get_dyn_info_list_addr;

--- a/src/sh/Ginit.c
+++ b/src/sh/Ginit.c
@@ -171,7 +171,7 @@ HIDDEN void
 sh_local_addr_space_init (void)
 {
   memset (&local_addr_space, 0, sizeof (local_addr_space));
-  local_addr_space.caching_policy = UNW_CACHE_GLOBAL;
+  local_addr_space.caching_policy = UNWI_DEFAULT_CACHING_POLICY;
   local_addr_space.acc.find_proc_info = dwarf_find_proc_info;
   local_addr_space.acc.put_unwind_info = put_unwind_info;
   local_addr_space.acc.get_dyn_info_list_addr = get_dyn_info_list_addr;

--- a/src/tilegx/Ginit.c
+++ b/src/tilegx/Ginit.c
@@ -152,7 +152,7 @@ tilegx_local_addr_space_init (void)
 
   local_addr_space.abi = UNW_TILEGX_ABI_N64;
   local_addr_space.addr_size = sizeof (void *);
-  local_addr_space.caching_policy = UNW_CACHE_GLOBAL;
+  local_addr_space.caching_policy = UNWI_DEFAULT_CACHING_POLICY;
   local_addr_space.acc.find_proc_info = dwarf_find_proc_info;
   local_addr_space.acc.put_unwind_info = put_unwind_info;
   local_addr_space.acc.get_dyn_info_list_addr = get_dyn_info_list_addr;

--- a/src/x86/Ginit.c
+++ b/src/x86/Ginit.c
@@ -228,7 +228,7 @@ HIDDEN void
 x86_local_addr_space_init (void)
 {
   memset (&local_addr_space, 0, sizeof (local_addr_space));
-  local_addr_space.caching_policy = UNW_CACHE_GLOBAL;
+  local_addr_space.caching_policy = UNWI_DEFAULT_CACHING_POLICY;
   local_addr_space.acc.find_proc_info = dwarf_find_proc_info;
   local_addr_space.acc.put_unwind_info = put_unwind_info;
   local_addr_space.acc.get_dyn_info_list_addr = get_dyn_info_list_addr;

--- a/src/x86_64/Ginit.c
+++ b/src/x86_64/Ginit.c
@@ -310,7 +310,7 @@ HIDDEN void
 x86_64_local_addr_space_init (void)
 {
   memset (&local_addr_space, 0, sizeof (local_addr_space));
-  local_addr_space.caching_policy = UNW_CACHE_GLOBAL;
+  local_addr_space.caching_policy = UNWI_DEFAULT_CACHING_POLICY;
   local_addr_space.acc.find_proc_info = dwarf_find_proc_info;
   local_addr_space.acc.put_unwind_info = put_unwind_info;
   local_addr_space.acc.get_dyn_info_list_addr = get_dyn_info_list_addr;

--- a/src/x86_64/Gtrace.c
+++ b/src/x86_64/Gtrace.c
@@ -68,7 +68,7 @@ trace_cache_free (void *arg)
   }
   tls_cache_destroyed = 1;
   tls_cache = NULL;
-  munmap (cache->frames, (1u << cache->log_size) * sizeof(unw_tdep_frame_t));
+  mi_munmap (cache->frames, (1u << cache->log_size) * sizeof(unw_tdep_frame_t));
   mempool_free (&trace_cache_pool, cache);
   Debug(5, "freed cache %p\n", cache);
 }
@@ -150,7 +150,7 @@ trace_cache_expand (unw_trace_cache_t *cache)
   }
 
   Debug(5, "expanded cache from 2^%lu to 2^%lu buckets\n", cache->log_size, new_log_size);
-  munmap(cache->frames, old_size * sizeof(unw_tdep_frame_t));
+  mi_munmap(cache->frames, old_size * sizeof(unw_tdep_frame_t));
   cache->frames = new_frames;
   cache->log_size = new_log_size;
   cache->used = 0;

--- a/tests/Gperf-simple.c
+++ b/tests/Gperf-simple.c
@@ -249,6 +249,8 @@ main (int argc, char **argv)
 
   measure_init ();
 
+  doit ("default         ");
+
   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_NONE);
   doit ("no cache        ");
 

--- a/tests/Gperf-simple.c
+++ b/tests/Gperf-simple.c
@@ -129,6 +129,7 @@ doit (const char *label)
       if (i == 0)
 	first_step = step;
     }
+  #pragma omp single
   printf ("%s: unw_step : 1st=%9.3f min=%9.3f avg=%9.3f nsec\n", label,
 	  1e9*first_step, 1e9*min_step, 1e9*sum_step/iterations);
 }
@@ -249,15 +250,19 @@ main (int argc, char **argv)
 
   measure_init ();
 
+  #pragma omp parallel
   doit ("default         ");
 
   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_NONE);
+  #pragma omp parallel
   doit ("no cache        ");
 
   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_GLOBAL);
+  #pragma omp parallel
   doit ("global cache    ");
 
   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_PER_THREAD);
+  #pragma omp parallel
   doit ("per-thread cache");
 
   return 0;

--- a/tests/Gperf-trace.c
+++ b/tests/Gperf-trace.c
@@ -235,6 +235,8 @@ main (int argc, char **argv)
 
   measure_init ();
 
+  doit ("default         ");
+
   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_NONE);
   doit ("no cache        ");
 

--- a/tests/Gperf-trace.c
+++ b/tests/Gperf-trace.c
@@ -115,6 +115,7 @@ doit (const char *label)
       if (i == 0)
 	first_step = step;
     }
+  #pragma omp single
   printf ("%s: unw_step : 1st=%9.3f min=%9.3f avg=%9.3f nsec\n", label,
 	  1e9*first_step, 1e9*min_step, 1e9*sum_step/iterations);
 }
@@ -235,15 +236,19 @@ main (int argc, char **argv)
 
   measure_init ();
 
+  #pragma omp parallel
   doit ("default         ");
 
   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_NONE);
+  #pragma omp parallel
   doit ("no cache        ");
 
   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_GLOBAL);
+  #pragma omp parallel
   doit ("global cache    ");
 
   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_PER_THREAD);
+  #pragma omp parallel
   doit ("per-thread cache");
 
   return 0;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -186,8 +186,10 @@ Gtest_exc_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 Gtest_init_LDADD = $(LIBUNWIND) $(LIBUNWIND_local) @BACKTRACELIB@
 Gtest_resume_sig_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 Gtest_resume_sig_rt_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
+Gperf_simple_CFLAGS = $(AM_CFLAGS) $(OPENMP_CFLAGS)
 Gperf_simple_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 Gtest_trace_LDADD=$(LIBUNWIND) $(LIBUNWIND_local)
+Gperf_trace_CFLAGS = $(AM_CFLAGS) $(OPENMP_CFLAGS)
 Gperf_trace_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 
 Ltest_bt_LDADD = $(LIBUNWIND_local)
@@ -199,8 +201,10 @@ Ltest_nomalloc_LDADD = $(LIBUNWIND_local) @DLLIB@
 Ltest_nocalloc_LDADD = $(LIBUNWIND_local) @DLLIB@ -lpthread
 Ltest_resume_sig_LDADD = $(LIBUNWIND_local)
 Ltest_resume_sig_rt_LDADD = $(LIBUNWIND_local)
+Lperf_simple_CFLAGS = $(AM_CFLAGS) $(OPENMP_CFLAGS)
 Lperf_simple_LDADD = $(LIBUNWIND_local)
 Ltest_trace_LDADD = $(LIBUNWIND_local)
+Lperf_trace_CFLAGS = $(AM_CFLAGS) $(OPENMP_CFLAGS)
 Lperf_trace_LDADD = $(LIBUNWIND_local)
 
 test_setjmp_LDADD = $(LIBUNWIND_setjmp)


### PR DESCRIPTION
Needs to be build with --enable-per-thread-cache.

@JoZie can you please test this (performance only), though we need a call to
```
unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_PER_THREAD);
```

somewhere in our init-phase.