### PR TITLE
Fix placement of alignas() specifier

### DIFF
--- a/include/libunwind-aarch64.h
+++ b/include/libunwind-aarch64.h
@@ -194,7 +194,7 @@ struct unw_sigcontext
 	uint64_t sp;
 	uint64_t pc;
 	uint64_t pstate;
-	uint8_t alignas(16) __reserved[(66 * 8)];
+	alignas(16) uint8_t __reserved[(66 * 8)];
 };
 
 typedef struct

--- a/include/unwind.h
+++ b/include/unwind.h
@@ -77,7 +77,7 @@ typedef _Unwind_Reason_Code (*_Unwind_Stop_Fn) (int, _Unwind_Action,
    even on 32-bit machines for gcc compatibility.  */
 struct _Unwind_Exception
   {
-    uint64_t alignas(8) exception_class;
+    alignas(8) uint64_t exception_class;
     _Unwind_Exception_Cleanup_Fn exception_cleanup;
     unsigned long private_1;
     unsigned long private_2;

--- a/include/win/fakestdalign.h.in
+++ b/include/win/fakestdalign.h.in
@@ -1,4 +1,4 @@
-// This is a fake implementatino of stdaliagn.h for when 
+// This is a fake implementation of stdalign.h for when
 // compiler C11 stdaliagn.h support is missing
 
 #ifndef FAKE_STD_ALIGN_H

--- a/include/win/fakestdatomic.h.in
+++ b/include/win/fakestdatomic.h.in
@@ -1,4 +1,4 @@
-// This is a non-atomic fake implementatino of stdatomics for when 
+// This is a non-atomic fake implementation of stdatomic.h for when
 // compiler C11 stdatomic support is missing and only single threaded
 // operation is required
 

--- a/include/win/sys/types.h
+++ b/include/win/sys/types.h
@@ -13,7 +13,7 @@
 #include <../ucrt/sys/types.h>
 #include <stddef.h>
 
-typedef size_t pid_t;
+typedef int pid_t;
 typedef ptrdiff_t ssize_t;
 
 #endif // _MSC_VER

--- a/src/mi/mempool.c
+++ b/src/mi/mempool.c
@@ -41,7 +41,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 # define MAX_ALIGN      MAX_ALIGN_(sizeof (long double))
 #endif
 
-static char alignas(MAX_ALIGN) sos_memory[SOS_MEMORY_SIZE];
+static alignas(MAX_ALIGN) char sos_memory[SOS_MEMORY_SIZE];
 static _Atomic size_t sos_memory_freepos = 0;
 static size_t pg_size;
 


### PR DESCRIPTION
The alignment specifier must appear before the typename

i.e. clang9 refuses to compile

uint8_t alignas(MAX_ALIGN) __reserved[128];

but accepts

alignas(MAX_ALIGN) uint8_t __reserved[128];