### PR TITLE
fix various dataraces

### DIFF
--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -932,7 +932,6 @@ find_reg_state (struct dwarf_cursor *c, dwarf_state_record_t *sr)
   unsigned short index = -1;
   if (cache)
     {
-      put_rs_cache (c->as, cache, &saved_mask);
       if (rs)
 	{
 	  index = rs - cache->buckets;
@@ -940,6 +939,7 @@ find_reg_state (struct dwarf_cursor *c, dwarf_state_record_t *sr)
 	  cache->links[c->prev_rs].hint = index + 1;
 	  c->prev_rs = index;
 	}
+      put_rs_cache (c->as, cache, &saved_mask);
     }
   if (ret < 0)
       return ret;

--- a/src/x86_64/Ginit.c
+++ b/src/x86_64/Ginit.c
@@ -78,9 +78,10 @@ static int mem_validate_pipe[2] = {-1, -1};
 static inline void
 open_pipe (void)
 {
-  /* ignore errors for closing invalid fd's */
-  close (mem_validate_pipe[0]);
-  close (mem_validate_pipe[1]);
+  if (mem_validate_pipe[0] != -1)
+    close (mem_validate_pipe[0]);
+  if (mem_validate_pipe[1] != -1)
+    close (mem_validate_pipe[1]);
 
   pipe2 (mem_validate_pipe, O_CLOEXEC | O_NONBLOCK);
 }

--- a/src/x86_64/Ginit.c
+++ b/src/x86_64/Ginit.c
@@ -132,7 +132,6 @@ static int msync_validate (void *addr, size_t len)
 static int mincore_validate (void *addr, size_t len)
 {
   unsigned char mvec[2]; /* Unaligned access may cross page boundary */
-  size_t i;
 
   /* mincore could fail with EAGAIN but we conservatively return -1
      instead of looping. */


### PR DESCRIPTION
This is a follow up to the mail I sent to the list. Contained in this patch series are two fixes for data races found by TSAN. Additionally, a valgrind warning is fixed where close was called with `fd == -1`. Then one compiler warning is silenced by removing an unused variable.

Tests still seem to pass fine on my system. More importantly, the TSAN / valgrind warnings are not shown anymore.