### PR TITLE
src/arm/Gex_tables.c: resolve possible null pointer dereference

### DIFF
--- a/src/arm/Gex_tables.c
+++ b/src/arm/Gex_tables.c
@@ -152,12 +152,12 @@ HIDDEN int
 arm_exidx_decode (const uint8_t *buf, uint8_t len, struct dwarf_cursor *c)
 {
 #define READ_OP() *buf++
+  assert(buf != NULL);
+  assert(len > 0);
+
   const uint8_t *end = buf + len;
   int ret;
   struct arm_exbuf_data edata;
-
-  assert(buf != NULL);
-  assert(len > 0);
 
   while (buf < end)
     {


### PR DESCRIPTION
found by cppcheck

[src/arm/Gex_tables.c:159] -> [src/arm/Gex_tables.c:155]: (warning) Either the condition 'buf!=NULL' is redundant or there is pointer arithmetic with NULL pointer.

Upstreamed from dotnet/coreclr#26869

/cc @chipitsine