### PR TITLE
reduce UNW_TDEP_CURSOR_LEN to 512 on aarch64. This allows libunwind t…

### DIFF
--- a/include/libunwind-aarch64.h
+++ b/include/libunwind-aarch64.h
@@ -46,7 +46,7 @@ extern "C" {
    relatively cheap and unwind-state copying is relatively rare, so we
    want to err on making it rather too big than too small.  */
 
-#define UNW_TDEP_CURSOR_LEN     4096
+#define UNW_TDEP_CURSOR_LEN     512
 
 typedef uint64_t unw_word_t;
 typedef int64_t unw_sword_t;


### PR DESCRIPTION
…o work in situations with limited stack size (ie. fibers). 512 is still more than enough for storing the cursor with some slack.