### PR TITLE
Delete hardcode of address size to support MIPS64.

### DIFF
--- a/include/tdep-mips/dwarf-config.h
+++ b/include/tdep-mips/dwarf-config.h
@@ -35,9 +35,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 /* Return TRUE if the ADDR_SPACE uses big-endian byte-order.  */
 #define dwarf_is_big_endian(addr_space) ((addr_space)->big_endian)
 
-/* Return the size of an address, for DWARF purposes.  */
-#define dwarf_addr_size(addr_space) ((addr_space)->addr_size)
-
 /* Convert a pointer to a dwarf_cursor structure to a pointer to
    unw_cursor_t.  */
 #define dwarf_to_cursor(c)      ((unw_cursor_t *) (c))

--- a/src/mips/Gcreate_addr_space.c
+++ b/src/mips/Gcreate_addr_space.c
@@ -67,7 +67,6 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
 #else
 # error Unsupported ABI
 #endif
-  as->addr_size = 4;
 
   return as;
 #endif


### PR DESCRIPTION
Use the define for dwarf_addr_size in include/dwarf_i.h instead of hardcode(4) to support various MIPS architectures.

Signed-off-by: Archer Yan <ayan@wavecomp.com>