### PR TITLE
Use `ucontext_t` instead of `struct ucontext`

### DIFF
--- a/src/x86/Gos-linux.c
+++ b/src/x86/Gos-linux.c
@@ -314,7 +314,7 @@ x86_sigreturn (unw_cursor_t *cursor)
 {
   struct cursor *c = (struct cursor *) cursor;
   struct sigcontext *sc = (struct sigcontext *) c->sigcontext_addr;
-  mcontext_t *sc_mcontext = &((struct ucontext*)sc)->uc_mcontext;
+  mcontext_t *sc_mcontext = &((ucontext_t*)sc)->uc_mcontext;
   /* Copy in saved uc - all preserved regs are at the start of sigcontext */
   memcpy(sc_mcontext, &c->uc->uc_mcontext,
          DWARF_NUM_PRESERVED_REGS * sizeof(unw_word_t));


### PR DESCRIPTION
Ref https://github.com/libunwind/libunwind/pull/40.
I didn't caught it last time since I don't have a 32bits buildbot.