### PR TITLE
x86_64: Add fixup code if previous RIP was invalid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,5 +76,6 @@ tests/[GL]ia64-test-stack
 tests/ia64-test-dyn1
 tests/ia64-test-sig
 tests/[GL]x64-test-dwarf-expressions
+tests/x64-unwind-badjmp-signal-frame
 tests/*.log
 tests/*.trs

--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -149,7 +149,11 @@ unw_step (unw_cursor_t *cursor)
               return ret;
             }
 
-          if (!rbp)
+          unw_word_t invalid_prev_rip = 0;
+          unw_word_t not_used;
+          invalid_prev_rip = dwarf_get(&c->dwarf, DWARF_MEM_LOC(c->dwarf, prev_ip), &not_used);
+
+          if (!rbp && invalid_prev_rip == 0)
             {
               /* Looks like we may have reached the end of the call-chain.  */
               rbp_loc = DWARF_NULL_LOC;
@@ -164,9 +168,8 @@ unw_step (unw_cursor_t *cursor)
                * followed and so the stack wasn't updated by the
                * preamble
                */
-              unw_word_t not_used = 0;
               int rip_fixup_success = 0;
-              if (dwarf_get(&c->dwarf, DWARF_MEM_LOC(c->dwarf, prev_ip), &not_used) != 0)
+              if (invalid_prev_rip != 0)
                 {
                     Debug (2, "Previous RIP 0x%lx was invalid, attempting fixup\n", prev_ip);
                     unw_word_t rsp;

--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -158,38 +158,91 @@ unw_step (unw_cursor_t *cursor)
             }
           else
             {
-              unw_word_t rbp1 = 0;
-              rbp_loc = DWARF_LOC(rbp, 0);
-              rsp_loc = DWARF_NULL_LOC;
-              rip_loc = DWARF_LOC (rbp + 8, 0);
-              ret = dwarf_get (&c->dwarf, rbp_loc, &rbp1);
-              Debug (1, "[RBP=0x%lx] = 0x%lx (cfa = 0x%lx) -> 0x%lx\n",
-                     (unsigned long) DWARF_GET_LOC (c->dwarf.loc[RBP]),
-                     rbp, c->dwarf.cfa, rbp1);
-
-              /* Heuristic to determine incorrect guess.  For RBP to be a
-                 valid frame it needs to be above current CFA, but don't
-                 let it go more than a little.  Note that we can't deduce
-                 anything about new RBP (rbp1) since it may not be a frame
-                 pointer in the frame above.  Just check we get the value. */
-              if (ret < 0
-                  || rbp < c->dwarf.cfa
-                  || (rbp - c->dwarf.cfa) > 0x4000)
+              /*
+               * Check if previous RIP was invalid
+               * This could happen if a bad function pointer was
+               * followed and so the stack wasn't updated by the
+               * preamble
+               */
+              unw_word_t not_used = 0;
+              int rip_fixup_success = 0;
+              if (dwarf_get(&c->dwarf, DWARF_MEM_LOC(c->dwarf, prev_ip), &not_used) != 0)
                 {
-                  rip_loc = DWARF_NULL_LOC;
-                  rbp_loc = DWARF_NULL_LOC;
+                    Debug (2, "Previous RIP 0x%lx was invalid, attempting fixup\n", prev_ip);
+                    unw_word_t rsp;
+                    ret = dwarf_get (&c->dwarf, c->dwarf.loc[RSP], &rsp);
+
+                    /*Test to see if what we think is the previous RIP is valid*/
+                    unw_word_t new_ip = 0;
+                    if (dwarf_get(&c->dwarf, DWARF_MEM_LOC(c->dwarf, rsp), &new_ip) == 0)
+                      {
+                        Debug (2, "RSP 0x%lx looks valid\n", rsp);
+                        if ((ret = dwarf_get(&c->dwarf, DWARF_MEM_LOC(c->dwarf, new_ip), &not_used)) == 0)
+                          {
+                            Debug (2, "new_ip 0x%lx looks valid\n", new_ip);
+                            rip_fixup_success = 1;
+                            c->frame_info.cfa_reg_offset = 8;
+                            c->frame_info.cfa_reg_rsp = 1;
+                            c->frame_info.rbp_cfa_offset = -1;
+                            c->frame_info.rsp_cfa_offset = -1;
+                            c->frame_info.frame_type = UNW_X86_64_FRAME_OTHER;
+                            /*
+                             * The call should have pushed RIP to the stack
+                             * and since there was no preamble RSP hasn't been
+                             * touched so RIP should be at RSP.
+                             */
+                            c->dwarf.cfa += 8;
+                            /* Optimised x64 binaries don't use RBP it seems? */
+                            rbp_loc = DWARF_LOC (rbp, 0);
+                            rsp_loc = DWARF_LOC (rsp, 0);
+                            rip_loc = DWARF_LOC (rsp, 0);
+                          }
+                        else
+                          Debug (2, "new_ip 0x%lx dwarf_get(&c->dwarf, DWARF_MEM_LOC(c->dwarf, new_ip), &not_used) != 0\n", new_ip);
+                      }
+		                else
+                        Debug (2, "rsp 0x%lx dwarf_get(&c->dwarf, DWARF_MEM_LOC(c->dwarf, rsp), &new_ip) != 0\n", rsp);
+                  }
+              /*
+               * If the previous rip we found on the stack didn't look valid fall back
+               * to the previous method for finding a valid stack frame
+               */
+              if (!rip_fixup_success)
+                {
+                  Debug (2, "RIP fixup didn't work, falling back\n");
+                  unw_word_t rbp1 = 0;
+                  rbp_loc = DWARF_LOC(rbp, 0);
+                  rsp_loc = DWARF_NULL_LOC;
+                  rip_loc = DWARF_LOC (rbp + 8, 0);
+                  ret = dwarf_get (&c->dwarf, rbp_loc, &rbp1);
+                  Debug (1, "[RBP=0x%lx] = 0x%lx (cfa = 0x%lx) -> 0x%lx\n",
+                         (unsigned long) DWARF_GET_LOC (c->dwarf.loc[RBP]),
+                         rbp, c->dwarf.cfa, rbp1);
+
+                  /* Heuristic to determine incorrect guess.  For RBP to be a
+                     valid frame it needs to be above current CFA, but don't
+                     let it go more than a little.  Note that we can't deduce
+                     anything about new RBP (rbp1) since it may not be a frame
+                     pointer in the frame above.  Just check we get the value. */
+                  if (ret < 0
+                      || rbp < c->dwarf.cfa
+                      || (rbp - c->dwarf.cfa) > 0x4000)
+                    {
+                      rip_loc = DWARF_NULL_LOC;
+                      rbp_loc = DWARF_NULL_LOC;
+                    }
+
+                  c->frame_info.frame_type = UNW_X86_64_FRAME_GUESSED;
+                  c->frame_info.cfa_reg_rsp = 0;
+                  c->frame_info.cfa_reg_offset = 16;
+                  c->frame_info.rbp_cfa_offset = -16;
+                  c->dwarf.cfa += 16;
+
                 }
-
-              c->frame_info.frame_type = UNW_X86_64_FRAME_GUESSED;
-              c->frame_info.cfa_reg_rsp = 0;
-              c->frame_info.cfa_reg_offset = 16;
-              c->frame_info.rbp_cfa_offset = -16;
-              c->dwarf.cfa += 16;
             }
