### PR TITLE
dwarf_find_save_locs fixes

### DIFF
--- a/include/dwarf.h
+++ b/include/dwarf.h
@@ -398,7 +398,6 @@ struct dwarf_callback_data
 #define dwarf_extract_proc_info_from_fde \
                 UNW_OBJ (dwarf_extract_proc_info_from_fde)
 #define dwarf_find_save_locs            UNW_OBJ (dwarf_find_save_locs)
-#define dwarf_create_state_record       UNW_OBJ (dwarf_create_state_record)
 #define dwarf_make_proc_info            UNW_OBJ (dwarf_make_proc_info)
 #define dwarf_read_encoded_pointer      UNW_OBJ (dwarf_read_encoded_pointer)
 #define dwarf_step                      UNW_OBJ (dwarf_step)
@@ -441,8 +440,6 @@ extern int dwarf_extract_proc_info_from_fde (unw_addr_space_t as,
                                              int is_debug_frame,
                                              void *arg);
 extern int dwarf_find_save_locs (struct dwarf_cursor *c);
-extern int dwarf_create_state_record (struct dwarf_cursor *c,
-                                      dwarf_state_record_t *sr);
 extern int dwarf_make_proc_info (struct dwarf_cursor *c);
 extern int dwarf_read_encoded_pointer (unw_addr_space_t as,
                                        unw_accessors_t *a,

--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -880,7 +880,7 @@ HIDDEN int
 dwarf_find_save_locs (struct dwarf_cursor *c)
 {
   dwarf_state_record_t sr;
-  dwarf_reg_state_t *rs, rs_copy;
+  dwarf_reg_state_t *rs;
   struct dwarf_rs_cache *cache;
   int ret = 0;
   intrmask_t saved_mask;
@@ -894,8 +894,7 @@ dwarf_find_save_locs (struct dwarf_cursor *c)
       c->hint = rs->hint;
       c->ret_addr_column = rs->ret_addr_column;
       c->use_prev_instr = ! rs->signal_frame;
-      memcpy (&rs_copy, rs, sizeof (rs_copy));
-      rs = &rs_copy;
+      memcpy (&sr.rs_current, rs, sizeof (*rs));
     }
   else
     {
@@ -912,7 +911,6 @@ dwarf_find_save_locs (struct dwarf_cursor *c)
 	  c->prev_rs = rs - cache->buckets;
 	  c->hint = rs->hint = 0;
 	}
-      rs = &sr.rs_current;
     }
 
   if (cache)
@@ -921,7 +919,7 @@ dwarf_find_save_locs (struct dwarf_cursor *c)
       return ret;
   if (cache)
     tdep_reuse_frame (c, rs);
-  if ((ret = apply_reg_state (c, rs)) < 0)
+  if ((ret = apply_reg_state (c, &sr.rs_current)) < 0)
     return ret;
 
   return 0;


### PR DESCRIPTION
Avoid a leak for a no-cache failure in create_state_record_for.
Avoid a duplicate copy for a cache miss.