### PR TITLE
RFC: README: add libc requirement description

### DIFF
--- a/README
+++ b/README
@@ -22,6 +22,32 @@ several architecture/operating-system combinations:
 | FreeBSD | x86          | ✓      |
 | FreeBSD | AArch64      | ✓      |
 
+## Libc Requirements
+
+libunwind depends on getcontext(), setcontext() functions which are missing
+from C libraries like musl-libc because they are considered to be "obsolescent"
+API by POSIX document.  The following table tries to track current status of
+such dependencies
+
+ - r, requires
+ - p, provides its own implementation
+ - empty, no requirement
+
+| Archtecture  | getcontext | setcontext |
+|--------------|------------|------------|
+|    aarch64   |     p      |            |
+|    arm       |     p      |            |
+|    hppa      |     p      |      p     |
+|    ia64      |     p      |      r     |
+|    mips      |     p      |            |
+|    ppc32     |     r      |            |
+|    ppc64     |     r      |      r     |
+|    s390x     |     p      |      p     |
+|    sh        |     r      |            |
+|    tilegx    |     r      |      r     |
+|    x86       |     p      |      r     |
+|    x86_64    |     p      |      p     |
+
 ## General Build Instructions
 
 In general, this library can be built and installed with the following


### PR DESCRIPTION
I made this table when trying to fix [recent packaging issues in OpenWrt](https://github.com/openwrt/packages/issues/8548#issuecomment-498266597) .  It could help track progress on musl-libc support and may also help other distros.

The reason why subject of this pull request is prefixed with a RFC is that I am not sure about ppc32/ppc64's dependency on setcontext().

 - both of them provides _UI_setcontext assembly implmenetation, but I cannot see how this symbol could be get used in the code
 - ppc32 has no refs to setcontext() call
 - ppc64 calls setcontext() explicitly

