### PR TITLE
Coredump: use NT_FILE ELF notes if available

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,7 +94,9 @@ if(UNW_CMAKE_TARGET_LINUX)
     SET(libunwind_la_SOURCES_x86_64_os_local    x86_64/Los-linux.c)
     SET(libunwind_la_SOURCES_arm_os             arm/Gos-linux.c)
     SET(libunwind_la_SOURCES_arm_os_local       arm/Los-linux.c)
-    list(APPEND libunwind_coredump_la_SOURCES   coredump/_UCD_access_reg_linux.c)
+    list(APPEND libunwind_coredump_la_SOURCES   coredump/_UCD_access_reg_linux.c
+                                                coredump/_UCD_get_threadinfo_prstatus.c
+                                                coredump/_UCD_get_mapinfo_linux.c)
 elseif(UNW_CMAKE_TARGET_FREEBSD)
     SET(libunwind_la_SOURCES_os                 ${libunwind_la_SOURCES_os_freebsd})
     SET(libunwind_la_SOURCES_os_local           ${libunwind_la_SOURCES_os_freebsd_local})
@@ -105,7 +107,9 @@ elseif(UNW_CMAKE_TARGET_FREEBSD)
     SET(libunwind_la_SOURCES_x86_64_os_local    x86_64/Los-freebsd.c)
     SET(libunwind_la_SOURCES_arm_os             arm/Gos-freebsd.c)
     SET(libunwind_la_SOURCES_arm_os_local       arm/Los-freebsd.c)
-    list(APPEND libunwind_coredump_la_SOURCES   coredump/_UCD_access_reg_freebsd.c)
+    list(APPEND libunwind_coredump_la_SOURCES   coredump/_UCD_access_reg_freebsd.c
+                                                coredump/_UCD_get_threadinfo_prstatus.c
+                                                coredump/_UCD_get_mapinfo_generic.c)
 elseif(UNW_CMAKE_HOST_SUNOS)
     SET(libunwind_la_SOURCES_os                 ${libunwind_la_SOURCES_os_solaris})
     SET(libunwind_la_SOURCES_os_local           ${libunwind_la_SOURCES_os_solaris_local})

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -60,6 +60,7 @@ libunwind_coredump_la_SOURCES = \
 	coredump/_UCD_elf_map_image.c \
 	coredump/_UCD_find_proc_info.c \
 	coredump/_UCD_get_proc_name.c \
+	coredump/_UCD_corefile_elf.c \
 	\
 	coredump/_UPT_elf.c \
 	coredump/_UPT_access_fpreg.c \
@@ -520,6 +521,7 @@ if OS_LINUX
  libunwind_la_SOURCES_arm_os          = arm/Gos-linux.c
  libunwind_la_SOURCES_arm_os_local    = arm/Los-linux.c
  libunwind_coredump_la_SOURCES += coredump/_UCD_access_reg_linux.c
+ libunwind_coredump_la_SOURCES += coredump/_UCD_get_threadinfo_linux.c
 endif
 
 if OS_HPUX

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -521,7 +521,8 @@ if OS_LINUX
  libunwind_la_SOURCES_arm_os          = arm/Gos-linux.c
  libunwind_la_SOURCES_arm_os_local    = arm/Los-linux.c
  libunwind_coredump_la_SOURCES += coredump/_UCD_access_reg_linux.c
- libunwind_coredump_la_SOURCES += coredump/_UCD_get_threadinfo_linux.c
+ libunwind_coredump_la_SOURCES += coredump/_UCD_get_threadinfo_prstatus.c
+ libunwind_coredump_la_SOURCES += coredump/_UCD_get_mapinfo_linux.c
 endif
 
 if OS_HPUX
@@ -540,6 +541,8 @@ if OS_FREEBSD
  libunwind_la_SOURCES_arm_os          = arm/Gos-freebsd.c
  libunwind_la_SOURCES_arm_os_local    = arm/Los-freebsd.c
  libunwind_coredump_la_SOURCES += coredump/_UCD_access_reg_freebsd.c
