### PR TITLE
dwarf: Fix cache size calculation

### DIFF
--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -679,7 +679,7 @@ rs_new (struct dwarf_rs_cache *cache, struct dwarf_cursor * c)
   unsigned short head;
 
   head = cache->rr_head;
-  cache->rr_head = (head + 1) & (cache->log_size - 1);
+  cache->rr_head = (head + 1) & (DWARF_UNW_CACHE_SIZE(cache->log_size) - 1);
 
   /* remove the old rs from the hash table (if it's there): */
   if (cache->links[head].ip)


### PR DESCRIPTION
The and mask trick only works for power-of-two sized things,
but must be computed using the full size.  This incorrectly
resulted in a very small cache size.

Found using bisect and 'make perf' in tests directory.

blame rev: 0b51f5892df0691fc7b3b947647222ab8e57dd54