### PR TITLE
Enabling Travis builds for s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,18 @@ env:
 - TARGET=mipsel-unknown-linux-gnu
 # Currently experiencing build failures here
 #- TARGET=powerpc64-linux-gnu
+
+linux-s390x: &linux-s390x
+  os: linux
+  arch: s390x
+  env: TARGET=s390x-linux-gnu
+  script:
+    - ./autogen.sh
+    - ./configure
+    - make -j32
+    - ulimit -c unlimited
+    - make check -j32
+
 script:
 - ./autogen.sh
 - ./configure --target=$TARGET --host=$HOST
@@ -16,3 +28,7 @@ script:
 - sudo bash -c 'echo core.%p.%p > /proc/sys/kernel/core_pattern'
 - ulimit -c unlimited
 - if [ $TARGET == 'x86_64-linux-gnu' ]; then make check -j32; fi
+
+jobs:
+  include:
+    - <<: *linux-s390x


### PR DESCRIPTION
As Travis CI [officially supports](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) s390x builds, adding support for same.