### PR TITLE
Use `ucontext_t` instead of `struct ucontext`

### DIFF
--- a/src/x86_64/Gos-linux.c
+++ b/src/x86_64/Gos-linux.c
@@ -138,7 +138,7 @@ x86_64_sigreturn (unw_cursor_t *cursor)
 {
   struct cursor *c = (struct cursor *) cursor;
   struct sigcontext *sc = (struct sigcontext *) c->sigcontext_addr;
-  mcontext_t *sc_mcontext = &((struct ucontext*)sc)->uc_mcontext;
+  mcontext_t *sc_mcontext = &((ucontext_t*)sc)->uc_mcontext;
   /* Copy in saved uc - all preserved regs are at the start of sigcontext */
   memcpy(sc_mcontext, &c->uc->uc_mcontext,
          DWARF_NUM_PRESERVED_REGS * sizeof(unw_word_t));


### PR DESCRIPTION
Ref https://sourceware.org/git/?p=glibc.git;a=commit;h=251287734e89a52da3db682a8241eb6bccc050c9
And this is what other part of the code uses.

------------------------------

~~There's also `struct ucontext_t` from `<sys/ucontext.h>` that should be ABI compatible (and is what I usually use elsewhere). I'm not sure why the kernel version is used or which one is preferred here.~~