### PR TITLE
Fix unwinding of pre-linked libraries

### DIFF
--- a/include/dwarf.h
+++ b/include/dwarf.h
@@ -367,6 +367,8 @@ struct unw_debug_frame_list
     /* The start (inclusive) and end (exclusive) of the described region.  */
     unw_word_t start;
     unw_word_t end;
+    /* ELF load offset */
+    unw_word_t load_offset;
     /* The debug frame itself.  */
     char *debug_frame;
     size_t debug_frame_size;

--- a/include/libunwind-dynamic.h
+++ b/include/libunwind-dynamic.h
@@ -141,6 +141,7 @@ typedef struct unw_dyn_info
     unw_word_t gp;              /* global-pointer in effect for this entry */
     int32_t format;             /* real type: unw_dyn_info_format_t */
     int32_t pad;
+    unw_word_t load_offset;     /* ELF load offset */
     union
       {
         unw_dyn_proc_info_t pi;

--- a/src/dwarf/Gfind_unwind_table.c
+++ b/src/dwarf/Gfind_unwind_table.c
@@ -193,6 +193,7 @@ dwarf_find_unwind_table (struct elf_dyn_info *edi, unw_addr_space_t as,
 
       edi->di_cache.start_ip = start_ip;
       edi->di_cache.end_ip = end_ip;
+      edi->di_cache.load_offset = 0;
       edi->di_cache.format = UNW_INFO_FORMAT_REMOTE_TABLE;
       edi->di_cache.u.rti.name_ptr = 0;
       /* two 32-bit values (ip_offset/fde_offset) per table-entry: */


### PR DESCRIPTION
Prelinker updates section .eh_frame but does not change section .debug_frame.
Libunwind can work with prelinked .eh_frame, but if fails to find call frame
info in unmodified .debug_frame because it does not add the load offset.

ELF load offset from PT_LOAD p_vaddr has to be used to correctly interpret
addresses in the .debug_frame section.

Signed-off-by: Mikhail Durnev <mikhail_durnev@mentor.com>