### PR TITLE
Fix a memory leak issue

### DIFF
--- a/src/tilegx/Gcreate_addr_space.c
+++ b/src/tilegx/Gcreate_addr_space.c
@@ -33,15 +33,6 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
 #ifdef UNW_LOCAL_ONLY
   return NULL;
 #else
-  unw_addr_space_t as = malloc (sizeof (*as));
-
-  if (!as)
-    return NULL;
-
-  memset (as, 0, sizeof (*as));
-
-  as->acc = *a;
-
   /*
    * Tilegx supports only big or little-endian, not weird stuff like
    * PDP_ENDIAN.
@@ -50,6 +41,14 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
       && byte_order != __LITTLE_ENDIAN
       && byte_order != __BIG_ENDIAN)
     return NULL;
+
+  unw_addr_space_t as = malloc (sizeof (*as));
+  if (!as)
+    return NULL;
+
+  memset (as, 0, sizeof (*as));
+
+  as->acc = *a;
 
   if (byte_order == 0)
     /* use host default: */


### PR DESCRIPTION
One memleak issue was found by static analyzer.

```sh
$ cppcheck --enable=all . 2>&1 | grep -B5 -A5 -i leak
...
Checking src/tilegx/Gcreate_addr_space.c ...
src/tilegx/Gcreate_addr_space.c:52:5: error: Memory leak: as [memleak]
    return NULL;
    ^
...
```