### PR TITLE
aarch64: Use __asm__ instead of asm

### DIFF
--- a/include/libunwind-aarch64.h
+++ b/include/libunwind-aarch64.h
@@ -212,7 +212,7 @@ typedef struct
 
 #define unw_tdep_getcontext(uc) (({					\
   unw_tdep_context_t *unw_ctx = (uc);					\
-  register uint64_t *unw_base asm ("x0") = (uint64_t*) unw_ctx->uc_mcontext.regs;		\
+  register uint64_t *unw_base __asm__ ("x0") = (uint64_t*) unw_ctx->uc_mcontext.regs;		\
   __asm__ __volatile__ (						\
      "stp x0, x1, [%[base], #0]\n" \
      "stp x2, x3, [%[base], #16]\n" \


### PR DESCRIPTION
Otherwise this fails to compile with -stc=c99 like:

```
  $ cat <<EOF > bla.c
  #include <libunwind.h>

  int main()
  {
      unw_tdep_context_t *uc = NULL;
      unw_tdep_getcontext(uc);
  }
  EOF

  # This works
  $ gcc bla.c

  # This does not
  $ gcc -std=c99 bla.c
  In file included from /usr/include/aarch64-linux-gnu/libunwind.h:7,
                   from bla.c:1:
  bla.c: In function ‘main’:
  bla.c:6:5: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘asm’
       unw_tdep_getcontext(uc);
       ^~~~~~~~~~~~~~~~~~~
  bla.c:6:5: error: ‘mcontext_t’ {aka ‘struct <anonymous>’} has no member named ‘regs’; did you mean ‘__regs’?
       unw_tdep_getcontext(uc);
       ^~~~~~~~~~~~~~~~~~~
  bla.c:6:5: error: ‘unw_base’ undeclared (first use in this function); did you mean ‘unw_ctx’?
       unw_tdep_getcontext(uc);
       ^~~~~~~~~~~~~~~~~~~
  bla.c:6:5: note: each undeclared identifier is reported only once for each function it appears in
  bla.c:6:5: error: invalid lvalue in asm output 0
       unw_tdep_getcontext(uc);
       ^~~~~~~~~~~~~~~~~~~
```

See https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html:

> The asm keyword is a GNU extension. When writing code that can be
   compiled with -ansi and the various -std options, use __asm__ instead of
   asm (see Alternate Keywords).