### PR TITLE
dwarf: Fix size of state to avoid corrupting rs_stack

### DIFF
--- a/include/dwarf.h
+++ b/include/dwarf.h
@@ -260,7 +260,7 @@ dwarf_reg_state_t;
 typedef struct dwarf_stackable_reg_state
   {
     struct dwarf_stackable_reg_state *next;       /* for rs_stack */
-    dwarf_reg_only_state_t state;
+    dwarf_reg_state_t state;
   }
 dwarf_stackable_reg_state_t;
 

--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -275,7 +275,7 @@ run_cfi_program (struct dwarf_cursor *c, dwarf_state_record_t *sr,
               ret = -UNW_ENOMEM;
               break;
 	    }
-          memcpy (&(*rs_stack)->state, &sr->rs_current, sizeof (sr->rs_current));
+          (*rs_stack)->state = sr->rs_current;
           Debug (15, "CFA_remember_state\n");
           break;
 
@@ -286,7 +286,7 @@ run_cfi_program (struct dwarf_cursor *c, dwarf_state_record_t *sr,
               ret = -UNW_EINVAL;
               break;
             }
-          memcpy (&sr->rs_current, &(*rs_stack)->state, sizeof (sr->rs_current));
+          sr->rs_current = (*rs_stack)->state;
           pop_rstate_stack(rs_stack);
           Debug (15, "CFA_restore_state\n");
           break;


### PR DESCRIPTION
DW_CFA_remember_state used memcpy to overwrite state with the value
of rs_current. Unfortunately rs_current was slightly larger than state
potentially resulting in a buffer overrun. On my system this corrupted
rs_stack on a different thread.

Fix this by making the type of state match the type of rs_current. I've
also changed the memcpy call into an assignment which should ensure that
the sizes of state and rs_current match in future.