### PR TITLE
Added --disable-unwind-header option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,10 @@ include_HEADERS += include/libunwind-s390x.h
 endif
 
 if !REMOTE_ONLY
-include_HEADERS += include/libunwind.h include/unwind.h
+include_HEADERS += include/libunwind.h
+if BUILD_UNWIND_HEADER
+include_HEADERS += include/unwind.h
+endif
 endif
 
 nodist_include_HEADERS = include/libunwind-common.h

--- a/configure.ac
+++ b/configure.ac
@@ -149,6 +149,13 @@ AC_ARG_ENABLE(weak-backtrace,
  AS_HELP_STRING([--disable-weak-backtrace],[Do not provide the weak 'backtrace' symbol.]),,
  [enable_weak_backtrace=yes])
 
+AC_ARG_ENABLE(unwind-header,
+ AS_HELP_STRING([--disable-unwind-header],[Do not export the 'unwind.h' header]),,
+ [enable_unwind_header=yes])
+
+AC_MSG_CHECKING([if we should export unwind.h])
+AC_MSG_RESULT([$enable_unwind_header])
+
 AC_MSG_CHECKING([if we should build libunwind-setjmp])
 AC_MSG_RESULT([$enable_setjmp])
 
@@ -164,6 +171,7 @@ AC_MSG_RESULT([$target_os])
 AM_CONDITIONAL(BUILD_COREDUMP, test x$enable_coredump = xyes)
 AM_CONDITIONAL(BUILD_PTRACE, test x$enable_ptrace = xyes)
 AM_CONDITIONAL(BUILD_SETJMP, test x$enable_setjmp = xyes)
+AM_CONDITIONAL(BUILD_UNWIND_HEADER, test "x$enable_unwind_header" = xyes)
 AM_CONDITIONAL(NO_PTRACE_TEST, test x$build_arch != x$host_arch)
 AM_CONDITIONAL(REMOTE_ONLY, test x$target_arch != x$host_arch)
 AM_CONDITIONAL(ARCH_AARCH64, test x$target_arch = xaarch64)


### PR DESCRIPTION
When set, unwind.h won't be copied to the installation directory. Some platforms provide their own unwind.h that might conflict with the one supplied with libunwind.

As mentioned in #124, libunwind installs its own copy of unwind.h. This file externs `_Unwind_GetIPInfo` which some ARM platforms with an old libstdc++ don't have.

Depending on the order of include paths libunwind's unwind.h might be read before the system one, causing third party code that does not link against libunwind to fail with an `undefined reference to '_Unwind_GetIPInfo'` linker error.