+ libunwind_coredump_la_SOURCES += coredump/_UCD_get_threadinfo_prstatus.c
+ libunwind_coredump_la_SOURCES += coredump/_UCD_get_mapinfo_generic.c
 endif
 
 if OS_SOLARIS

--- a/src/coredump/_UCD_corefile_elf.c
+++ b/src/coredump/_UCD_corefile_elf.c
@@ -1,0 +1,126 @@
+/**
+ * Support functions for ELF corefiles
+ */
+/*
+ This file is part of libunwind.
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of
+ this software and associated documentation files (the "Software"), to deal in
+ the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+*/
+#include "_UCD_internal.h"
+
+#include <errno.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+
+/**
+ * Read an ELF segment into an allocated memory buffer.
+ * @param[in]  ui	    the unwind-coredump context
+ * @param[in]  phdr         pointer to the PHDR of the segment to load
+ * @param[out] segment      pointer to the segment loaded
+ * @param[out] segment_size size of the @segment in bytes
+ *
+ * Allocates an appropriately-sized buffer to contain the segment of the
+ * coredump described by @phdr and reads it in from the core file.
+ *
+ * The caller is responsible for freeing the allocated segment memory.
+ *
+ * @returns UNW_SUCCESS on success, something else otherwise.
+ */
+HIDDEN int
+_UCD_elf_read_segment(struct UCD_info *ui, coredump_phdr_t *phdr, uint8_t **segment, size_t *segment_size)
+{
+  int ret = -UNW_EUNSPEC;
+  if (lseek(ui->coredump_fd, phdr->p_offset, SEEK_SET) != (off_t)phdr->p_offset)
+  {
+    Debug(0, "errno %d setting offset to %lu in '%s': %s\n",
+    	  errno, phdr->p_offset, ui->coredump_filename, strerror(errno));
+    return ret;
+  }
+
+  *segment_size = phdr->p_filesz;
+  *segment = malloc(*segment_size);
+  if (*segment == NULL)
+  {
+    Debug(0, "error %zu bytes of memory for segment\n", *segment_size);
+    return ret;
+  }
+
+  if (read(ui->coredump_fd, *segment, *segment_size) != (ssize_t)*segment_size)
+  {
+    Debug(0, "errno %d reading %zu bytes from '%s': %s\n",
+    	  errno, *segment_size, ui->coredump_filename, strerror(errno));
+    return ret;
+  }
+
+  ret = UNW_ESUCCESS;
+  return ret;
+}
+
+
+/**
+ * Parse a PT_NOTE segment into zero or more notes and visit each one
+ * @param[in]  segment      pointer to the PT_NOTE segment
+ * @param[in]  segment_size size of @p segment in bytes
+ * @param[in]  visit        callback to process to the notes
+ * @param[in]  arg          context to forward to the callback
+ *
+ * One PT_NOTE segment might contain many variable-length notes.  Parsing them
+ * out is just a matter of calculating the size of each note from the size
+ * fields contained in the (fixed-size) note header and adjusting for 4-byte
+ * alignment.
+ *
+ * For each note found the @p visit callback will be invoked.  If the callback
+ * returns anything but UNW_ESUCCESS, traversal of the notes will be terminated
+ * and processing will return immediately, passing the return code through.
+ *
+ * @returns UNW_SUCCESS on success or the return value from @p visit otherwise.
+ */
+HIDDEN int
+_UCD_elf_visit_notes(uint8_t *segment, size_t segment_size, note_visitor_t visit, void *arg)
+{
+  int ret = UNW_ESUCCESS;
+  size_t parsed_size = 0;
+  while (parsed_size < segment_size)
+  {
+    /*
+     * Note that Elf32_Nhdr and Elf64_Nhdr are identical, so it doesn't matter which
+     * structure is chosen here. I chose the one with the larger number because
+     * bigger is better.
+     */
+    Elf64_Nhdr *note = (Elf64_Nhdr *)(segment + parsed_size);
+    unsigned header_size = sizeof(Elf64_Nhdr);
+    unsigned name_size = UNW_ALIGN(note->n_namesz, 4);
+    unsigned desc_size = UNW_ALIGN(note->n_descsz, 4);
+    unsigned note_size = header_size + name_size + desc_size;
+    char *name = (char *)(note) + header_size;
+    uint8_t *desc = (uint8_t *)(note) + header_size + name_size;
+
+    ret = visit(note->n_namesz, note->n_descsz, note->n_type, name, desc, arg);
+    if (ret != UNW_ESUCCESS)
+    {
+      break;
+    }
+
+    parsed_size += note_size;
+  }
+  return ret;
+}
+

