### PR TITLE
arm: initialize use_prev_instr to 0 in handle_signal_frame

### DIFF
--- a/src/arm/Gos-linux.c
+++ b/src/arm/Gos-linux.c
@@ -118,6 +118,7 @@ arm_handle_signal_frame (unw_cursor_t *cursor)
   dwarf_get (&c->dwarf, c->dwarf.loc[UNW_ARM_R15], &c->dwarf.ip);
 
   c->dwarf.pi_valid = 0;
+  c->dwarf.use_prev_instr = 0;
 
   return 1;
 }


### PR DESCRIPTION
ref: `c->use_prev_instr` use in `fetch_proc_info`
  /* The 'ip' can point either to the previous or next instruction
     depending on what type of frame we have: normal call or a place
     to resume execution (e.g. after signal frame).

     For a normal call frame we need to back up so we point within the
     call itself; this is important because a) the call might be the
     very last instruction of the function and the edge of the FDE,
     and b) so that run_cfi_program() runs locations up to the call
     but not more.

     For signal frame, we need to do the exact opposite and look
     up using the current 'ip' value.  That is where execution will
     continue, and it's important we get this right, as 'ip' could be
     right at the function entry and hence FDE edge, or at instruction
     that manipulates CFA (push/pop). */

if I read this correctly, all the archs need this initialization. But
I heavily use and test on arm & aarch64. I'm not very confidence on
other arch.