### PR TITLE
ia64: : disable dwarf-specific code

### DIFF
--- a/src/ia64/Gapply_reg_state.c
+++ b/src/ia64/Gapply_reg_state.c
@@ -33,5 +33,7 @@ unw_apply_reg_state (unw_cursor_t *cursor,
 {
   struct cursor *c = (struct cursor *) cursor;
 
-  return dwarf_apply_reg_state (&c->dwarf, (dwarf_reg_state_t *)reg_states_data);
+  // Needs dwarf support on ia64
+  // return dwarf_apply_reg_state (&c->dwarf, (dwarf_reg_state_t *)reg_states_data);
+  return -UNW_EINVAL;
 }

--- a/src/ia64/Greg_states_iterate.c
+++ b/src/ia64/Greg_states_iterate.c
@@ -33,5 +33,7 @@ unw_reg_states_iterate (unw_cursor_t *cursor,
 {
   struct cursor *c = (struct cursor *) cursor;
 
-  return dwarf_reg_states_iterate (&c->dwarf, cb, token);
+  // Needs dwarf support on ia64
+  // return dwarf_reg_states_iterate (&c->dwarf, cb, token);
+  return -UNW_EINVAL;
 }

--- a/src/mi/Gget_proc_name.c
+++ b/src/mi/Gget_proc_name.c
@@ -104,11 +104,15 @@ unw_get_proc_name (unw_cursor_t *cursor, char *buf, size_t buf_len,
   int error;
 
   ip = tdep_get_ip (c);
+#if !defined(__ia64__)
   if (c->dwarf.use_prev_instr)
     --ip;
+#endif
   error = get_proc_name (tdep_get_as (c), ip, buf, buf_len, offp,
                          tdep_get_as_arg (c));
+#if !defined(__ia64__)
   if (c->dwarf.use_prev_instr && offp != NULL && error == 0)
     *offp += 1;
+#endif
   return error;
 }

--- a/src/mi/Gset_cache_size.c
+++ b/src/mi/Gset_cache_size.c
@@ -48,10 +48,12 @@ unw_set_cache_size (unw_addr_space_t as, size_t size, int flag)
         break;
     }
 
+#if !defined(__ia64__)
   if (log_size == as->global_cache.log_size)
     return 0;   /* no change */
 
   as->global_cache.log_size = log_size;
+#endif
 
   /* Ensure caches are empty (and initialized).  */
   unw_flush_cache (as, 0, 0);


### PR DESCRIPTION
Commit dbce594d336dd1766e2e5727958b6b341492a7c9
added unconditional dwarf usage into unw_get_proc_name.
Unfortunately ia64 is the only architecture that
does not support it in libunwind (configure.ac):

```
if test x$target_arch != xia64; then
  use_dwarf=yes
else
  use_dwarf=no
fi
```

As a result build fails on ia64 as:

```
ia64-unknown-linux-gnu-gcc ... -c mi/Lget_proc_name.c ...
In file included from mi/Lget_proc_name.c:4:0:
mi/Gget_proc_name.c: In function '_ULia64_get_proc_name':
mi/Gget_proc_name.c:107:8: error: 'struct cursor' has no member named 'dwarf'
   if (c->dwarf.use_prev_instr)
        ^~
mi/Gget_proc_name.c:111:8: error: 'struct cursor' has no member named 'dwarf'
   if (c->dwarf.use_prev_instr && offp != NULL && error == 0)
        ^~
```

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>