### PR TITLE
Portability fixes (from QNX)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,8 +34,8 @@ esac
 
 dnl Checks for header files.
 AC_HEADER_STDC
-AC_CHECK_HEADERS(asm/ptrace_offsets.h endian.h sys/endian.h execinfo.h \
-		ia64intrin.h sys/uc_access.h unistd.h signal.h sys/types.h \
+AC_CHECK_HEADERS(asm/ptrace_offsets.h endian.h sys/endian.h sys/param.h \
+		execinfo.h ia64intrin.h sys/uc_access.h unistd.h signal.h sys/types.h \
 		sys/procfs.h sys/ptrace.h byteswap.h elf.h sys/elf.h link.h sys/link.h)
 
 dnl Checks for typedefs, structures, and compiler characteristics.

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,8 @@ dnl Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS(asm/ptrace_offsets.h endian.h sys/endian.h sys/param.h \
 		execinfo.h ia64intrin.h sys/uc_access.h unistd.h signal.h sys/types.h \
-		sys/procfs.h sys/ptrace.h byteswap.h elf.h sys/elf.h link.h sys/link.h)
+		sys/procfs.h sys/ptrace.h sys/syscall.h byteswap.h elf.h sys/elf.h \
+		link.h sys/link.h)
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/include/dwarf_i.h
+++ b/include/dwarf_i.h
@@ -142,7 +142,7 @@ dwarf_readu8 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
 
   *addr += 1;
   ret = (*a->access_mem) (as, aligned_addr, &val, 0, arg);
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if UNW_BYTE_ORDER == UNW_LITTLE_ENDIAN
   val >>= 8*off;
 #else
   val >>= 8*(sizeof (unw_word_t) - 1 - off);

--- a/include/libunwind-aarch64.h
+++ b/include/libunwind-aarch64.h
@@ -183,6 +183,7 @@ typedef struct unw_tdep_save_loc
   }
 unw_tdep_save_loc_t;
 
+#ifdef __linux__
 /* On AArch64, we can directly use ucontext_t as the unwind context,
  * however, the __reserved struct is quite large: tune it down to only
  * the necessary used fields.  */
@@ -214,7 +215,10 @@ typedef struct
 	uint32_t fpcr;
 	uint64_t vregs[64];
   } unw_fpsimd_context_t;
-
+#else
+/* On AArch64, we can directly use ucontext_t as the unwind context.  */
+typedef ucontext_t unw_tdep_context_t;
+#endif
 
 
 #include "libunwind-common.h"

--- a/include/libunwind-mips.h
+++ b/include/libunwind-mips.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 #include <inttypes.h>
-#include <sys/ucontext.h>
+#include <ucontext.h>
 
 #ifdef mips
 # undef mips

--- a/include/libunwind_i.h
+++ b/include/libunwind_i.h
@@ -63,6 +63,16 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #else
 # error Could not locate <elf.h>
 #endif
+#if defined(ELFCLASS32)
+# define UNW_ELFCLASS32 ELFCLASS32
+#else
+# define UNW_ELFCLASS32 1
+#endif
+#if defined(ELFCLASS64)
+# define UNW_ELFCLASS64 ELFCLASS64
+#else
+# define UNW_ELFCLASS64 2
+#endif
 
 #if defined(HAVE_ENDIAN_H)
 # include <endian.h>

--- a/include/libunwind_i.h
+++ b/include/libunwind_i.h
@@ -68,32 +68,62 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 # include <endian.h>
 #elif defined(HAVE_SYS_ENDIAN_H)
 # include <sys/endian.h>
-# if defined(_LITTLE_ENDIAN) && !defined(__LITTLE_ENDIAN)
-#   define __LITTLE_ENDIAN _LITTLE_ENDIAN
-# endif
-# if defined(_BIG_ENDIAN) && !defined(__BIG_ENDIAN)
-#   define __BIG_ENDIAN _BIG_ENDIAN
-# endif
-# if defined(_BYTE_ORDER) && !defined(__BYTE_ORDER)
-#   define __BYTE_ORDER _BYTE_ORDER
-# endif
+#elif defined(HAVE_SYS_PARAM_H)
+# include <sys/param.h>
+#endif
+
+#if defined(__LITTLE_ENDIAN)
+# define UNW_LITTLE_ENDIAN __LITTLE_ENDIAN
+#elif defined(_LITTLE_ENDIAN)
+# define UNW_LITTLE_ENDIAN _LITTLE_ENDIAN
+#elif defined(LITTLE_ENDIAN)
+# define UNW_LITTLE_ENDIAN LITTLE_ENDIAN
 #else
