### PR TITLE
Add FreeBSD/aarch64 support

### DIFF
--- a/include/libunwind-aarch64.h
+++ b/include/libunwind-aarch64.h
@@ -196,6 +196,17 @@ typedef struct
 	struct unw_sigcontext uc_mcontext;
   } unw_tdep_context_t;
 
+typedef struct
+  {
+	uint32_t _ctx_magic;
+	uint32_t _ctx_size;
+	uint32_t fpsr;
+	uint32_t fpcr;
+	uint64_t vregs[64];
+  } unw_fpsimd_context_t;
+
+
+
 #include "libunwind-common.h"
 #include "libunwind-dynamic.h"
 

--- a/src/aarch64/unwind_i.h
+++ b/src/aarch64/unwind_i.h
@@ -59,6 +59,6 @@ extern int aarch64_local_resume (unw_addr_space_t as, unw_cursor_t *cursor,
   } while (0)
 #endif
 
-#define GET_FPCTX(uc) ((struct fpsimd_context *)(&uc->uc_mcontext.__reserved))
+#define GET_FPCTX(uc) ((unw_fpsimd_context_t *)(&uc->uc_mcontext.__reserved))
 
 #endif /* unwind_i_h */

--- a/src/coredump/_UCD_access_reg_freebsd.c
+++ b/src/coredump/_UCD_access_reg_freebsd.c
@@ -129,6 +129,26 @@ _UCD_access_reg (unw_addr_space_t as,
        return -UNW_EINVAL;
      }
   }
+#elif defined(UNW_TARGET_AARCH64)
+  if (regnum >= UNW_AARCH64_X0 && regnum < UNW_AARCH64_X30) {
+     *valp = ui->prstatus->pr_reg.x[regnum];
+  } else {
+     switch (regnum) {
+     case UNW_AARCH64_SP:
+       *valp = ui->prstatus->pr_reg.sp;
+       break;
+     case UNW_AARCH64_X30:
+       *valp = ui->prstatus->pr_reg.lr;
+       break;
+     case UNW_AARCH64_PC:
+       *valp = ui->prstatus->pr_reg.elr;
+       break;
+     default:
+       Debug(0, "bad regnum:%d\n", regnum);
+       return -UNW_EINVAL;
+     }
+  }
+
 #else
 #error Port me
 #endif

--- a/src/ptrace/_UPT_access_fpreg.c
+++ b/src/ptrace/_UPT_access_fpreg.c
@@ -84,6 +84,9 @@ _UPT_access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
 #elif defined(__arm__)
   if ((unsigned) reg < UNW_ARM_F0 || (unsigned) reg > UNW_ARM_F7)
     return -UNW_EBADREG;
+#elif defined(__aarch64__)
+  if ((unsigned) reg < UNW_AARCH64_V0 || (unsigned) reg > UNW_AARCH64_V31)
+    return -UNW_EBADREG;
 #else
 #error Fix me
 #endif
@@ -99,6 +102,8 @@ _UPT_access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
           memcpy(&fpreg.fpr_acc[reg], val, sizeof(unw_fpreg_t));
 #elif defined(__arm__)
           memcpy(&fpreg.fpr[reg], val, sizeof(unw_fpreg_t));
+#elif defined(__aarch64__)
+          memcpy(&fpreg.fp_q[reg], val, sizeof(unw_fpreg_t));
 #else
 #error Fix me
 #endif
@@ -111,6 +116,8 @@ _UPT_access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
           memcpy(val, &fpreg.fpr_acc[reg], sizeof(unw_fpreg_t));
 #elif defined(__arm__)
           memcpy(val, &fpreg.fpr[reg], sizeof(unw_fpreg_t));
+#elif defined(__aarch64__)
+          memcpy(val, &fpreg.fp_q[reg], sizeof(unw_fpreg_t));
 #else
 #error Fix me
 #endif


### PR DESCRIPTION
I'm actually quite confused about how aarch64 contexts are implemented…

- there's `unw_tdep_context_t` / `unw_sigcontext`, a private copy of Linux structs
  - filled by the inline assembly in the `unw_tdep_getcontext` macro??
  - but there was a reference to `fpsimd_context` from Linux system headers??
  - the assembly does not seem to save the float/simd registers though??

So I added an internal Linux-compatible fpsimd struct and that compiles…

I'm not sure how to properly test, `make check` tries to link the library twice for some reason:

```
/usr/bin/ld: error: duplicate symbol: dwarf_search_unwind_table_int
>>> defined at Gfind_proc_info-lsb.c:809 (dwarf/Gfind_proc_info-lsb.c:809)
>>>            Gfind_proc_info-lsb.o:(_Uaarch64_dwarf_search_unwind_table) in archive ../src/.libs/libunwind-aarch64.a
>>> defined at Gfind_proc_info-lsb.c:809 (dwarf/Gfind_proc_info-lsb.c:809)
>>>            Lfind_proc_info-lsb.o:(_ULaarch64_dwarf_search_unwind_table) in archive /mnt/greg/src/github.com/libunwind/libunwind/src/.libs/libunwind.a
```

Tried to run something manually:

- `run-coredump-unwind` (and `-mdi`) expect GNU binaries: `mktemp: illegal option -- -`
- `test-ptrace-misc` returns `sum = 0`
- `test-strerror` and `test-proc-info` exit 0 without printing anything
- `forker` segfaults in `strtol_l`
- the example from issue #68 prints something reasonable (`ip = 20394, sp = ffffffffdaf0`) and does not segfault! :)