### PR TITLE
Illumos fixes

### DIFF
--- a/README
+++ b/README
@@ -21,7 +21,7 @@ several architecture/operating-system combinations:
 | FreeBSD | x86-64       | ✓      |
 | FreeBSD | x86          | ✓      |
 | FreeBSD | AArch64      | ✓      |
-| Solaris | x86-64       | Initial support |
+| Solaris | x86-64       | ✓      |
 
 ## Libc Requirements
 

--- a/include/tdep-x86_64/libunwind_i.h
+++ b/include/tdep-x86_64/libunwind_i.h
@@ -89,6 +89,7 @@ struct cursor
         X86_64_SCF_LINUX_RT_SIGFRAME,   /* Linux ucontext_t */
         X86_64_SCF_FREEBSD_SIGFRAME,    /* FreeBSD signal frame */
         X86_64_SCF_FREEBSD_SYSCALL,     /* FreeBSD syscall */
+        X86_64_SCF_SOLARIS_SIGFRAME,    /* illumos/Solaris signal frame */
       }
     sigcontext_format;
     unw_word_t sigcontext_addr;
@@ -200,7 +201,7 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
 #define tdep_get_exe_image_path         UNW_ARCH_OBJ(get_exe_image_path)
 #define tdep_access_reg                 UNW_OBJ(access_reg)
 #define tdep_access_fpreg               UNW_OBJ(access_fpreg)
-#if __linux__ || __sun
+#if __linux__
 # define tdep_fetch_frame               UNW_OBJ(fetch_frame)
 # define tdep_cache_frame               UNW_OBJ(cache_frame)
 # define tdep_reuse_frame               UNW_OBJ(reuse_frame)
@@ -252,7 +253,7 @@ extern int tdep_access_reg (struct cursor *c, unw_regnum_t reg,
                             unw_word_t *valp, int write);
 extern int tdep_access_fpreg (struct cursor *c, unw_regnum_t reg,
                               unw_fpreg_t *valp, int write);
-#if __linux__ || __sun
+#if __linux__
 extern void tdep_fetch_frame (struct dwarf_cursor *c, unw_word_t ip,
                               int need_unwind_info);
 extern int tdep_cache_frame (struct dwarf_cursor *c);

--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -572,6 +572,10 @@ dwarf_callback (struct dl_phdr_info *info, size_t size, void *ptr)
         }
       else if (phdr->p_type == PT_GNU_EH_FRAME)
         p_eh_hdr = phdr;
+#if defined __sun
+      else if (phdr->p_type == PT_SUNW_UNWIND)
+        p_eh_hdr = phdr;
+#endif
       else if (phdr->p_type == PT_DYNAMIC)
         p_dynamic = phdr;
     }

--- a/src/dwarf/Gfind_unwind_table.c
+++ b/src/dwarf/Gfind_unwind_table.c
@@ -80,6 +80,9 @@ dwarf_find_unwind_table (struct elf_dyn_info *edi, unw_addr_space_t as,
           break;
 
         case PT_GNU_EH_FRAME:
+#if defined __sun
+        case PT_SUNW_UNWIND:
+#endif
           peh_hdr = phdr + i;
           break;
 

--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -270,6 +270,13 @@ unw_step (unw_cursor_t *cursor)
               Debug (2, "returning %d\n", ret);
               return ret;
             }
+#if __sun
+          if (c->dwarf.ip == 0)
+            {
+              Debug (2, "returning 0\n");
+              return ret;
+            }
+#endif
           ret = 1;
         }
       else

