### PR TITLE
Dwarf cache nodes are allocated in a round-robin fashion, despite the

### DIFF
--- a/include/dwarf.h
+++ b/include/dwarf.h
@@ -345,7 +345,7 @@ typedef unsigned char unw_hash_index_t;
 struct dwarf_rs_cache
   {
     pthread_mutex_t lock;
-    unsigned short lru_head;    /* index of least-recently allocated rs */
+    unsigned short rr_head;    /* index of least-recently allocated rs */
 
     unsigned short log_size;
     unsigned short prev_log_size;

--- a/include/dwarf.h
+++ b/include/dwarf.h
@@ -273,7 +273,6 @@ dwarf_stackable_reg_state_t;
 typedef struct dwarf_reg_cache_entry
   {
     unw_word_t ip;                        /* ip this rs is for */
-    unsigned short lru_chain;     /* used for least-recently-used chain */
     unsigned short coll_chain;  /* used for hash collisions */
     unsigned short hint;              /* hint for next rs to try (or -1) */
     unsigned short valid : 1;         /* optional machine-dependent signal info */
@@ -346,8 +345,7 @@ typedef unsigned char unw_hash_index_t;
 struct dwarf_rs_cache
   {
     pthread_mutex_t lock;
-    unsigned short lru_head;    /* index of lead-recently used rs */
-    unsigned short lru_tail;    /* index of most-recently used rs */
+    unsigned short lru_head;    /* index of least-recently allocated rs */
 
     unsigned short log_size;
     unsigned short prev_log_size;

--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -583,7 +583,7 @@ dwarf_flush_rs_cache (struct dwarf_rs_cache *cache)
     cache->prev_log_size = cache->log_size;
   }
 
-  cache->lru_head = 0;
+  cache->rr_head = 0;
 
   for (i = 0; i < DWARF_UNW_CACHE_SIZE(cache->log_size); ++i)
     {
@@ -678,8 +678,8 @@ rs_new (struct dwarf_rs_cache *cache, struct dwarf_cursor * c)
   unw_hash_index_t index;
   unsigned short head;
 
-  head = cache->lru_head;
-  cache->lru_head = (head + 1) % DWARF_UNW_CACHE_SIZE(cache->log_size);
+  head = cache->rr_head;
+  cache->rr_head = (head + 1) & (cache->log_size - 1);
 
   /* remove the old rs from the hash table (if it's there): */
   if (cache->links[head].ip)

--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -583,13 +583,10 @@ dwarf_flush_rs_cache (struct dwarf_rs_cache *cache)
     cache->prev_log_size = cache->log_size;
   }
 
-  cache->lru_head = DWARF_UNW_CACHE_SIZE(cache->log_size) - 1;
-  cache->lru_tail = 0;
+  cache->lru_head = 0;
 
   for (i = 0; i < DWARF_UNW_CACHE_SIZE(cache->log_size); ++i)
     {
-      if (i > 0)
-        cache->links[i].lru_chain = (i - 1);
       cache->links[i].coll_chain = -1;
       cache->links[i].ip = 0;
       cache->links[i].valid = 0;
@@ -682,11 +679,7 @@ rs_new (struct dwarf_rs_cache *cache, struct dwarf_cursor * c)
   unsigned short head;
 
   head = cache->lru_head;
-  cache->lru_head = cache->links[head].lru_chain;
-
-  /* re-insert rs at the tail of the LRU chain: */
-  cache->links[cache->lru_tail].lru_chain = head;
-  cache->lru_tail = head;
+  cache->lru_head = (head + 1) % DWARF_UNW_CACHE_SIZE(cache->log_size);
 
   /* remove the old rs from the hash table (if it's there): */
   if (cache->links[head].ip)


### PR DESCRIPTION
'lru' prefix used in several data fields.  Drop the unnecessary fields,
and just use a simple counter to track the next cache entry to be recycled.