--- a/src/coredump/_UCD_create.c
+++ b/src/coredump/_UCD_create.c
@@ -187,32 +187,29 @@ _UCD_create(const char *filename)
 		goto err;
 	}
 
-    if (unwi_debug_level > 1)
+	coredump_phdr_t *cur = phdrs;
+	for (unsigned i = 0; i < size; ++i)
 	  {
-		coredump_phdr_t *cur = phdrs;
-		for (unsigned i = 0; i < size; ++i)
+		if (cur->p_type == PT_LOAD)
 		  {
-			if (cur->p_type == PT_LOAD)
+			Debug(2, " ofs:%08llx va:%08llx filesize:%08llx memsize:%08llx flg:%x",
+								(unsigned long long) cur->p_offset,
+								(unsigned long long) cur->p_vaddr,
+								(unsigned long long) cur->p_filesz,
+								(unsigned long long) cur->p_memsz,
+								cur->p_flags
+			);
+			if (cur->p_filesz < cur->p_memsz)
 			  {
-				Debug(2, " ofs:%08llx va:%08llx filesize:%08llx memsize:%08llx flg:%x",
-									(unsigned long long) cur->p_offset,
-									(unsigned long long) cur->p_vaddr,
-									(unsigned long long) cur->p_filesz,
-									(unsigned long long) cur->p_memsz,
-									cur->p_flags
-				);
-				if (cur->p_filesz < cur->p_memsz)
-				  {
-					Debug(2, " partial");
-				  }
-				if (cur->p_flags & PF_X)
-				  {
-					Debug(2, " executable");
-				  }
+				Debug(2, " partial");
 			  }
-			Debug(2, "\n");
-			cur++;
+			if (cur->p_flags & PF_X)
+			  {
+				Debug(2, " executable");
+			  }
 		  }
+		Debug(2, "\n");
+		cur++;
 	  }
 
     if (ui->n_threads == 0)

--- a/src/coredump/_UCD_get_mapinfo_generic.c
+++ b/src/coredump/_UCD_get_mapinfo_generic.c
@@ -1,0 +1,34 @@
+/**
+ * Extract filemap info from a coredump (generic)
+ */
+/*
+ This file is part of libunwind.
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of
+ this software and associated documentation files (the "Software"), to deal in
+ the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+*/
+#include "_UCD_internal.h"
+
+
+int
+_UCD_get_mapinfo(struct UCD_info *ui, coredump_phdr_t *phdrs, unsigned phdr_size)
+{
+  int ret = UNW_ESUCCESS; /* it's OK if there are no file mappings */
+
+  return ret;
+}

