### PR TITLE
Fix SmartOS/Solaris build

### DIFF
--- a/README
+++ b/README
@@ -208,9 +208,15 @@ only test programs that are known to work at this time are:
 
 ### Expected results on Solaris x86-64
 
-`make check` is passing 23 out of 32 tests. The following nine tests are consistently
+`make check` is passing 13 out of 33 tests. The following nine tests are consistently
 failing:
 
+* `Gtest-bt`
+* `Ltest-bt`
+* `Gtest-init`
+* `Ltest-init`
+* `Gtest-concurrent`
+* `Ltest-concurrent`
 * `Gtest-resume-sig`
 * `Ltest-resume-sig`
 * `Gtest-resume-sig-rt`
@@ -218,7 +224,12 @@ failing:
 * `Gtest-trace`
 * `Ltest-trace`
 * `Ltest-init-local-signal`
+* `test-async-sig`
+* `test-init-remote`
+* `test-mem`
+* `Ltest-nomalloc`
 * `test-setjmp`
+* `x64-unwind-badjmp-signal-frame`
 * `run-check-namespace`
 
 ## Performance Testing

--- a/tests/x64-unwind-badjmp-signal-frame.c
+++ b/tests/x64-unwind-badjmp-signal-frame.c
@@ -30,7 +30,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <sys/types.h>
 #include <sys/ucontext.h>
 #include <unistd.h>
+
+#ifdef HAVE_SYS_PTRACE_H
 #include <sys/ptrace.h>
+#endif
 
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>


### PR DESCRIPTION
` #include <sys/ptrace.h>` was neither available nor required on Solaris/SmartOS.

Also, a bit unfortunately Solaris x86_64 support has been regressed since it was added last year (https://github.com/libunwind/libunwind/commit/edc427a9eccd6db583fd0cd920e2af23b4b544a9), now only 13 out of 33 tests are passing, which was previously 23 out of 32. I have updated `README.md` to reflect the current stats. Here is the test run logs collected on SmartOS x64: [test-suite.log](https://github.com/libunwind/libunwind/files/4173580/test-suite.log).
