### PR TITLE
Include wait-related headers for Ltest-mem-validate

### DIFF
--- a/tests/Ltest-mem-validate.c
+++ b/tests/Ltest-mem-validate.c
@@ -35,6 +35,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include <sys/resource.h>
 #include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 
 #define panic(args...)				\
 	{ fprintf (stderr, args); exit (-1); }


### PR DESCRIPTION
Without these, I was getting errors from this test set claiming that `wait`, `WIFCONTINUED`, et al. were undefined on FreeBSD 11.1.