### PR TITLE
arm: clear thumb bit in $PC before setting it to $IP

### DIFF
--- a/src/arm/Gstep.c
+++ b/src/arm/Gstep.c
@@ -46,7 +46,8 @@ arm_exidx_step (struct cursor *c)
   c->dwarf.loc[UNW_ARM_R15] = DWARF_NULL_LOC;
   unw_word_t ip = c->dwarf.ip;
   if (c->dwarf.use_prev_instr)
-    --ip;
+    /* The least bit denotes thumb/arm mode, clear it. */
+    ip = (ip & ~(unw_word_t)0x1) - 1;
 
   /* check dynamic info first --- it overrides everything else */
   ret = unwi_find_dynamic_proc_info (c->dwarf.as, ip, &c->dwarf.pi, 1,

--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -440,8 +440,15 @@ fetch_proc_info (struct dwarf_cursor *c, unw_word_t ip)
      continue, and it's important we get this right, as 'ip' could be
      right at the function entry and hence FDE edge, or at instruction
      that manipulates CFA (push/pop). */
+
   if (c->use_prev_instr)
-    --ip;
+    {
+#if defined(__arm__)
+      /* On arm, the least bit denotes thumb/arm mode, clear it. */
+      ip &= ~(unw_word_t)0x1;
+#endif
+      --ip;
+    }
 
   memset (&c->pi, 0, sizeof (c->pi));
 

--- a/src/mi/Gget_proc_name.c
+++ b/src/mi/Gget_proc_name.c
@@ -106,7 +106,15 @@ unw_get_proc_name (unw_cursor_t *cursor, char *buf, size_t buf_len,
   ip = tdep_get_ip (c);
 #if !defined(__ia64__)
   if (c->dwarf.use_prev_instr)
-    --ip;
+    {
+#if defined(__arm__)
+      /* On arm, the least bit denotes thumb/arm mode, clear it. */
+      ip &= ~(unw_word_t)0x1;
+#endif
+      --ip;
+    }
+
+
 #endif
   error = get_proc_name (tdep_get_as (c), ip, buf, buf_len, offp,
                          tdep_get_as_arg (c));


### PR DESCRIPTION
PR #55 doesn't skip non-signal frame correctly. In general, arm32 has two instruction modes. The least-significant bit of the address is used to indicate which mode the function is using.

if we're using thumb mode, `-1` is not enough for moving to previous frame