### PR TITLE
Enable C++ exception support on x86 and 32bit ARM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -242,11 +242,8 @@ AC_MSG_CHECKING([whether to enable C++ exception support])
 AC_ARG_ENABLE(cxx_exceptions,
 AS_HELP_STRING([--enable-cxx-exceptions],[use libunwind to handle C++ exceptions]),,
 [
-# C++ exception handling doesn't work too well on x86
 case $target_arch in
-  x86*) enable_cxx_exceptions=no;;
   aarch64*) enable_cxx_exceptions=no;;
-  arm*) enable_cxx_exceptions=no;;
   mips*) enable_cxx_exceptions=no;;
   tile*) enable_cxx_exceptions=no;;
   *) enable_cxx_exceptions=yes;;


### PR DESCRIPTION
Debian/Ubuntu were building with --enable-cxx-exceptions
on all architectures since 2012.

This enabled C++ exception support both on architectures
where it is working and on architectures where it is not
working.

I checked the enable_cxx_exceptions=no targets on real
hardware with Ltest-cxx-exceptions:

Test passes:
- 64bit x86
- 32bit x86
- 32bit ARM

Test fails:
- 64bit ARM
- 32bit big endian MIPS
- 32bit little endian MIPS
- 64bit big endian MIPS

I do not have access to TILE-Gx hardware,
and the Linux kernel dropped support 2 years ago.

The results on x86 and ARM match the observation that Debian
users reported crashes only with 64bit ARM, which is the most
recent of the four x86/ARM options.

MIPS has few users, breakage might have been unnoticed.

Enable C++ exception support on x86 and 32bit ARM,
to avoid the need of overwriting the defaults on
targets where it appears to be working.