--- a/src/coredump/_UCD_get_mapinfo_linux.c
+++ b/src/coredump/_UCD_get_mapinfo_linux.c
@@ -1,0 +1,132 @@
+/**
+ * Extract filemap info from a coredump (Linux and similar)
+ */
+/*
+ This file is part of libunwind.
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of
+ this software and associated documentation files (the "Software"), to deal in
+ the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+*/
+#include "_UCD_internal.h"
+
+
+/**
+ * The format of the NT_FILE note is not well documented, but it goes something
+ * like this.
+ *
+ * The note has a header containing the @i count of the number of file maps, plus a
+ * value of the size of the offset field in each map. Since we don;t care about
+ * the offset field in a core file, there is no further information available on
+ * exactly what the means.
+ *
+ * Following the header are @count mapinfo structures. The mapinfo structure consists of
+ * a start address, and end address, and some wacky offset thing.  The start and
+ * end address are the virtual addresses of a LOAD segment that was mapped from
+ * the named file.
+ *
+ * Following the array of mapinfo structures is a block of null-terminated C strings
+ * containing the mapped file names.  They are ordered correspondingly to each
+ * entry in the map structure array.
+ */
+typedef struct {
+  unsigned long count;
+  unsigned long pagesz;
+} linux_mapinfo_hdr_t;
+
+typedef struct {
+  unsigned long start;
+  unsigned long end;
+  unsigned long offset;
+} linux_mapinfo_t;
+
+
+/**
+ * Map a file note to program headers
+ *
+ * If a NT_FILE note is recognized, parse it and add the resulting backing files
+ * to the program header list.
+ *
+ * Any file names that end in the string "(deleted)" are ignored.
+ */
+static int
+_handle_file_note(uint32_t n_namesz, uint32_t n_descsz, uint32_t n_type, char *name, uint8_t *desc, void *arg)
+{
+  struct UCD_info *ui = (struct UCD_info *)arg;
+  if (n_type == NT_FILE)
+  {
+    Debug(0, "found a PT_FILE note\n");
+    static const char * deleted = "(deleted)";
+    size_t deleted_len = strlen(deleted);
+    static const size_t mapinfo_offset = sizeof(linux_mapinfo_hdr_t);
+
+    linux_mapinfo_hdr_t *mapinfo = (linux_mapinfo_hdr_t *)desc;
+    linux_mapinfo_t *maps = (linux_mapinfo_t *)(desc + mapinfo_offset);
+    char *strings = (char *)(desc + mapinfo_offset + sizeof(linux_mapinfo_t)*mapinfo->count);
+    for (unsigned long i = 0; i < mapinfo->count; ++i)
+    {
+      size_t len = strlen(strings);
+      for (unsigned p = 0; p < ui->phdrs_count; ++p)
+      {
+      	if (ui->phdrs[p].p_type == PT_LOAD
+      	  && maps[i].start >= ui->phdrs[p].p_vaddr
+      	  && maps[i].end <= ui->phdrs[p].p_vaddr + ui->phdrs[p].p_filesz)
+	{
+	  if (len > deleted_len && memcmp(strings + len - deleted_len, deleted, deleted_len))
+	  {
+	    _UCD_add_backing_file_at_segment(ui, p, strings);
+	  }
+	  break;
+	}
+      }
+      strings += (len + 1);
+    }
+  }
+  return UNW_ESUCCESS;
+}
+
+
+/**
+ * Get filemap info from core file (Linux and similar)
+ *
+ * If there is a mapinfo not in the core file, map its contents to the phdrs.
+ *
+ * Since there may or may not be any mapinfo notes it's OK for this function to
+ * fail.
+ */
+int
+_UCD_get_mapinfo(struct UCD_info *ui, coredump_phdr_t *phdrs, unsigned phdr_size)
+{
+  int ret = UNW_ESUCCESS; /* it's OK if there are no file mappings */
+
+  for (unsigned i = 0; i < phdr_size; ++i)
+  {
+    if (phdrs[i].p_type == PT_NOTE)
+    {
+      uint8_t *segment;
+      size_t segment_size;
+      ret = _UCD_elf_read_segment(ui, &phdrs[i], &segment, &segment_size);
+      if (ret == UNW_ESUCCESS)
+      {
+      	_UCD_elf_visit_notes(segment, segment_size, _handle_file_note, ui);
+      	free(segment);
+      }
+    }
+  }
+
+  return ret;
+}

