### PR TITLE
Use __linux__ define everywhere instead of __linux

### DIFF
--- a/src/coredump/_UCD_find_proc_info.c
+++ b/src/coredump/_UCD_find_proc_info.c
@@ -35,7 +35,7 @@ get_unwind_info(struct UCD_info *ui, unw_addr_space_t as, unw_word_t ip)
 {
   unsigned long segbase, mapoff;
 
-#if UNW_TARGET_IA64 && defined(__linux)
+#if UNW_TARGET_IA64 && defined(__linux__)
   if (!ui->edi.ktab.start_ip && _Uia64_get_kernel_table (&ui->edi.ktab) < 0)
     return -UNW_ENOINFO;
 

--- a/src/coredump/_UPT_get_dyn_info_list_addr.c
+++ b/src/coredump/_UPT_get_dyn_info_list_addr.c
@@ -26,7 +26,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "_UCD_lib.h"
 #include "_UCD_internal.h"
 
-#if UNW_TARGET_IA64 && defined(__linux)
+#if UNW_TARGET_IA64 && defined(__linux__)
 # include "elf64.h"
 # include "os-linux.h"
 

--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -46,7 +46,7 @@ struct table_entry
 
 #ifndef UNW_REMOTE_ONLY
 
-#ifdef __linux
+#ifdef __linux__
 #include "os-linux.h"
 #endif
 
@@ -184,7 +184,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local)
 static int
 find_binary_for_address (unw_word_t ip, char *name, size_t name_size)
 {
-#if defined(__linux) && (!UNW_REMOTE_ONLY)
+#if defined(__linux__) && (!UNW_REMOTE_ONLY)
   struct map_iterator mi;
   int found = 0;
   int pid = getpid ();

--- a/src/hppa/Gresume.c
+++ b/src/hppa/Gresume.c
@@ -29,7 +29,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #ifndef UNW_REMOTE_ONLY
 
-#if defined(__linux)
+#if defined(__linux__)
 
 # include <sys/syscall.h>
 
@@ -48,12 +48,12 @@ my_rt_sigreturn (void *new_sp, int in_syscall)
   abort ();
 }
 