--- a/tests/Gtest-bt.c
+++ b/tests/Gtest-bt.c
@@ -176,7 +176,7 @@ sighandler (int signal, void *siginfo UNUSED, void *context)
     {
       printf ("sighandler: got signal %d, sp=%p", signal, &sp);
 #if UNW_TARGET_IA64
-# if defined(__linux__)
+# if defined(__linux__) || defined __sun
       printf (" @ %lx", uc->uc_mcontext.sc_ip);
 # else
       {
@@ -189,13 +189,13 @@ sighandler (int signal, void *siginfo UNUSED, void *context)
       }
 # endif
 #elif UNW_TARGET_X86
-#if defined __linux__
+#if defined __linux__ || defined __sun
       printf (" @ %lx", (unsigned long) uc->uc_mcontext.gregs[REG_EIP]);
 #elif defined __FreeBSD__
       printf (" @ %lx", (unsigned long) uc->uc_mcontext.mc_eip);
 #endif
 #elif UNW_TARGET_X86_64
-#if defined __linux__
+#if defined __linux__ || defined __sun
       printf (" @ %lx", (unsigned long) uc->uc_mcontext.gregs[REG_RIP]);
 #elif defined __FreeBSD__
       printf (" @ %lx", (unsigned long) uc->uc_mcontext.mc_rip);

--- a/tests/Gtest-trace.c
+++ b/tests/Gtest-trace.c
@@ -207,7 +207,7 @@ sighandler (int signal, void *siginfo UNUSED, void *context)
       printf (" @ %lx", (unsigned long) uc->uc_mcontext.mc_eip);
 #endif
 #elif UNW_TARGET_X86_64
-#if defined __linux__
+#if defined __linux__ || defined __sun
       printf (" @ %lx", (unsigned long) uc->uc_mcontext.gregs[REG_RIP]);
 #elif defined __FreeBSD__
       printf (" @ %lx", (unsigned long) uc->uc_mcontext.mc_rip);

--- a/tests/check-namespace.sh.in
+++ b/tests/check-namespace.sh.in
@@ -85,6 +85,11 @@ filter_misc () {
 	ignore _ftext
 	ignore _gp
     fi
+
+    if [ ${os} == "solaris2.11" ]; then
+        ignore _PROCEDURE_LINKAGE_TABLE_
+        ignore _etext
+    fi
 }
 
 check_local_unw_abi () {


### PR DESCRIPTION
These commits fix a number of issues using libunwind on illumos. With these changes (along with a fix to crt1.o on illumos to provide CFI entries to terminate a stack walk), the test results look like:

```
PASS: test-proc-info
PASS: test-static-link
PASS: test-strerror
PASS: Gtest-bt
PASS: Ltest-bt
PASS: Gtest-exc
PASS: Ltest-exc
PASS: Gtest-init
PASS: Ltest-init
../config/test-driver: line 107: 8727: User signal 1
FAIL: Gtest-concurrent
FAIL: Ltest-concurrent
PASS: Gtest-resume-sig
PASS: Ltest-resume-sig
PASS: Gtest-resume-sig-rt
PASS: Ltest-resume-sig-rt
PASS: Gtest-trace
PASS: Ltest-trace
FAIL: Ltest-init-local-signal
PASS: Ltest-mem-validate
PASS: test-async-sig
PASS: test-flush-cache
PASS: test-init-remote
PASS: test-mem
PASS: test-reg-state
PASS: Ltest-varargs
PASS: Ltest-nomalloc
PASS: Ltest-nocalloc
PASS: Lrs-race
../config/test-driver: line 107: 8995: Abort(coredump)
FAIL: test-setjmp
PASS: Gx64-test-dwarf-expressions
PASS: Lx64-test-dwarf-expressions
FAIL: x64-unwind-badjmp-signal-frame
PASS: run-check-namespace
============================================================================
Testsuite summary for libunwind 1.5-rc1
============================================================================
# TOTAL: 33
# PASS:  28
# SKIP:  0
# XFAIL: 0
# FAIL:  5
# XPASS: 0
# ERROR: 0
============================================================================
See tests/test-suite.log
Please report to libunwind-devel@nongnu.org
============================================================================
```

While it doesn't fix all of the tests, it seems a significant enough improvement to contribute them now.

While I cannot test Solaris, it seems highly unlikely that the signal handling code in the kernel has diverged much since the code bases forked, so I'm fairly sure these will also improve the situation on Solaris as well.