### PR TITLE
aarch: [v2] aarch64 PLT entry recognition & fixes

### DIFF
--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -839,7 +839,7 @@ apply_reg_state (struct dwarf_cursor *c, struct dwarf_reg_state *rs)
               break;
             }
 #endif
-          new_loc[i] = DWARF_REG_LOC (c, dwarf_to_unw_regnum (rs->reg.val[i]));
+          new_loc[i] = new_loc[rs->reg.val[i]];
           break;
 
         case DWARF_WHERE_EXPR:


### PR DESCRIPTION
Fix missing Gparser.c changes from patchset

'aarch64 PLT entry recognition & fixes'