--- a/src/coredump/_UCD_get_threadinfo_linux.c
+++ b/src/coredump/_UCD_get_threadinfo_linux.c
@@ -1,0 +1,121 @@
+/**
+ * Extract threadinfo from a coredump (Linux and similar)
+ */
+/*
+ This file is part of libunwind.
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of
+ this software and associated documentation files (the "Software"), to deal in
+ the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+*/
+#include "_UCD_internal.h"
+
+#if defined(HAVE_ELF_H)
+# include <elf.h>
+#elif defined(HAVE_SYS_ELF_H)
+# include <sys/elf.h>
+#endif
+
+
+/**
+ * Accumulate a count of the number of thread notes
+ *
+ * This _UCD_elf_visit_notes() callback just increments a count for each
+ * NT_PRSTATUS note seen.
+ */
+static int
+_count_thread_notes(uint32_t n_namesz, uint32_t n_descsz, uint32_t n_type, char *name, uint8_t *desc, void *arg)
+{
+  size_t *thread_count = (size_t *)arg;
+  if (n_type == NT_PRSTATUS)
+  {
+    ++*thread_count;
+  }
+  return UNW_ESUCCESS;
+}
+
+
+/**
+ * Save a thread note to the unwind-coredump context
+ *
+ * This _UCD_elf_visit_notes() callback just copies the actual data structure
+ * from any NT_PRSTATUS note seen into an array of such structures and
+ * increments the count.
+ */
+static int
+_save_thread_notes(uint32_t n_namesz, uint32_t n_descsz, uint32_t n_type, char *name, uint8_t *desc, void *arg)
+{
+  struct UCD_info *ui = (struct UCD_info *)arg;
+  if (n_type == NT_PRSTATUS)
+  {
+    memcpy(&ui->threads[ui->n_threads], desc, sizeof(struct PRSTATUS_STRUCT));
+    ++ui->n_threads;
+  }
+  return UNW_ESUCCESS;
+}
+
+
+/**
+ * Get thread info from core file (Linux and similar)
+ *
+ * On Linux threads are emulated by cloned processes sharing an address space
+ * and the process information is described by a note in the core file of type
+ * NT_PRSTATUS.  In fact, on Linux, the state of a thread is described by a
+ * CPU-dependent group of notes but right now we're only going to care about the
+ * one process-status note.  This statement is also true for FreeBSD.
+ *
+ * Depending on how the core file is created, there may be one PT_NOTE segment
+ * with multiple NT_PRSTATUS notes in it, or multiple PT_NOTE segments.  Just to
+ * be safe, it's better to assume there are multiple PT_NOTE segments each with
+ * multiple NT_PRSTATUS notes, as that covers all the cases.
+ */
+int
+_UCD_get_threadinfo(struct UCD_info *ui, coredump_phdr_t *phdrs, unsigned phdr_size)
+{
+  int ret = -UNW_ENOINFO;
+
+  for (unsigned i = 0; i < phdr_size; ++i)
+  {
+    Debug(8, "phdr[%03d]: type:%d", i, phdrs[i].p_type);
+    if (phdrs[i].p_type == PT_NOTE)
+    {
+      size_t thread_count = 0;
+      uint8_t *segment;
+      size_t segment_size;
+      ret = _UCD_elf_read_segment(ui, &phdrs[i], &segment, &segment_size);
+      if (ret == UNW_ESUCCESS)
+      {
+      	_UCD_elf_visit_notes(segment, segment_size, _count_thread_notes, &thread_count);
+	Debug(2, "found %zu threads\n", thread_count);
+
+      	size_t new_size = sizeof(struct PRSTATUS_STRUCT) * (ui->n_threads + thread_count);
+      	ui->threads = realloc(ui->threads, new_size);
+      	if (ui->threads == NULL)
+	{
+	  Debug(0, "error allocating %zu bytes of memory \n", new_size);
+      	  free(segment);
+	  return -UNW_EUNSPEC;
+	}
+      	_UCD_elf_visit_notes(segment, segment_size, _save_thread_notes, ui);
+
+      	free(segment);
+      }
+    }
+  }
+
+  return ret;
+}

