### PR TITLE
Make SHF_COMPRESSED use contingent on its existence

### DIFF
--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -127,6 +127,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local)
       return 1;
     }
 
+#if defined(SHF_COMPRESSED)
   if (shdr->sh_flags & SHF_COMPRESSED)
     {
       unsigned long destSize;
@@ -161,6 +162,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local)
     }
   else
     {
+#endif
       *bufsize = shdr->sh_size;
       GET_MEMORY(*buf, *bufsize);
 
@@ -168,7 +170,9 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local)
 
       Debug (4, "read %zd bytes of .debug_frame from offset %zd\n",
 	     *bufsize, shdr->sh_offset);
+#if defined(SHF_COMPRESSED)
     }
+#endif
   munmap(ei.image, ei.size);
   return 0;
 }


### PR DESCRIPTION
A recent change broke builds for many non-recent and non-Linux targets (like QNX)
by adding code dependent on a non-portable preprocessor macro SHF_COMPRESSED
found in some more recent GLIBC elf.h headers.

This fixes the first part of #190.

Build and verified on x86_64 Ubuntu 16.04, All tests pass.