### PR TITLE
Update dwarf ip cache on more archs

### DIFF
--- a/src/aarch64/Gregs.c
+++ b/src/aarch64/Gregs.c
@@ -55,6 +55,9 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
         loc = c->dwarf.loc[reg];
       break;
 
+    case UNW_AARCH64_PC:
+      if (write)
+        c->dwarf.ip = *valp;            /* update the IP cache */
     case UNW_AARCH64_X4:
     case UNW_AARCH64_X5:
     case UNW_AARCH64_X6:
@@ -82,7 +85,6 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
     case UNW_AARCH64_X28:
     case UNW_AARCH64_X29:
     case UNW_AARCH64_X30:
-    case UNW_AARCH64_PC:
     case UNW_AARCH64_PSTATE:
       loc = c->dwarf.loc[reg];
       break;

--- a/src/aarch64/Gregs.c
+++ b/src/aarch64/Gregs.c
@@ -55,7 +55,7 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
         loc = c->dwarf.loc[reg];
       break;
 
-    case UNW_AARCH64_PC:
+    case UNW_AARCH64_X30:
       if (write)
         c->dwarf.ip = *valp;            /* update the IP cache */
     case UNW_AARCH64_X4:
@@ -84,7 +84,7 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
     case UNW_AARCH64_X27:
     case UNW_AARCH64_X28:
     case UNW_AARCH64_X29:
-    case UNW_AARCH64_X30:
+    case UNW_AARCH64_PC:
     case UNW_AARCH64_PSTATE:
       loc = c->dwarf.loc[reg];
       break;

--- a/src/arm/Gregs.c
+++ b/src/arm/Gregs.c
@@ -32,6 +32,9 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
   
   switch (reg)
     {
+    case UNW_ARM_R15:
+      if (write)
+        c->dwarf.ip = *valp;            /* update the IP cache */
     case UNW_ARM_R0:
     case UNW_ARM_R1:
     case UNW_ARM_R2:
@@ -46,7 +49,6 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
     case UNW_ARM_R11:
     case UNW_ARM_R12:
     case UNW_ARM_R14:
-    case UNW_ARM_R15:
       loc = c->dwarf.loc[reg - UNW_ARM_R0];
       break;
 

--- a/src/mips/Gregs.c
+++ b/src/mips/Gregs.c
@@ -70,6 +70,8 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
       break;
 
     case UNW_MIPS_PC:
+      if (write)
+	c->dwarf.ip = *valp;            /* update the IP cache */
       loc = c->dwarf.loc[reg];
       break;
 

--- a/src/sh/Gregs.c
+++ b/src/sh/Gregs.c
@@ -33,6 +33,9 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
 
   switch (reg)
     {
+    case UNW_SH_PC:
+      if (write)
+        c->dwarf.ip = *valp;            /* update the IP cache */
     case UNW_SH_R0:
     case UNW_SH_R1:
     case UNW_SH_R2:
@@ -48,7 +51,6 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
     case UNW_SH_R12:
     case UNW_SH_R13:
     case UNW_SH_R14:
-    case UNW_SH_PC:
     case UNW_SH_PR:
       loc = c->dwarf.loc[reg];
       break;

--- a/src/tilegx/Gregs.c
+++ b/src/tilegx/Gregs.c
@@ -53,8 +53,14 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
   
   if (write)
     {
-      if (reg == UNW_TILEGX_PC)
-	c->dwarf.ip = *valp;            /* update the IP cache */
+      if (ci->dwarf.use_prev_instr == 0) {
+	if (reg == UNW_TILEGX_PC)
+	  c->dwarf.ip = *valp;            /* update the IP cache */
+       }
+      else {
+	if (reg == UNW_TILEGX_R55)
+	  c->dwarf.ip = *valp;            /* update the IP cache */
+      }
       return dwarf_put (&c->dwarf, loc, *valp);
     }
   else

--- a/src/tilegx/Gregs.c
+++ b/src/tilegx/Gregs.c
@@ -52,7 +52,11 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
     }
   
   if (write)
-    return dwarf_put (&c->dwarf, loc, *valp);
+    {
+      if (reg == UNW_TILEGX_PC)
+	c->dwarf.ip = *valp;            /* update the IP cache */
+      return dwarf_put (&c->dwarf, loc, *valp);
+    }
   else
     return dwarf_get (&c->dwarf, loc, valp);
 }


### PR DESCRIPTION
For architectures that initialize the dwarf ip cache, but do not update when the ip register is set, add those updates.