-# define __LITTLE_ENDIAN        1234
-# define __BIG_ENDIAN           4321
+# define UNW_LITTLE_ENDIAN 1234
+#endif
+
+#if defined(__BIG_ENDIAN)
+# define UNW_BIG_ENDIAN __BIG_ENDIAN
+#elif defined(_BIG_ENDIAN)
+# define UNW_BIG_ENDIAN _BIG_ENDIAN
+#elif defined(BIG_ENDIAN)
+# define UNW_BIG_ENDIAN BIG_ENDIAN
+#else
+# define UNW_BIG_ENDIAN 4321
+#endif
+
+#if defined(__BYTE_ORDER)
+# define UNW_BYTE_ORDER __BYTE_ORDER
+#elif defined(_BYTE_ORDER)
+# define UNW_BYTE_ORDER _BYTE_ORDER
+#elif defined(BIG_ENDIAN)
+# define UNW_BYTE_ORDER BYTE_ORDER
+#else
 # if defined(__hpux)
-#   define __BYTE_ORDER __BIG_ENDIAN
-# elif defined(__QNX__)
-#   if defined(__BIGENDIAN__)
-#     define __BYTE_ORDER __BIG_ENDIAN
-#   elif defined(__LITTLEENDIAN__)
-#     define __BYTE_ORDER __LITTLE_ENDIAN
-#   else
-#     error Host has unknown byte-order.
-#   endif
+#  define UNW_BYTE_ORDER UNW_BIG_ENDIAN
 # else
-#   error Host has unknown byte-order.
+#  error Target has unknown byte ordering.
 # endif
 #endif
+
+static inline int
+byte_order_is_valid(int byte_order)
+{
+    return byte_order != UNW_BIG_ENDIAN
+        && byte_order != UNW_LITTLE_ENDIAN;
+}
+
+static inline int
+byte_order_is_big_endian(int byte_order)
+{
+    return byte_order == UNW_BIG_ENDIAN;
+}
+
+static inline int
+target_is_big_endian()
+{
+    return byte_order_is_big_endian(UNW_BYTE_ORDER);
+}
 
 #if defined(HAVE__BUILTIN_UNREACHABLE)
 # define unreachable() __builtin_unreachable()

