### PR TITLE
Allow to build without weak `backtrace` symbol.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,6 +147,10 @@ AC_ARG_ENABLE(tests,
  AS_HELP_STRING([--disable-tests],[Disable tests build]),,
  [enable_tests=yes])
 
+AC_ARG_ENABLE(weak-backtrace,
+ AS_HELP_STRING([--disable-weak-backtrace],[Do not provide the weak 'backtrace' symbol.]),,
+ [enable_weak_backtrace=yes])
+
 AC_MSG_CHECKING([if we should build libunwind-setjmp])
 AC_MSG_RESULT([$enable_setjmp])
 
@@ -462,6 +466,11 @@ AM_CONDITIONAL([CONFIG_TESTS], [test x$enable_tests = xyes])
 if test "x$enable_tests" = "xyes"; then
   AC_CONFIG_FILES(tests/Makefile tests/check-namespace.sh)
 fi
+
+AM_CONDITIONAL([CONFIG_WEAK_BACKTRACE], [test "x$enable_weak_backtrace" = xyes])
+AM_COND_IF([CONFIG_WEAK_BACKTRACE], [
+  AC_DEFINE([CONFIG_WEAK_BACKTRACE], [1], [Define if the weak 'backtrace' symbol is provided.])
+])
 
 AC_CONFIG_FILES(Makefile src/Makefile
                 include/libunwind-common.h

--- a/src/mi/backtrace.c
+++ b/src/mi/backtrace.c
@@ -75,7 +75,9 @@ unw_backtrace (void **buffer, int size)
   return n;
 }
 
+#ifdef CONFIG_WEAK_BACKTRACE
 extern int backtrace (void **buffer, int size)
   WEAK ALIAS(unw_backtrace);
+#endif
 
 #endif /* !UNW_REMOTE_ONLY */

--- a/tests/check-namespace.sh.in
+++ b/tests/check-namespace.sh.in
@@ -121,7 +121,7 @@ check_local_unw_abi () {
     match _U_dyn_register
 
     match unw_backtrace
-    match backtrace
+    @CONFIG_WEAK_BACKTRACE_TRUE@match backtrace
 
     case ${plat} in
 	arm)


### PR DESCRIPTION
Signed-off-by: Bert Wesarg <bert.wesarg@tu-dresden.de>