### PR TITLE
Fix crasher test for gcc >= 8 when using -O2 or -O3.

### DIFF
--- a/tests/crasher.c
+++ b/tests/crasher.c
@@ -87,6 +87,11 @@ write_maps(char *fname)
 #endif
 
 #ifdef __GNUC__
+#ifndef __clang__
+// Gcc >= 8 became too good at inlining aliase c into b when using -O2 or -O3,
+// so force -O1 in all cases, otherwise a frame will be missing in the tests.
+#pragma GCC optimize "-O1"
+#endif
 int c(int x) NOINLINE ALIAS(b);
 #define compiler_barrier() asm volatile("");
 #else


### PR DESCRIPTION
Hi,

This should fix the crasher tests with gcc >= 8 and -O2/-O3:

gdb backtrace with -O2/-O3 and without this patch:
```
Program received signal SIGSEGV, Segmentation fault.
a () at crasher.c:100
100       *(volatile int *)32 = 1;
(gdb) bt
#0  a () at crasher.c:100
#1  0x00000000004008d0 in b (x=x@entry=0) at crasher.c:111
#2  0x00000000004006b9 in main (argc=<optimized out>, argv=<optimized out>) at crasher.c:122
```

with this patch, we get the expected output:
```
Program received signal SIGSEGV, Segmentation fault.
a () at crasher.c:100
100       *(volatile int *)32 = 1;
(gdb) bt
#0  a () at crasher.c:100
#1  0x00000000004008ad in b (x=<optimized out>) at crasher.c:111
#2  0x00000000004008c2 in b (x=x@entry=0) at crasher.c:113
#3  0x00000000004008ec in main (argc=<optimized out>, argv=<optimized out>) at crasher.c:122
```

Cheers,
Romain