--- a/include/remote.h
+++ b/include/remote.h
@@ -58,7 +58,7 @@ fetch8 (unw_addr_space_t as, unw_accessors_t *a,
 
   ret = (*a->access_mem) (as, aligned_addr, &val, 0, arg);
 
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if UNW_BYTE_ORDER == UNW_LITTLE_ENDIAN
   val >>= 8*off;
 #else
   val >>= 8*(WSIZE - 1 - off);
@@ -81,7 +81,7 @@ fetch16 (unw_addr_space_t as, unw_accessors_t *a,
 
   ret = (*a->access_mem) (as, aligned_addr, &val, 0, arg);
 
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if UNW_BYTE_ORDER == UNW_LITTLE_ENDIAN
   val >>= 8*off;
 #else
   val >>= 8*(WSIZE - 2 - off);
@@ -104,7 +104,7 @@ fetch32 (unw_addr_space_t as, unw_accessors_t *a,
 
   ret = (*a->access_mem) (as, aligned_addr, &val, 0, arg);
 
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if UNW_BYTE_ORDER == UNW_LITTLE_ENDIAN
   val >>= 8*off;
 #else
   val >>= 8*(WSIZE - 4 - off);

--- a/src/aarch64/Gcreate_addr_space.c
+++ b/src/aarch64/Gcreate_addr_space.c
@@ -37,8 +37,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
   unw_addr_space_t as;
 
   /* AArch64 supports little-endian and big-endian. */
-  if (byte_order != 0 && byte_order != __LITTLE_ENDIAN
-      && byte_order != __BIG_ENDIAN)
+  if (byte_order != 0 && byte_order_is_valid(byte_order) == 0)
     return NULL;
 
   as = malloc (sizeof (*as));
@@ -50,7 +49,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
   as->acc = *a;
 
   /* Default to little-endian for AArch64. */
-  if (byte_order == 0 || byte_order == __LITTLE_ENDIAN)
+  if (byte_order == 0 || byte_order == UNW_LITTLE_ENDIAN)
     as->big_endian = 0;
   else
     as->big_endian = 1;

--- a/src/aarch64/Ginit.c
+++ b/src/aarch64/Ginit.c
@@ -182,7 +182,7 @@ aarch64_local_addr_space_init (void)
   local_addr_space.acc.access_fpreg = access_fpreg;
   local_addr_space.acc.resume = aarch64_local_resume;
   local_addr_space.acc.get_proc_name = get_static_proc_name;
-  local_addr_space.big_endian = (__BYTE_ORDER == __BIG_ENDIAN);
+  local_addr_space.big_endian = target_is_big_endian();
   unw_flush_cache (&local_addr_space, 0, 0);
 }
 

--- a/src/arm/Gcreate_addr_space.c
+++ b/src/arm/Gcreate_addr_space.c
@@ -37,8 +37,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
   /*
    * ARM supports little-endian and big-endian.
    */
-  if (byte_order != 0 && byte_order != __LITTLE_ENDIAN
-      && byte_order != __BIG_ENDIAN)
+  if (byte_order != 0 && byte_order_is_valid(byte_order) == 0)
     return NULL;
 
   as = malloc (sizeof (*as));
@@ -50,7 +49,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
   as->acc = *a;
 
   /* Default to little-endian for ARM.  */
-  if (byte_order == 0 || byte_order == __LITTLE_ENDIAN)
+  if (byte_order == 0 || byte_order == UNW_LITTLE_ENDIAN)
     as->big_endian = 0;
   else
     as->big_endian = 1;

--- a/src/coredump/_UCD_create.c
+++ b/src/coredump/_UCD_create.c
@@ -31,7 +31,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <byteswap.h>
 #endif
 
-#include <elf.h>
+#if defined(HAVE_ELF_H)
+# include <elf.h>
+#if defined(HAVE_SYS_ELF_H)
+# include <sys/elf.h>
+#endif
 #include <sys/procfs.h> /* struct elf_prstatus */
 
 #include "_UCD_lib.h"

--- a/src/coredump/_UCD_create.c
+++ b/src/coredump/_UCD_create.c
@@ -30,35 +30,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #if defined(HAVE_BYTESWAP_H)
 #include <byteswap.h>
 #endif
-#if defined(HAVE_ENDIAN_H)
-# include <endian.h>
-#elif defined(HAVE_SYS_ENDIAN_H)
-# include <sys/endian.h>
-#endif
-#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
-# define WE_ARE_BIG_ENDIAN    1
-# define WE_ARE_LITTLE_ENDIAN 0
-#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
-# define WE_ARE_BIG_ENDIAN    0
-# define WE_ARE_LITTLE_ENDIAN 1
-#elif defined(_BYTE_ORDER) && _BYTE_ORDER == _BIG_ENDIAN
-# define WE_ARE_BIG_ENDIAN    1
-# define WE_ARE_LITTLE_ENDIAN 0
-#elif defined(_BYTE_ORDER) && _BYTE_ORDER == _LITTLE_ENDIAN
-# define WE_ARE_BIG_ENDIAN    0
-# define WE_ARE_LITTLE_ENDIAN 1
-#elif defined(BYTE_ORDER) && BYTE_ORDER == BIG_ENDIAN
-# define WE_ARE_BIG_ENDIAN    1
-# define WE_ARE_LITTLE_ENDIAN 0
-#elif defined(BYTE_ORDER) && BYTE_ORDER == LITTLE_ENDIAN
-# define WE_ARE_BIG_ENDIAN    0
-# define WE_ARE_LITTLE_ENDIAN 1
-#elif defined(__386__)
-# define WE_ARE_BIG_ENDIAN    0
-# define WE_ARE_LITTLE_ENDIAN 1
-#else
-# error "Can't determine endianness"
-#endif
 
 #include <elf.h>
 #include <sys/procfs.h> /* struct elf_prstatus */
@@ -118,7 +89,7 @@ _UCD_create(const char *filename)
       goto err;
     }
 
-  if (WE_ARE_LITTLE_ENDIAN != (elf_header32.e_ident[EI_DATA] == ELFDATA2LSB))
+  if (target_is_big_endian() && (elf_header32.e_ident[EI_DATA] == ELFDATA2LSB))
     {
       Debug(0, "'%s' is endian-incompatible\n", filename);
       goto err;

--- a/src/coredump/_UCD_create.c
+++ b/src/coredump/_UCD_create.c
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #if defined(HAVE_ELF_H)
 # include <elf.h>
-#if defined(HAVE_SYS_ELF_H)
+#elif defined(HAVE_SYS_ELF_H)
 # include <sys/elf.h>
 #endif
 #include <sys/procfs.h> /* struct elf_prstatus */

--- a/src/coredump/_UCD_elf_map_image.c
+++ b/src/coredump/_UCD_elf_map_image.c
@@ -21,7 +21,11 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
-#include <elf.h>
+#if defined(HAVE_ELF_H)
+# include <elf.h>
+#elif defined(HAVE_SYS_ELF_H)
+# include <sys/elf.h>
+#endif
 
 #include "_UCD_lib.h"
 #include "_UCD_internal.h"

--- a/src/coredump/_UCD_find_proc_info.c
+++ b/src/coredump/_UCD_find_proc_info.c
@@ -21,7 +21,11 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
-#include <elf.h>
+#if defined(HAVE_ELF_H)
+# include <elf.h>
+#elif defined(HAVE_SYS_ELF_H)
+# include <sys/elf.h>
+#endif
 
 #include "_UCD_lib.h"
 #include "_UCD_internal.h"

--- a/src/coredump/_UCD_get_proc_name.c
+++ b/src/coredump/_UCD_get_proc_name.c
@@ -64,9 +64,9 @@ _UCD_get_proc_name (unw_addr_space_t as, unw_word_t ip,
 {
   struct UCD_info *ui = arg;
 
-#if ELF_CLASS == ELFCLASS64
+#if UNW_ELF_CLASS == UNW_ELFCLASS64
   return _Uelf64_CD_get_proc_name (ui, as, ip, buf, buf_len, offp);
-#elif ELF_CLASS == ELFCLASS32
+#elif UNW_ELF_CLASS == UNW_ELFCLASS32
   return _Uelf32_CD_get_proc_name (ui, as, ip, buf, buf_len, offp);
 #else
   return -UNW_ENOINFO;

--- a/src/elf32.h
+++ b/src/elf32.h
@@ -1,8 +1,8 @@
 #ifndef elf32_h
 #define elf32_h
 
-#ifndef ELF_CLASS
-#define ELF_CLASS       ELFCLASS32
+#ifndef UNW_ELF_CLASS
+# define UNW_ELF_CLASS UNW_ELFCLASS32
 #endif
 #include "elfxx.h"
 

--- a/src/elf64.h
+++ b/src/elf64.h
@@ -1,8 +1,8 @@
 #ifndef elf64_h
 #define elf64_h
 
-#ifndef ELF_CLASS
-#define ELF_CLASS       ELFCLASS64
+#ifndef UNW_ELF_CLASS
+# define UNW_ELF_CLASS UNW_ELFCLASS64
 #endif
 #include "elfxx.h"
 

--- a/src/elfxx.h
+++ b/src/elfxx.h
@@ -32,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "libunwind_i.h"
 
-#if ELF_CLASS == ELFCLASS32
+#if UNW_ELF_CLASS == UNW_ELFCLASS32
 # define ELF_W(x)       ELF32_##x
 # define Elf_W(x)       Elf32_##x
 # define elf_w(x)       _Uelf32_##x
@@ -64,7 +64,7 @@ elf_w (valid_object) (struct elf_image *ei)
     return 0;
 
   return (memcmp (ei->image, ELFMAG, SELFMAG) == 0
-          && ((uint8_t *) ei->image)[EI_CLASS] == ELF_CLASS
+          && ((uint8_t *) ei->image)[EI_CLASS] == UNW_ELF_CLASS
           && ((uint8_t *) ei->image)[EI_VERSION] != EV_NONE
           && ((uint8_t *) ei->image)[EI_VERSION] <= EV_CURRENT);
 }

--- a/src/hppa/Gcreate_addr_space.c
+++ b/src/hppa/Gcreate_addr_space.c
@@ -38,7 +38,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
   /*
    * hppa supports only big-endian.
    */
-  if (byte_order != 0 && byte_order != __BIG_ENDIAN)
+  if (byte_order != 0 && byte_order != UNW_BIG_ENDIAN)
     return NULL;
 
   as = malloc (sizeof (*as));

--- a/src/ia64/Gcreate_addr_space.c
+++ b/src/ia64/Gcreate_addr_space.c
@@ -39,9 +39,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
    * IA-64 supports only big or little-endian, not weird stuff like
    * PDP_ENDIAN.
    */
-  if (byte_order != 0
-      && byte_order != __LITTLE_ENDIAN
-      && byte_order != __BIG_ENDIAN)
+  if (byte_order != 0 && byte_order_is_valid(byte_order) == 0)
     return NULL;
 
   as = malloc (sizeof (*as));
@@ -55,9 +53,9 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
 
   if (byte_order == 0)
     /* use host default: */
-    as->big_endian = (__BYTE_ORDER == __BIG_ENDIAN);
+    as->big_endian = target_is_big_endian();
   else
-    as->big_endian = (byte_order == __BIG_ENDIAN);
+    as->big_endian = byte_order_is_big_endian(byte_order);
   return as;
 #endif
 }

--- a/src/ia64/Ginit.c
+++ b/src/ia64/Ginit.c
@@ -356,7 +356,7 @@ HIDDEN void
 ia64_local_addr_space_init (void)
 {
   memset (&local_addr_space, 0, sizeof (local_addr_space));
-  local_addr_space.big_endian = (__BYTE_ORDER == __BIG_ENDIAN);
+  local_addr_space.big_endian = target_is_big_endian();
 #if defined(__linux)
   local_addr_space.abi = ABI_LINUX;
 #elif defined(__hpux)
@@ -407,7 +407,7 @@ ia64_uc_access_reg (struct cursor *c, ia64_loc_t loc, unw_word_t *valp,
          become possible at some point in the future, the
          copy-in/copy-out needs to be adjusted to do byte-swapping if
          necessary. */
-      assert (c->as->big_endian == (__BYTE_ORDER == __BIG_ENDIAN));
+      assert (c->as->big_endian == target_is_big_endian());
 
       dst = (unw_word_t *) ucp;
       for (src = uc_addr; src < uc_addr + sizeof (ucontext_t); src += 8)
@@ -475,7 +475,7 @@ ia64_uc_access_fpreg (struct cursor *c, ia64_loc_t loc, unw_fpreg_t *valp,
          become possible at some point in the future, the
          copy-in/copy-out needs to be adjusted to do byte-swapping if
          necessary. */
-      assert (c->as->big_endian == (__BYTE_ORDER == __BIG_ENDIAN));
+      assert (c->as->big_endian == target_is_big_endian());
 
       dst = (unw_word_t *) ucp;
       for (src = uc_addr; src < uc_addr + sizeof (ucontext_t); src += 8)

--- a/src/ia64/unwind_i.h
+++ b/src/ia64/unwind_i.h
@@ -61,7 +61,7 @@ inlined_uc_addr (ucontext_t *uc, int reg, uint8_t *nat_bitnr)
     case UNW_IA64_NAT + 0:      addr = &unw.read_only.r0; break;
     case UNW_IA64_FR + 0:       addr = &unw.read_only.f0; break;
     case UNW_IA64_FR + 1:
-      if (__BYTE_ORDER == __BIG_ENDIAN)
+      if (target_is_big_endian())
         addr = &unw.read_only.f1_be;
       else
         addr = &unw.read_only.f1_le;

--- a/src/mips/Gcreate_addr_space.c
+++ b/src/mips/Gcreate_addr_space.c
@@ -38,9 +38,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
    * MIPS supports only big or little-endian, not weird stuff like
    * PDP_ENDIAN.
    */
-  if (byte_order != 0
-      && byte_order != __LITTLE_ENDIAN
-      && byte_order != __BIG_ENDIAN)
+  if (byte_order != 0 byte_order_is_valid(byte_order) == 0)
     return NULL;
 
   as = malloc (sizeof (*as));
@@ -53,9 +51,9 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
 
   if (byte_order == 0)
     /* use host default: */
-    as->big_endian = (__BYTE_ORDER == __BIG_ENDIAN);
+    as->big_endian = target_is_big_endian();
   else
-    as->big_endian = (byte_order == __BIG_ENDIAN);
+    as->big_endian = (byte_order == UNW_BIG_ENDIAN);
 
   /* FIXME!  There is no way to specify the ABI.  */
 #if _MIPS_SIM == _ABIO32

--- a/src/mips/Gcreate_addr_space.c
+++ b/src/mips/Gcreate_addr_space.c
@@ -38,7 +38,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
    * MIPS supports only big or little-endian, not weird stuff like
    * PDP_ENDIAN.
    */
-  if (byte_order != 0 byte_order_is_valid(byte_order) == 0)
+  if (byte_order != 0 && byte_order_is_valid(byte_order) == 0)
     return NULL;
 
   as = malloc (sizeof (*as));

--- a/src/mips/Ginit.c
+++ b/src/mips/Ginit.c
@@ -183,7 +183,7 @@ HIDDEN void
 mips_local_addr_space_init (void)
 {
   memset (&local_addr_space, 0, sizeof (local_addr_space));
-  local_addr_space.big_endian = (__BYTE_ORDER == __BIG_ENDIAN);
+  local_addr_space.big_endian = target_is_big_endian();
 #if _MIPS_SIM == _ABIO32
   local_addr_space.abi = UNW_MIPS_ABI_O32;
 #elif _MIPS_SIM == _ABIN32

--- a/src/ppc32/Gcreate_addr_space.c
+++ b/src/ppc32/Gcreate_addr_space.c
@@ -40,7 +40,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
   /*
    * We support only big-endian on Linux ppc32.
    */
-  if (byte_order != 0 && byte_order != __BIG_ENDIAN)
+  if (byte_order != 0 && byte_order != UNW_BIG_ENDIAN)
     return NULL;
 
   as = malloc (sizeof (*as));

--- a/src/ppc32/Gresume.c
+++ b/src/ppc32/Gresume.c
@@ -31,8 +31,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #ifndef UNW_REMOTE_ONLY
 
-#include <sys/syscall.h>
-
 /* sigreturn() is a no-op on x86_64 glibc.  */
 
 static NORETURN inline long

--- a/src/ppc32/unwind_i.h
+++ b/src/ppc32/unwind_i.h
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <libunwind-ppc32.h>
 
 #include <libunwind_i.h>
-#include <sys/ucontext.h>
+#include <ucontext.h>
 
 #define ppc32_lock                      UNW_OBJ(lock)
 #define ppc32_local_resume              UNW_OBJ(local_resume)

--- a/src/ppc64/Gcreate_addr_space.c
+++ b/src/ppc64/Gcreate_addr_space.c
@@ -40,9 +40,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
   /*
    * We support both big- and little-endian on Linux ppc64.
    */
-  if (byte_order != 0
-      && byte_order != __LITTLE_ENDIAN
-      && byte_order != __BIG_ENDIAN)
+  if (byte_order != 0 && byte_order_is_valid(byte_order) == 0);
     return NULL;
 
   as = malloc (sizeof (*as));
@@ -55,9 +53,9 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
 
   if (byte_order == 0)
     /* use host default: */
-    as->big_endian = (__BYTE_ORDER == __BIG_ENDIAN);
+    as->big_endian = target_is_big_endian();
   else
-    as->big_endian = (byte_order == __BIG_ENDIAN);
+    as->big_endian = order_is_big_endian(byte_order);
 
   /* FIXME!  There is no way to specify the ABI.
      Default to ELFv1 on big-endian and ELFv2 on little-endian.  */

--- a/src/ppc64/Ginit.c
+++ b/src/ppc64/Ginit.c
@@ -211,7 +211,7 @@ HIDDEN void
 ppc64_local_addr_space_init (void)
 {
   memset (&local_addr_space, 0, sizeof (local_addr_space));
-  local_addr_space.big_endian = (__BYTE_ORDER == __BIG_ENDIAN);
+  local_addr_space.big_endian = target_is_big_endian();
 #if _CALL_ELF == 2
   local_addr_space.abi = UNW_PPC64_ABI_ELFv2;
 #else

--- a/src/ppc64/Gresume.c
+++ b/src/ppc64/Gresume.c
@@ -31,8 +31,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #ifndef UNW_REMOTE_ONLY
 
-#include <sys/syscall.h>
-
 /* sigreturn() is a no-op on x86_64 glibc.  */
 
 static NORETURN inline long

--- a/src/ppc64/unwind_i.h
+++ b/src/ppc64/unwind_i.h
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <libunwind-ppc64.h>
 
 #include <libunwind_i.h>
-#include <sys/ucontext.h>
+#include <ucontext.h>
 
 #define ppc64_lock                      UNW_OBJ(lock)
 #define ppc64_local_resume              UNW_OBJ(local_resume)

--- a/src/ptrace/_UPT_get_proc_name.c
+++ b/src/ptrace/_UPT_get_proc_name.c
@@ -32,9 +32,9 @@ _UPT_get_proc_name (unw_addr_space_t as, unw_word_t ip,
 {
   struct UPT_info *ui = arg;
 
-#if ELF_CLASS == ELFCLASS64
+#if UNW_ELF_CLASS == UNW_ELFCLASS64
   return _Uelf64_get_proc_name (as, ui->pid, ip, buf, buf_len, offp);
-#elif ELF_CLASS == ELFCLASS32
+#elif UNW_ELF_CLASS == UNW_ELFCLASS32
   return _Uelf32_get_proc_name (as, ui->pid, ip, buf, buf_len, offp);
 #else
   return -UNW_ENOINFO;

--- a/src/s390x/Gcreate_addr_space.c
+++ b/src/s390x/Gcreate_addr_space.c
@@ -31,10 +31,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "unwind_i.h"
 
-#if defined(_BIG_ENDIAN) && !defined(__BIG_ENDIAN)
-#define __BIG_ENDIAN _BIG_ENDIAN
-#endif
-
 unw_addr_space_t
 unw_create_addr_space (unw_accessors_t *a, int byte_order)
 {
@@ -46,7 +42,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
   /*
    * s390x supports only big-endian.
    */
-  if (byte_order != 0 && byte_order != __BIG_ENDIAN)
+  if (byte_order != 0 && byte_order != UNW_BIG_ENDIAN)
     return NULL;
 
   as = malloc (sizeof (*as));

--- a/src/sh/Gcreate_addr_space.c
+++ b/src/sh/Gcreate_addr_space.c
@@ -36,8 +36,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
   unw_addr_space_t as;
 
   /* SH supports little-endian and big-endian. */
-  if (byte_order != 0 && byte_order != __LITTLE_ENDIAN
-      && byte_order != __BIG_ENDIAN)
+  if (byte_order != 0 && byte_order_is_valid(byte_order) == 0)
     return NULL;
 
   as = malloc (sizeof (*as));
@@ -49,7 +48,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
   as->acc = *a;
 
   /* Default to little-endian for SH. */
-  if (byte_order == 0 || byte_order == __LITTLE_ENDIAN)
+  if (byte_order == 0 || byte_order == UNW_LITTLE_ENDIAN)
     as->big_endian = 0;
   else
     as->big_endian = 1;

--- a/src/tilegx/Gcreate_addr_space.c
+++ b/src/tilegx/Gcreate_addr_space.c
@@ -37,9 +37,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
    * Tilegx supports only big or little-endian, not weird stuff like
    * PDP_ENDIAN.
    */
-  if (byte_order != 0
-      && byte_order != __LITTLE_ENDIAN
-      && byte_order != __BIG_ENDIAN)
+  if (byte_order != 0 && byte_order_is_valid(byte_order) == 0)
     return NULL;
 
   unw_addr_space_t as = malloc (sizeof (*as));
@@ -52,9 +50,9 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
 
   if (byte_order == 0)
     /* use host default: */
-    as->big_endian = (__BYTE_ORDER == __BIG_ENDIAN);
+    as->big_endian = target_is_big_endian();
   else
-    as->big_endian = (byte_order == __BIG_ENDIAN);
+    as->big_endian = (byte_order == UNW_BIG_ENDIAN);
 
   as->abi = UNW_TILEGX_ABI_N64;
   as->addr_size = 8;

--- a/src/tilegx/Ginit.c
+++ b/src/tilegx/Ginit.c
@@ -147,7 +147,7 @@ __attribute__((weak)) void
 tilegx_local_addr_space_init (void)
 {
   memset (&local_addr_space, 0, sizeof (local_addr_space));
-  local_addr_space.big_endian = (__BYTE_ORDER == __BIG_ENDIAN);
+  local_addr_space.big_endian = target_is_big_endian();
 
   local_addr_space.abi = UNW_TILEGX_ABI_N64;
   local_addr_space.addr_size = sizeof (void *);

--- a/src/x86_64/Ginit.c
+++ b/src/x86_64/Ginit.c
@@ -34,7 +34,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
-#include <sys/syscall.h>
+#if defined(HAVE_SYS_SYSCALL_H)
+# include <sys/syscall.h>
+#endif
 #include <stdatomic.h>
 
 #include "unwind_i.h"
@@ -138,8 +140,12 @@ write_validate (void *addr)
 
   do
     {
-      /* use syscall insteadof write() so that ASAN does not complain */
-      ret = syscall (SYS_write, mem_validate_pipe[1], addr, 1);
+#ifdef HAVE_SYS_SYSCALL_H
+       /* use syscall insteadof write() so that ASAN does not complain */
+       ret = syscall (SYS_write, mem_validate_pipe[1], addr, 1);
+#else
+	  ret = write (mem_validate_pipe[1], addr, 1);
+#endif
     }
   while ( errno == EINTR );
 

--- a/src/x86_64/Gos-freebsd.c
+++ b/src/x86_64/Gos-freebsd.c
@@ -26,7 +26,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "config.h"
 #endif
 
-#include <sys/ucontext.h>
+#include <ucontext.h>
 #include <machine/sigframe.h>
 #include <signal.h>
 #include <stddef.h>

--- a/src/x86_64/unwind_i.h
+++ b/src/x86_64/unwind_i.h
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <libunwind-x86_64.h>
 
 #include "libunwind_i.h"
-#include <sys/ucontext.h>
+#include <ucontext.h>
 
 /* DWARF column numbers for x86_64: */
 #define RAX     0

--- a/tests/test-coredump-unwind.c
+++ b/tests/test-coredump-unwind.c
@@ -62,7 +62,7 @@
 #else
   extern int backtrace (void **, int);
 #endif
-#include <sys/ucontext.h>
+#include <ucontext.h>
 
 #include <libunwind-coredump.h>
 


### PR DESCRIPTION
We have been porting libunwind to the QNX Neutrino operating system (see unrelated #156).  Before we can do that, we have had to make some OS-independent changes to replace some Linuxisms.  In some cases we replaced the use of "symbols reserved for the implementation" with valid libunwind-namespaced symbols because using the reserved symbols is undefined behaviour.

These are really just a collection of minor pain points we would rather push upstream so we can all win.

Builds cleanly on Ubuntu 16.04 x86_64 with GCC 5.4 and GCC 8.3. All tests pass.