### PR TITLE
Reflect current status of Solaris x64 in the README

### DIFF
--- a/README
+++ b/README
@@ -208,29 +208,15 @@ only test programs that are known to work at this time are:
 
 ### Expected results on Solaris x86-64
 
-`make check` is passing 13 out of 33 tests. The following twenty tests are consistently
+`make check` is passing 27 out of 33 tests. The following six tests are consistently
 failing:
 
-* `Gtest-bt`
-* `Ltest-bt`
-* `Gtest-init`
-* `Ltest-init`
 * `Gtest-concurrent`
 * `Ltest-concurrent`
-* `Gtest-resume-sig`
-* `Ltest-resume-sig`
-* `Gtest-resume-sig-rt`
-* `Ltest-resume-sig-rt`
-* `Gtest-trace`
-* `Ltest-trace`
 * `Ltest-init-local-signal`
-* `test-async-sig`
-* `test-init-remote`
-* `test-mem`
-* `Ltest-nomalloc`
+* `Lrs-race`
 * `test-setjmp`
 * `x64-unwind-badjmp-signal-frame`
-* `run-check-namespace`
 
 ## Performance Testing
 


### PR DESCRIPTION
Captured these results on latest SmartOS 20200408T231825Z x86_64. 

Inside the pkgsrc zone, `run-check-namespace` is passing, but it fails consistently in the global zone for some (yet-to-be-discovered) reason.

`Lrs-race` was passing for @jasonbking (#171), but it is consistently failing for me on SmartOS in both global and pkgsrc zones.

Build steps in both zones:

```sh
# pkgin install gcc7 automake libtool
cd libunwind
./autogen.sh
make
make check
```

cc @jasonbking, @sjorge