### PR TITLE
RFC: Remove tsl_model(initial-exec)

### DIFF
--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -597,7 +597,7 @@ get_rs_cache (unw_addr_space_t as, intrmask_t *saved_maskp)
 #if defined(HAVE___THREAD) && HAVE___THREAD
   if (likely (caching == UNW_CACHE_PER_THREAD))
     {
-      static __thread struct dwarf_rs_cache tls_cache __attribute__((tls_model("initial-exec")));
+      static __thread struct dwarf_rs_cache tls_cache;
       Debug (16, "using TLS cache\n");
       cache = &tls_cache;
     }


### PR DESCRIPTION
Use the default tsl_model for the per-thread dwarf cache.
This allows using libunwind via dlopen even when it is configured
with --enable-per-thread-cache.

We'll need to wait for a result in the mailing list discussion on how to handle this.