### PR TITLE
Fixed a missing dependency in dwarf-eh.h

### DIFF
--- a/include/dwarf-eh.h
+++ b/include/dwarf-eh.h
@@ -27,6 +27,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #define dwarf_eh_h
 
 #include "dwarf.h"
+#include "libunwind_i.h"
 
 /* This header file defines the format of a DWARF exception-header
    section (.eh_frame_hdr, pointed to by program-header


### PR DESCRIPTION
The dwarf-eh.h header is not self-contained, which causes problems depending on which order headers are included. In particular, it references the Elf_W macro but does not include its definition. If dwarf-eh.h is included after dwarf_i.h everything works, but if you reverse this order you get compile errors. This patch removes the implicit header ordering dependency by making sure the definition of Elf_W is visible in dwarf-eh.h.

I include libunwind_i.h rather than the elfxx.h files directly because libunwind_i.h contains macro logic to choose which elf header to include, and I didn't want to duplicate that.