-#endif /* __linux */
+#endif /* __linux__ */
 
 HIDDEN inline int
 hppa_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
 {
-#if defined(__linux)
+#if defined(__linux__)
   struct cursor *c = (struct cursor *) cursor;
   ucontext_t *uc = c->dwarf.as_arg;
 

--- a/src/ia64/Ginit.c
+++ b/src/ia64/Ginit.c
@@ -357,7 +357,7 @@ ia64_local_addr_space_init (void)
 {
   memset (&local_addr_space, 0, sizeof (local_addr_space));
   local_addr_space.big_endian = target_is_big_endian();
-#if defined(__linux)
+#if defined(__linux__)
   local_addr_space.abi = ABI_LINUX;
 #elif defined(__hpux)
   local_addr_space.abi = ABI_HPUX;

--- a/src/ia64/Ginit_local.c
+++ b/src/ia64/Ginit_local.c
@@ -39,7 +39,7 @@ unw_init_local (unw_cursor_t *cursor, unw_context_t *uc)
 static inline void
 set_as_arg (struct cursor *c, unw_context_t *uc)
 {
-#if defined(__linux) && defined(__KERNEL__)
+#if defined(__linux__) && defined(__KERNEL__)
   c->task = current;
   c->as_arg = &uc->sw;
 #else
@@ -51,7 +51,7 @@ static inline int
 get_initial_stack_pointers (struct cursor *c, unw_context_t *uc,
                             unw_word_t *sp, unw_word_t *bsp)
 {
-#if defined(__linux)
+#if defined(__linux__)
   unw_word_t sol, bspstore;
 
 #ifdef __KERNEL__

--- a/src/ia64/Gregs.c
+++ b/src/ia64/Gregs.c
@@ -30,7 +30,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 static inline ia64_loc_t
 linux_scratch_loc (struct cursor *c, unw_regnum_t reg, uint8_t *nat_bitnr)
 {
-#if !defined(UNW_LOCAL_ONLY) || defined(__linux)
+#if !defined(UNW_LOCAL_ONLY) || defined(__linux__)
   unw_word_t addr = c->sigcontext_addr, flags, tmp_addr;
   int i;
 

--- a/src/ia64/Gresume.c
+++ b/src/ia64/Gresume.c
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 static inline int
 local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
 {
-#if defined(__linux)
+#if defined(__linux__)
   unw_word_t dirty_partition[2048]; /* AR.RSC.LOADRS is a 14-bit field */
   unw_word_t val, sol, sof, pri_unat, n, pfs, bspstore, dirty_rnat;
   struct cursor *c = (struct cursor *) cursor;
@@ -184,7 +184,7 @@ remote_install_cursor (struct cursor *c)
   unw_word_t val;
   int reg;
 
-#if defined(__linux) && !defined(UNW_REMOTE_ONLY)
+#if defined(__linux__) && !defined(UNW_REMOTE_ONLY)
   if (c->as == unw_local_addr_space)
     {
       /* Take a short-cut: we directly resume out of the cursor and
@@ -233,7 +233,7 @@ remote_install_cursor (struct cursor *c)
       MEMIFY (IA64_REG_F31,     UNW_IA64_FR + 31);
     }
   else
-#endif /* __linux && !UNW_REMOTE_ONLY */
+#endif /* __linux__ && !UNW_REMOTE_ONLY */
     {
       access_reg = c->as->acc.access_reg;
       access_fpreg = c->as->acc.access_fpreg;

--- a/src/ia64/Gstep.c
+++ b/src/ia64/Gstep.c
@@ -30,7 +30,7 @@ static inline int
 linux_sigtramp (struct cursor *c, ia64_loc_t prev_cfm_loc,
                 unw_word_t *num_regsp)
 {
-#if defined(UNW_LOCAL_ONLY) && !defined(__linux)
+#if defined(UNW_LOCAL_ONLY) && !defined(__linux__)
   return -UNW_EINVAL;
 #else
   unw_word_t sc_addr;
@@ -64,7 +64,7 @@ static inline int
 linux_interrupt (struct cursor *c, ia64_loc_t prev_cfm_loc,
                  unw_word_t *num_regsp, int marker)
 {
-#if defined(UNW_LOCAL_ONLY) && !(defined(__linux) && defined(__KERNEL__))
+#if defined(UNW_LOCAL_ONLY) && !(defined(__linux__) && defined(__KERNEL__))
   return -UNW_EINVAL;
 #else
   unw_word_t sc_addr, num_regs;

--- a/src/ptrace/_UPT_find_proc_info.c
+++ b/src/ptrace/_UPT_find_proc_info.c
@@ -38,7 +38,7 @@ get_unwind_info (struct elf_dyn_info *edi, pid_t pid, unw_addr_space_t as, unw_w
   unsigned long segbase, mapoff;
   char path[PATH_MAX];
 
-#if UNW_TARGET_IA64 && defined(__linux)
+#if UNW_TARGET_IA64 && defined(__linux__)
   if (!edi->ktab.start_ip && _Uia64_get_kernel_table (&edi->ktab) < 0)
     return -UNW_ENOINFO;
 

--- a/src/ptrace/_UPT_get_dyn_info_list_addr.c
+++ b/src/ptrace/_UPT_get_dyn_info_list_addr.c
@@ -25,7 +25,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "_UPT_internal.h"
 
-#if UNW_TARGET_IA64 && defined(__linux)
+#if UNW_TARGET_IA64 && defined(__linux__)
 # include "elf64.h"
 # include "os-linux.h"
 

--- a/src/x86_64/init.h
+++ b/src/x86_64/init.h
@@ -28,7 +28,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "unwind_i.h"
 
 /* Avoid a trip to x86_64_r_uc_addr() for purely local initialisation. */
-#if defined UNW_LOCAL_ONLY && defined __linux
+#if defined UNW_LOCAL_ONLY && defined __linux__
 # define REG_INIT_LOC(c, rlc, ruc) \
     DWARF_LOC ((unw_word_t) &c->uc->uc_mcontext.gregs[REG_ ## ruc], 0)
 

--- a/tests/Gia64-test-nat.c
+++ b/tests/Gia64-test-nat.c
@@ -132,7 +132,7 @@ sighandler (int signal, void *siginfo, void *context)
   save_func_t **arg0;
   ucontext_t *uc = context;
 
-#if defined(__linux)
+#if defined(__linux__)
   {
     long sof;
     int sp;
@@ -159,7 +159,7 @@ sighandler (int signal, void *siginfo, void *context)
   (*arg0[0]) (arg0 + 1, arg1);
 
   /* skip over the instruction which triggered sighandler() */
-#if defined(__linux)
+#if defined(__linux__)
   ++uc->uc_mcontext.sc_ip;
 #elif defined(HAVE_SYS_UC_ACCESS_H)
   {


### PR DESCRIPTION
The libunwind code base uses __linux__ already in many locations, but
some others relied on __linux instead. Apparently on some older
toolchain configurations, such as Ubuntu Trusty that's still used for
AppImage generation sometimes, __linux is never defined - only
__linux__ is. Fixes compiler warning on such platforms:

```
coredump/_UPT_get_dyn_info_list_addr.c: In function 'get_list_addr':
coredump/_UPT_get_dyn_info_list_addr.c:86:3: warning: #warning Implement get_list_addr(), please. [-Wcpp]
 # warning Implement get_list_addr(), please.
   ^
```