### PR TITLE
Fix format specifier for int64_t:29

### DIFF
--- a/src/x86_64/Gstash_frame.c
+++ b/src/x86_64/Gstash_frame.c
@@ -110,7 +110,7 @@ tdep_stash_frame (struct dwarf_cursor *d, struct dwarf_reg_state *rs)
   }
 
   else if (f->frame_type == UNW_X86_64_FRAME_ALIGNED) {
-    Debug (4, " aligned frame, offset %li\n", f->cfa_reg_offset);
+    Debug (4, " aligned frame, offset %i\n", f->cfa_reg_offset);
   }
   /* PLT and guessed RBP-walked frames are handled in unw_step(). */
   else {


### PR DESCRIPTION
When width is less than 32 (i.e. 29 in this case), the preferred format specifier is `%i`.

clang:
> x86_64/Gstash_frame.c:113:47: warning: format specifies type 'long' but the argument has type 'int' [-Wformat]

gcc:
> x86_64/Gstash_frame.c:113:15: warning: format ‘%li’ expects argument of type ‘long int’, but argument 3 has type ‘int’ [-Wformat=]