### PR TITLE
Link Ltest-cxx-exceptions with libunwind

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -216,6 +216,7 @@ Gperf_trace_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 
 Ltest_bt_LDADD = $(LIBUNWIND_local)
 Ltest_concurrent_LDADD = $(LIBUNWIND_local) -lpthread
+Ltest_cxx_exceptions_LDADD = $(LIBUNWIND_local)
 Ltest_dyn1_LDADD = $(LIBUNWIND_local)
 Ltest_exc_LDADD = $(LIBUNWIND_local)
 Ltest_init_LDADD = $(LIBUNWIND_local)


### PR DESCRIPTION
Bernhard Übelacker noticed that Ltest-cxx-exceptions was actually
testing the gcc implementation due to not linking with libunwind.

Fixes: #129