### PR TITLE
Fix off-by-one error in x86_64 stack frames

### DIFF
--- a/src/x86_64/Gtrace.c
+++ b/src/x86_64/Gtrace.c
@@ -540,7 +540,7 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       break;
 
     /* Record this address in stack trace. We skipped the first address. */
-    buffer[depth++] = (void *) (rip - d->use_prev_instr);
+    buffer[depth++] = (void *) rip;
   }
 
 #if UNW_DEBUG


### PR DESCRIPTION
This tiny change fixes issue #94. Currently, on x86_64 based platforms, stack addresses generated by are off-by-one - actually 1 byte under the actual rip of the frame. As described in issue #94, this is owing to the way that the 'use_prev_instr' variable is applied incorrectly to the actual rip being recorded.

As an example `tests/Gtest-trace` before the fix clearly shows the brokenness for unw_backtrace():

```
Normal backtrace:
  normal trace:
   #0   ip=0x400e88
   #1   ip=0x4015f9
   #2   ip=0x400b8d
   #3   ip=0x7f3866c3a505

  via backtrace():
   #0   ip=0x400f17
   #1   ip=0x4015f9
   #2   ip=0x400b8d
   #3   ip=0x7f3866c3a505
   #4   ip=0x400d9b

  via unw_backtrace():
   #0   ip=0x400f79
   #1   ip=0x4015f8
   #2   ip=0x400b8c
   #3   ip=0x7f3866c3a504
   #4   ip=0x400d9a
```

With the fix the addresses are now correct:

```
Normal backtrace:
  normal trace:
   #0   ip=0x400e88
   #1   ip=0x4015f9
   #2   ip=0x400b8d
   #3   ip=0x7eff9af0e505

  via backtrace():
   #0   ip=0x400f17
   #1   ip=0x4015f9
   #2   ip=0x400b8d
   #3   ip=0x7eff9af0e505
   #4   ip=0x400d9b

  via unw_backtrace():
   #0   ip=0x400f7a
   #1   ip=0x4015f9
   #2   ip=0x400b8d
   #3   ip=0x7eff9af0e505
   #4   ip=0x400d9b
```

This problem was introduced by 5f38f35 just over 9 years ago :-) .