--- a/src/coredump/_UCD_get_threadinfo_prstatus.c
+++ b/src/coredump/_UCD_get_threadinfo_prstatus.c
@@ -1,5 +1,5 @@
 /**
- * Extract threadinfo from a coredump (Linux and similar)
+ * Extract threadinfo from a coredump (targets with NT_PRSTATUS)
  */
 /*
  This file is part of libunwind.
@@ -70,7 +70,7 @@ _save_thread_notes(uint32_t n_namesz, uint32_t n_descsz, uint32_t n_type, char *
 
 
 /**
- * Get thread info from core file (Linux and similar)
+ * Get thread info from core file
  *
  * On Linux threads are emulated by cloned processes sharing an address space
  * and the process information is described by a note in the core file of type

--- a/src/coredump/_UCD_internal.h
+++ b/src/coredump/_UCD_internal.h
@@ -101,9 +101,11 @@ typedef int (*note_visitor_t)(uint32_t, uint32_t, uint32_t, char *, uint8_t *, v
 
 
 coredump_phdr_t * _UCD_get_elf_image(struct UCD_info *ui, unw_word_t ip);
-int _UCD_get_threadinfo(struct UCD_info *ui, coredump_phdr_t *phdrs, unsigned phdr_size);
+
 int _UCD_elf_read_segment(struct UCD_info *ui, coredump_phdr_t *phdr, uint8_t **segment, size_t *segment_size);
 int _UCD_elf_visit_notes(uint8_t *segment, size_t segment_size, note_visitor_t visit, void *arg);
+int _UCD_get_threadinfo(struct UCD_info *ui, coredump_phdr_t *phdrs, unsigned phdr_size);
+int _UCD_get_mapinfo(struct UCD_info *ui, coredump_phdr_t *phdrs, unsigned phdr_size);
 
 
 #endif

--- a/src/coredump/_UCD_internal.h
+++ b/src/coredump/_UCD_internal.h
@@ -92,14 +92,18 @@ struct UCD_info
     void *note_phdr; /* allocated or NULL */
     struct PRSTATUS_STRUCT *prstatus; /* points inside note_phdr */
     int n_threads;
-    struct PRSTATUS_STRUCT **threads;
-
+    struct PRSTATUS_STRUCT *threads;
     struct elf_dyn_info edi;
   };
 
-extern coredump_phdr_t * _UCD_get_elf_image(struct UCD_info *ui, unw_word_t ip);
 
-#define STRUCT_MEMBER_P(struct_p, struct_offset) ((void *) ((char*) (struct_p) + (long) (struct_offset)))
-#define STRUCT_MEMBER(member_type, struct_p, struct_offset) (*(member_type*) STRUCT_MEMBER_P ((struct_p), (struct_offset)))
+typedef int (*note_visitor_t)(uint32_t, uint32_t, uint32_t, char *, uint8_t *, void *);
+
+
+coredump_phdr_t * _UCD_get_elf_image(struct UCD_info *ui, unw_word_t ip);
+int _UCD_get_threadinfo(struct UCD_info *ui, coredump_phdr_t *phdrs, unsigned phdr_size);
+int _UCD_elf_read_segment(struct UCD_info *ui, coredump_phdr_t *phdr, uint8_t **segment, size_t *segment_size);
+int _UCD_elf_visit_notes(uint8_t *segment, size_t segment_size, note_visitor_t visit, void *arg);
+
 
 #endif

--- a/tests/test-coredump-unwind.c
+++ b/tests/test-coredump-unwind.c
@@ -322,7 +322,7 @@ main(int argc UNUSED, char **argv)
       if (*colon != ':')
         error_msg_and_die("Bad format: '%s'", *argv);
       if (_UCD_add_backing_file_at_vaddr(ui, vaddr, colon + 1) < 0)
