### PR TITLE
x86-64: make `is_cached_valid_mem` functional

### DIFF
--- a/src/x86_64/Ginit.c
+++ b/src/x86_64/Ginit.c
@@ -215,7 +215,7 @@ is_cached_valid_mem(unw_word_t addr)
   int i;
   for (i = 0; i < NLGA; i++)
     {
-      if (addr == &last_good_addr[i])
+      if (addr == last_good_addr[i])
         return 1;
     }
   return 0;


### PR DESCRIPTION
Comparing against an address of `last_good_addr` wont ever be true.

Signed-off-by: Bert Wesarg <bert.wesarg@tu-dresden.de>