-
           /* Mark all registers unsaved */
           for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
-            c->dwarf.loc[i] = DWARF_NULL_LOC;
+          c->dwarf.loc[i] = DWARF_NULL_LOC;
 
           c->dwarf.loc[RBP] = rbp_loc;
           c->dwarf.loc[RSP] = rsp_loc;

--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -104,6 +104,7 @@ unw_step (unw_cursor_t *cursor)
               via CALLQ.  Try this for all non-signal trampoline
               code.  */
 
+      unw_word_t invalid_prev_rip = 0;
       unw_word_t prev_ip = c->dwarf.ip, prev_cfa = c->dwarf.cfa;
       struct dwarf_loc rbp_loc, rsp_loc, rip_loc;
 
@@ -149,7 +150,6 @@ unw_step (unw_cursor_t *cursor)
               return ret;
             }
 
-          unw_word_t invalid_prev_rip = 0;
           unw_word_t not_used;
           invalid_prev_rip = dwarf_get(&c->dwarf, DWARF_MEM_LOC(c->dwarf, prev_ip), &not_used);
 
@@ -253,7 +253,7 @@ unw_step (unw_cursor_t *cursor)
           c->dwarf.use_prev_instr = 1;
         }
 
-      if (DWARF_IS_NULL_LOC (c->dwarf.loc[RBP]))
+      if (DWARF_IS_NULL_LOC (c->dwarf.loc[RBP]) && invalid_prev_rip == 0)
         {
           ret = 0;
           Debug (2, "NULL %%rbp loc, returning %d\n", ret);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -39,7 +39,7 @@ if USE_ALTIVEC
 endif #USE_ALTIVEC
 else  #!ARCH_PPC64
 if ARCH_X86_64
- check_PROGRAMS_arch +=	Gx64-test-dwarf-expressions Lx64-test-dwarf-expressions
+ check_PROGRAMS_arch +=	Gx64-test-dwarf-expressions Lx64-test-dwarf-expressions x64-unwind-badjmp-signal-frame
 endif #ARCH X86_64
 endif #!ARCH_PPC64
 endif #!ARCH_IA64
@@ -157,6 +157,7 @@ Ltest_cxx_exceptions_SOURCES = Ltest-cxx-exceptions.cxx
 
 Ltest_init_local_signal_SOURCES = Ltest-init-local-signal.c Ltest-init-local-signal-lib.c
 
+x64_unwind_badjmp_signal_frame_SOURCES = x64-unwind-badjmp-signal-frame.c
 Gtest_dyn1_SOURCES = Gtest-dyn1.c flush-cache.S flush-cache.h
 Ltest_dyn1_SOURCES = Ltest-dyn1.c flush-cache.S flush-cache.h
 test_static_link_SOURCES = test-static-link-loc.c test-static-link-gen.c
@@ -203,6 +204,7 @@ Ltest_init_local_signal_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 
 Gtest_bt_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 Gtest_concurrent_LDADD = $(LIBUNWIND) $(LIBUNWIND_local) -lpthread
+x64_unwind_badjmp_signal_frame_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 Gtest_dyn1_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 Gtest_exc_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 Gtest_init_LDADD = $(LIBUNWIND) $(LIBUNWIND_local) @BACKTRACELIB@

--- a/tests/x64-unwind-badjmp-signal-frame.c
+++ b/tests/x64-unwind-badjmp-signal-frame.c
@@ -33,8 +33,6 @@ void handle_sigsegv(int signal, siginfo_t *info, void *ucontext)
 	char *names[] = {
 		"",
 		"main",
-		"__libc_start_main",
-		"_start"
 	};
 	int names_count = sizeof(names) / sizeof(*names);
 

--- a/tests/x64-unwind-badjmp-signal-frame.c
+++ b/tests/x64-unwind-badjmp-signal-frame.c
@@ -17,75 +17,81 @@
  */
 void handle_sigsegv(int signal, siginfo_t *info, void *ucontext)
 {
-	/*
-	 * 0 = success
-	 * !0 = general failure
-	 * 77 = test skipped
-	 * 99 = complete failure
-	 */
-	int test_status = 0; 
+  /*
+   * 0 = success
+   * !0 = general failure
+   * 77 = test skipped
+   * 99 = complete failure
+   */
+  int test_status = 0;
+  unw_cursor_t cursor; unw_context_t uc;
+  unw_word_t ip, sp, offset;
+  char name[1000];
+  int found_signal_frame = 0;
+  int i = 0;
+  char *names[] = {
+    "",
+    "main",
+  };
+  int names_count = sizeof(names) / sizeof(*names);
 
-	unw_cursor_t cursor; unw_context_t uc;
-	unw_word_t ip, sp, offset;
-	char name[1000];
-	int found_signal_frame = 0;
-	int i = 0;
-	char *names[] = {
-		"",
-		"main",
-	};
-	int names_count = sizeof(names) / sizeof(*names);
+  unw_getcontext(&uc);
+  unw_init_local(&cursor, &uc);
 
-	unw_getcontext(&uc);
-	unw_init_local(&cursor, &uc);
+  while (unw_step(&cursor) > 0 && !test_status)
+    {
+      if (unw_is_signal_frame(&cursor))
+        {
+          found_signal_frame = 1;
+        }
+      if (found_signal_frame)
+        {
+          unw_get_reg(&cursor, UNW_REG_IP, &ip);
+          unw_get_reg(&cursor, UNW_REG_SP, &sp);
+          memset(name, 0, sizeof(char) * 1000);
+          unw_get_proc_name(&cursor, name, sizeof(char) * 1000, &offset);
+          printf("ip = %lx, sp = %lx offset = %lx name = %s\n", (long) ip, (long) sp, (long) offset, name);
+          if (i < names_count)
+            {
+              if (strcmp(names[i], name) != 0)
+                {
+                  test_status = 1;
+                  printf("frame %s doesn't match expected frame %s\n", name, names[i]);
+                }
+              else
+                {
+                  i += 1;
+                }
+            }
+        }
+    }
 
-	while (unw_step(&cursor) > 0 && !test_status) {
-		if(unw_is_signal_frame(&cursor)) {
-			found_signal_frame = 1;
-		}
-		if(found_signal_frame) {
-			unw_get_reg(&cursor, UNW_REG_IP, &ip);
-			unw_get_reg(&cursor, UNW_REG_SP, &sp);
-			memset(name, 0, sizeof(char) * 1000);
-			unw_get_proc_name(&cursor, name, sizeof(char) * 1000, &offset);
-			printf("ip = %lx, sp = %lx offset = %lx name = %s\n", (long) ip, (long) sp, (long) offset, name);
-			if(i < names_count) {
-				if(strcmp(names[i], name) != 0) {
-					test_status = 1;
-					printf("frame %s doesn't match expected frame %s\n", name, names[i]);
-				} else {
-					i += 1;
-				}
-			}
-		}
-	}
+  if (i != names_count) //Make sure we found all the frames!
+    {
+      printf("Failed to find all frames i:%d != names_count:%d\n", i, names_count);
+      test_status = 1;
+    }
 
-	if(i != names_count) { //Make sure we found all the frames!
-		printf("Failed to find all frames i:%d != names_count:%d\n", i, names_count);
-		test_status = 1;
-	}
-
-	/*return test_status to test harness*/
-	exit(test_status);
+  /*return test_status to test harness*/
+  exit(test_status);
 }
-
 
 void (*invalid_function)() = (void*)1;
 
 int main(int argc, char *argv[])
 {
-	struct sigaction sa;
-	memset(&sa, 0, sizeof(sa));
-	sa.sa_sigaction = handle_sigsegv;
-	sa.sa_flags = SA_SIGINFO;
-	sigaction(SIGSEGV, &sa, NULL);
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_sigaction = handle_sigsegv;
+  sa.sa_flags = SA_SIGINFO;
+  sigaction(SIGSEGV, &sa, NULL);
 
-	invalid_function();
+  invalid_function();
 
-	/*
-	 * 99 is the hard error exit status for automake tests:
-	 * https://www.gnu.org/software/automake/manual/html_node/Scripts_002dbased-Testsuites.html#Scripts_002dbased-Testsuites
-	 * If we dont end up in the signal handler something went horribly wrong.
-	 */
-	return 99;
+  /*
+   * 99 is the hard error exit status for automake tests:
+   * https://www.gnu.org/software/automake/manual/html_node/Scripts_002dbased-Testsuites.html#Scripts_002dbased-Testsuites
+   * If we dont end up in the signal handler something went horribly wrong.
+   */
+  return 99;
 }

--- a/tests/x64-unwind-badjmp-signal-frame.c
+++ b/tests/x64-unwind-badjmp-signal-frame.c
@@ -49,17 +49,19 @@ void handle_sigsegv(int signal, siginfo_t *info, void *ucontext)
 			memset(name, 0, sizeof(char) * 1000);
 			unw_get_proc_name(&cursor, name, sizeof(char) * 1000, &offset);
 			printf("ip = %lx, sp = %lx offset = %lx name = %s\n", (long) ip, (long) sp, (long) offset, name);
-			if(strcmp(names[i], name) != 0) {
-				test_status = 1;
-				printf("frame %s doesn't match expected frame %s\n", name, names[i]);
-			} else {
-				i += 1;
+			if(i < names_count) {
+				if(strcmp(names[i], name) != 0) {
+					test_status = 1;
+					printf("frame %s doesn't match expected frame %s\n", name, names[i]);
+				} else {
+					i += 1;
+				}
 			}
 		}
 	}
 
 	if(i != names_count) { //Make sure we found all the frames!
-		printf("Failed to find all frames\n");
+		printf("Failed to find all frames i:%d != names_count:%d\n", i, names_count);
 		test_status = 1;
 	}
 