-        error_msg_and_die("Can't add backing file '%s'", colon + 1);
+        error_msg("Can't add backing file '%s'", colon + 1);
       argv++;
     }
 
@@ -338,11 +338,16 @@ main(int argc UNUSED, char **argv)
       if (ret < 0)
         error_msg_and_die("unw_get_proc_info(ip=0x%lx) failed: ret=%d\n", (long) ip, ret);
 
-      if (!testcase)
-        printf("\tip=0x%08lx proc=%08lx-%08lx handler=0x%08lx lsda=0x%08lx\n",
+      if (!testcase) {
+        char proc_name[128];
+        unw_word_t off;
+        unw_get_proc_name(&c, proc_name, sizeof(proc_name), &off);
+
+        printf("\tip=0x%08lx proc=%08lx-%08lx handler=0x%08lx lsda=0x%08lx %s\n",
 				(long) ip,
 				(long) pi.start_ip, (long) pi.end_ip,
-				(long) pi.handler, (long) pi.lsda);
+				(long) pi.handler, (long) pi.lsda, proc_name);
+	  }
 
       if (testcase && test_cur < TEST_FRAMES)
         {


### PR DESCRIPTION
Uses the Linux NT_FILE ELF note is available to provide backing file names in the coredump library.

With this change unwinding will work on coredumps provided by stripped binaries. This make the library far more useful for tools dealing with embedded systems.

```
$ tests/test-coredump-unwind ../vim2.core.23223 
 >_handle_file_note: found a PT_FILE note
	ip=0x7f32b3b3d74d proc=7f32b3b3d720-7f32b3b3d77a handler=0x00000000 lsda=0x00000000 __poll
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x7f32b6c6238c proc=7f32b6c62210-7f32b6c62419 handler=0x00000000 lsda=0x00000000 g_main_context_dispatch
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x7f32b6c6249c proc=7f32b6c62470-7f32b6c624ba handler=0x00000000 lsda=0x00000000 g_main_context_iteration
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x5586cafea7e7 proc=5586cafea750-5586cafea84f handler=0x00000000 lsda=0x00000000 gui_mch_wait_for_chars
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x5586cafda40b proc=5586cafda390-5586cafda445 handler=0x00000000 lsda=0x00000000 win_findbuf
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x5586cafdc378 proc=5586cafdc2b0-5586cafdc3b1 handler=0x00000000 lsda=0x00000000 gui_wait_for_chars
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x5586cafc8a10 proc=5586cafc8920-5586cafc8b6e handler=0x00000000 lsda=0x00000000 ui_inchar
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x5586caed6b13 proc=5586caed68f0-5586caed6b2f handler=0x00000000 lsda=0x00000000 inchar
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x5586caed8abf proc=5586caed7b50-5586caed9298 handler=0x00000000 lsda=0x00000000 vim_unescape_csi
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x5586caed943a proc=5586caed92a0-5586caed97a1 handler=0x00000000 lsda=0x00000000 vgetc
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x5586caed97b9 proc=5586caed97b0-5586caed97d1 handler=0x00000000 lsda=0x00000000 safe_vgetc
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x5586caf27f25 proc=5586caf27e20-5586caf29476 handler=0x00000000 lsda=0x00000000 normal_cmd
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x5586cb016625 proc=5586cb016220-5586cb016963 handler=0x00000000 lsda=0x00000000 main_loop
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x5586cae4698d proc=5586cae45350-5586cae47c0a handler=0x00000000 lsda=0x00000000 main
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x7f32b3a62830 proc=7f32b3a62740-7f32b3a6290a handler=0x00000000 lsda=0x00000000 __libc_start_main
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:1
	ip=0x5586cae47c39 proc=5586cae47c10-5586cae47c3a handler=0x00000000 lsda=0x00000000 _start
lt-test-coredump-unwind: step
lt-test-coredump-unwind: step done:0
lt-test-coredump-unwind: stepping ended
```
closes: #192

This change also contains some refactoring of Linux-specific code into separate source files for portability.