### PR TITLE
Allow DWARF version both 3 and 4

### DIFF
--- a/include/dwarf.h
+++ b/include/dwarf.h
@@ -135,7 +135,8 @@ typedef enum
   }
 dwarf_expr_op_t;
 
-#define DWARF_CIE_VERSION       3       /* GCC emits version 1??? */
+#define DWARF_CIE_VERSION       3
+#define DWARF_CIE_VERSION_MAX   4
 
 #define DWARF_CFA_OPCODE_MASK   0xc0
 #define DWARF_CFA_OPERAND_MASK  0x3f

--- a/src/dwarf/Gfde.c
+++ b/src/dwarf/Gfde.c
@@ -116,10 +116,11 @@ parse_cie (unw_addr_space_t as, unw_accessors_t *a, unw_word_t addr,
   if ((ret = dwarf_readu8 (as, a, &addr, &version, arg)) < 0)
     return ret;
 
-  if (version != 1 && version != DWARF_CIE_VERSION)
+  /* GCC emits version 1??? */
+  if (version != 1 && (version < DWARF_CIE_VERSION || version > DWARF_CIE_VERSION_MAX))
     {
-      Debug (1, "Got CIE version %u, expected version 1 or "
-             STR (DWARF_CIE_VERSION) "\n", version);
+      Debug (1, "Got CIE version %u, expected version 1 or between "
+             STR (DWARF_CIE_VERSION) " and " STR (DWARF_CIE_VERSION_MAX) "\n", version);
       return -UNW_EBADVERSION;
     }
 


### PR DESCRIPTION
I was told that there isn't much addition in 4 for unwinding so just allowing it should be fine.

I didn't change the name since it's in a public header. If it is not to be used by user application I can certainly change the lower bound to ...`_MIN` too.