--- a/tests/x64-unwind-badjmp-signal-frame.c
+++ b/tests/x64-unwind-badjmp-signal-frame.c
@@ -1,3 +1,27 @@
+/* libunwind - a platform-independent unwind library
+   Copyright (C) 2019 Brock York <twunknown AT gmail.com>
+
+This file is part of libunwind.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>

--- a/tests/x64-unwind-badjmp-signal-frame.c
+++ b/tests/x64-unwind-badjmp-signal-frame.c
@@ -1,0 +1,91 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <string.h>
+#include <execinfo.h>
+#include <sys/types.h>
+#include <sys/ucontext.h>
+#include <unistd.h>
+#include <sys/ptrace.h>
+
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
+
+/*
+ * unwind in the signal handler checking the backtrace is correct
+ * after a bad jump.
+ */
+void handle_sigsegv(int signal, siginfo_t *info, void *ucontext)
+{
+	/*
+	 * 0 = success
+	 * !0 = general failure
+	 * 77 = test skipped
+	 * 99 = complete failure
+	 */
+	int test_status = 0; 
+
+	unw_cursor_t cursor; unw_context_t uc;
+	unw_word_t ip, sp, offset;
+	char name[1000];
+	int found_signal_frame = 0;
+	int i = 0;
+	char *names[] = {
+		"",
+		"main",
+		"__libc_start_main",
+		"_start"
+	};
+	int names_count = sizeof(names) / sizeof(*names);
+
+	unw_getcontext(&uc);
+	unw_init_local(&cursor, &uc);
+
+	while (unw_step(&cursor) > 0 && !test_status) {
+		if(unw_is_signal_frame(&cursor)) {
+			found_signal_frame = 1;
+		}
+		if(found_signal_frame) {
+			unw_get_reg(&cursor, UNW_REG_IP, &ip);
+			unw_get_reg(&cursor, UNW_REG_SP, &sp);
+			memset(name, 0, sizeof(char) * 1000);
+			unw_get_proc_name(&cursor, name, sizeof(char) * 1000, &offset);
+			printf("ip = %lx, sp = %lx offset = %lx name = %s\n", (long) ip, (long) sp, (long) offset, name);
+			if(strcmp(names[i], name) != 0) {
+				test_status = 1;
+				printf("frame %s doesn't match expected frame %s\n", name, names[i]);
+			} else {
+				i += 1;
+			}
+		}
+	}
+
+	if(i != names_count) { //Make sure we found all the frames!
+		printf("Failed to find all frames\n");
+		test_status = 1;
+	}
+
+	/*return test_status to test harness*/
+	exit(test_status);
+}
+
+
+void (*invalid_function)() = (void*)1;
+
+int main(int argc, char *argv[])
+{
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_sigaction = handle_sigsegv;
+	sa.sa_flags = SA_SIGINFO;
+	sigaction(SIGSEGV, &sa, NULL);
+
+	invalid_function();
+
+	/*
+	 * 99 is the hard error exit status for automake tests:
+	 * https://www.gnu.org/software/automake/manual/html_node/Scripts_002dbased-Testsuites.html#Scripts_002dbased-Testsuites
+	 * If we dont end up in the signal handler something went horribly wrong.
+	 */
+	return 99;
+}


### PR DESCRIPTION
Previous RIP could become invalid if a bad function pointer
was followed. Calling unwind from a signal frame in this case
skips the frame that called the bad pointer.

I added a test and fixed up the code so that it works with the test-ptrace test as advised in pull request #106 finally after 3 months.
I've been rebasing my code without thinking. So now I can't push to the original branch in the pull request. So I've instead created this pull request. All original information can be found in pull request #106 

Any advise on whether I'm setting up the cursor values correctly would be greatly appreciated as it's quite confusing if I've doing it correctly.