### PR TITLE
x86_64: support for RIP in unw_get_save_loc

### DIFF
--- a/src/x86_64/Gget_save_loc.c
+++ b/src/x86_64/Gget_save_loc.c
@@ -44,6 +44,7 @@ unw_get_save_loc (unw_cursor_t *cursor, int reg, unw_save_loc_t *sloc)
     case UNW_X86_64_R13: loc = c->dwarf.loc[R13]; break;
     case UNW_X86_64_R14: loc = c->dwarf.loc[R14]; break;
     case UNW_X86_64_R15: loc = c->dwarf.loc[R15]; break;
+    case UNW_X86_64_RIP: loc = c->dwarf.loc[RIP]; break;
 
     default:
       break;


### PR DESCRIPTION
Added one line that returns the location of RIP through unw_get_save_loc on x86_64 machines. (Support for IP is available in unw_get_save_loc on x86.)

We need to know the location of IP in HPCToolkit when our tool unwinds the call stack and injects trampoline.