### PR TITLE
Added braces to suppress empty if/else warnings

### DIFF
--- a/src/coredump/_UCD_create.c
+++ b/src/coredump/_UCD_create.c
@@ -259,9 +259,13 @@ _UCD_create(const char *filename)
                                 cur->p_flags
             );
             if (cur->p_filesz < cur->p_memsz)
-              Debug(2, " partial");
+              {
+                Debug(2, " partial");
+              }
             if (cur->p_flags & PF_X)
-              Debug(2, " executable");
+              {
+                Debug(2, " executable");
+              }
           }
         Debug(2, "\n");
         i++;
@@ -338,7 +342,10 @@ int _UCD_add_backing_file_at_segment(struct UCD_info *ui, int phdr_no, const cha
   phdr->backing_filesize = (uoff_t)statbuf.st_size;
 
   if (phdr->p_flags != (PF_X | PF_R))
-    Debug(1, "Note: phdr[%u] is not r-x: flags are 0x%x\n", phdr_no, phdr->p_flags);
+    {
+      Debug(1, "Note: phdr[%u] is not r-x: flags are 0x%x\n",
+                        phdr_no, phdr->p_flags);
+    }
 
   if (phdr->backing_filesize > phdr->p_memsz)
     {

--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -615,11 +615,15 @@ dwarf_callback (struct dl_phdr_info *info, size_t size, void *ptr)
           /* If there is no search table or it has an unsupported
              encoding, fall back on linear search.  */
           if (hdr->table_enc == DW_EH_PE_omit)
-            Debug (4, "table `%s' lacks search table; doing linear search\n",
-                   info->dlpi_name);
+            {
+              Debug (4, "table `%s' lacks search table; doing linear search\n",
+                     info->dlpi_name);
+            }
           else
-            Debug (4, "table `%s' has encoding 0x%x; doing linear search\n",
-                   info->dlpi_name, hdr->table_enc);
+            {
+              Debug (4, "table `%s' has encoding 0x%x; doing linear search\n",
+                     info->dlpi_name, hdr->table_enc);
+            }
 
           eh_frame_end = max_load_addr; /* XXX can we do better? */
 

--- a/src/x86_64/Gstash_frame.c
+++ b/src/x86_64/Gstash_frame.c
@@ -112,8 +112,8 @@ tdep_stash_frame (struct dwarf_cursor *d, struct dwarf_reg_state *rs)
   else if (f->frame_type == UNW_X86_64_FRAME_ALIGNED) {
     Debug (4, " aligned frame, offset %li\n", f->cfa_reg_offset);
   }
-
   /* PLT and guessed RBP-walked frames are handled in unw_step(). */
-  else
+  else {
     Debug (4, " unusual frame\n");
+  }
 }


### PR DESCRIPTION
This change fixes all empty if/else block warnings from gcc.
It does not change the functionality of libunwind in any way.