### PR TITLE
Fix init-local-signal test

### DIFF
--- a/tests/Ltest-init-local-signal-lib.c
+++ b/tests/Ltest-init-local-signal-lib.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
 /* To prevent inlining and optimizing away */
-int foo(int* f) {
+int foo(volatile int* f) {
   return *f;
 }

--- a/tests/Ltest-init-local-signal.c
+++ b/tests/Ltest-init-local-signal.c
@@ -46,12 +46,13 @@ void handler(int num, siginfo_t* info, void* ucontext) {
   exit(-1);
 }
 
-int foo(int* f);
+int foo(volatile int* f);
 
 int main(){
   struct sigaction a;
   memset(&a, 0, sizeof(struct sigaction));
   a.sa_sigaction = &handler;
+  a.sa_flags = SA_SIGINFO;
   sigaction(SIGSEGV, &a, NULL);
 
   foo(NULL);


### PR DESCRIPTION
* Add `SA_SIGINFO` flag

  This is needed to guarantee the availability of the `ucontext` argument

* Mark the `NULL` pointer load as `volatile`

  Further prevent any compiler optimization on the load.