### PR TITLE
x86_64: tsan clean

### DIFF
--- a/include/libunwind_i.h
+++ b/include/libunwind_i.h
@@ -140,6 +140,7 @@ cmpxchg_ptr (void *addr, void *old, void *new)
 }
 # define fetch_and_add1(_ptr)           AO_fetch_and_add1(_ptr)
 # define fetch_and_add(_ptr, value)     AO_fetch_and_add(_ptr, value)
+# define atomic_read(ptr) (AO_load(ptr))
    /* GCC 3.2.0 on HP-UX crashes on cmpxchg_ptr() */
 #  if !(defined(__hpux) && __GNUC__ == 3 && __GNUC_MINOR__ == 2)
 #   define HAVE_CMPXCHG
@@ -164,10 +165,14 @@ cmpxchg_ptr (void *addr, void *old, void *new)
 }
 # define fetch_and_add1(_ptr)           __sync_fetch_and_add(_ptr, 1)
 # define fetch_and_add(_ptr, value)     __sync_fetch_and_add(_ptr, value)
+# define atomic_read(ptr) (__atomic_load_n(ptr,__ATOMIC_RELAXED))
 # define HAVE_CMPXCHG
 # define HAVE_FETCH_AND_ADD
 #endif
+
+#ifndef atomic_read
 #define atomic_read(ptr)        (*(ptr))
+#endif
 
 #define UNWI_OBJ(fn)      UNW_PASTE(UNW_PREFIX,UNW_PASTE(I,fn))
 #define UNWI_ARCH_OBJ(fn) UNW_PASTE(UNW_PASTE(UNW_PASTE(_UI,UNW_TARGET),_), fn)

--- a/src/x86_64/Ginit_local.c
+++ b/src/x86_64/Ginit_local.c
@@ -43,7 +43,7 @@ unw_init_local_common (unw_cursor_t *cursor, ucontext_t *uc, unsigned use_prev_i
 {
   struct cursor *c = (struct cursor *) cursor;
 
-  if (unlikely (!tdep_init_done))
+  if (unlikely (!atomic_read(&tdep_init_done)))
     tdep_init ();
 
   Debug (1, "(cursor=%p)\n", c);

--- a/src/x86_64/Ginit_remote.c
+++ b/src/x86_64/Ginit_remote.c
@@ -36,7 +36,7 @@ unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
 #else /* !UNW_LOCAL_ONLY */
   struct cursor *c = (struct cursor *) cursor;
 
-  if (!tdep_init_done)
+  if (!atomic_read(&tdep_init_done))
     tdep_init ();
 
   Debug (1, "(cursor=%p)\n", c);


### PR DESCRIPTION
Make x86_64 tsan safe.  The initial unw_full_mask must be on the stack, and the tdep_init_done check needs to be atomic. 

We could do this for all arches, but it's unclear which need TSAN support, or have the appropriate atomics.