### PR TITLE
fix compile issue on SH platform

### DIFF
--- a/src/sh/Ginit_local.c
+++ b/src/sh/Ginit_local.c
@@ -37,7 +37,7 @@ unw_init_local (unw_cursor_t *cursor, unw_context_t *uc)
 #else /* !UNW_REMOTE_ONLY */
 
 static int
-unw_init_local (unw_cursor_t *cursor, unw_context_t *uc, unsigned use_prev_instr)
+unw_init_local_common (unw_cursor_t *cursor, unw_context_t *uc, unsigned use_prev_instr)
 {
   struct cursor *c = (struct cursor *) cursor;
 


### PR DESCRIPTION
While compile for SH4 (STiH205 platform) I got the following error

libtool: compile:  sh4-linux-gcc -DHAVE_CONFIG_H -I. -I../include -I../include -I../include/tdep-sh -I. -D_GNU_SOURCE -DNDEBUG -g -O2 -fexceptions -Wall -Wsign-compare -D__EXTENSIONS__ -MT sh/Ginit_local.lo -MD -MP -MF sh/.deps/Ginit_local.Tpo -c sh/Ginit_local.c  -fPIC -DPIC -o sh/.libs/Ginit_local.o
sh/Ginit_local.c:40:1: error: conflicting types for ‘_Ush_init_local’
 unw_init_local (unw_cursor_t *cursor, unw_context_t *uc, unsigned use_prev_instr)
 ^
In file included from ../include/libunwind-sh.h:105:0,
                 from sh/unwind_i.h:28,
                 from sh/Ginit_local.c:26:
../include/libunwind-common.h:272:12: note: previous declaration of ‘_Ush_init_local’ was here
 extern int unw_init_local (unw_cursor_t *, unw_context_t *);
            ^
sh/Ginit_local.c:56:1: error: conflicting types for ‘_Ush_init_local’
 unw_init_local (unw_cursor_t *cursor, unw_context_t *uc)
 ^
sh/Ginit_local.c:40:1: note: previous definition of ‘_Ush_init_local’ was here
 unw_init_local (unw_cursor_t *cursor, unw_context_t *uc, unsigned use_prev_instr)
 ^
sh/Ginit_local.c: In function ‘_Ush_init_local’:
sh/Ginit_local.c:58:3: warning: implicit declaration of function ‘unw_init_local_common’ [-Wimplicit-function-declaration]
   return unw_init_local_common(cursor, uc, 1);
   ^
sh/Ginit_local.c: At top level:
sh/Ginit_local.c:40:1: warning: ‘_Ush_init_local’ defined but not used [-Wunused-function]
 unw_init_local (unw_cursor_t *cursor, unw_context_t *uc, unsigned use_prev_instr)
 ^
Makefile:3519: recipe for target 'sh/Ginit_local.lo' failed
make[3]: *** [sh/Ginit_local.lo] Error 1
make[3]: *** Waiting for unfinished jobs....

The name of the function must be unw_init_local_common as for the other platforms