### PR TITLE
ia64: Fix dyn_info_list.S with newer binutils

### DIFF
--- a/src/ia64/dyn_info_list.S
+++ b/src/ia64/dyn_info_list.S
@@ -16,7 +16,7 @@
 	string "dyn-list"	/* lsda */
 	data8 @gprel(_U_dyn_info_list)
 
-	.section .IA_64.unwind, "a", "progbits"
+	.section .IA_64.unwind, "ao", "unwind"
 	data8 0, 0, @segrel(.info)
 
 #endif


### PR DESCRIPTION
Using binutils 2.34 or 2.35, libunwind fails to link on ia64 with:

  /usr/bin/ld: .IA_64.unwind has both ordered [`.IA_64.unwind' in unwind/.libs/GetIPInfo.o] and unordered [`.IA_64.unwind' in ia64/.libs/dyn_info_list.o] sections

Fix this by using the right flags and type for the section, taken from binutils's gas/testsuite/gas/ia64/unwind.s.