### PR TITLE
Port libunwind to FreeBSD/powerpc64.

### DIFF
--- a/src/ppc64/Gcreate_addr_space.c
+++ b/src/ppc64/Gcreate_addr_space.c
@@ -40,7 +40,7 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
   /*
    * We support both big- and little-endian on Linux ppc64.
    */
-  if (byte_order != 0 && byte_order_is_valid(byte_order) == 0);
+  if (byte_order != 0 && byte_order_is_valid(byte_order) == 0)
     return NULL;
 
   as = malloc (sizeof (*as));
@@ -55,14 +55,19 @@ unw_create_addr_space (unw_accessors_t *a, int byte_order)
     /* use host default: */
     as->big_endian = target_is_big_endian();
   else
-    as->big_endian = order_is_big_endian(byte_order);
+    as->big_endian = byte_order_is_big_endian(byte_order);
 
+/* FreeBSD 13 and up are always ELFv2. */
+#if defined(__FreeBSD__) && __FreeBSD__ >= 13
+  as->abi = UNW_PPC64_ABI_ELFv2;
+#else
   /* FIXME!  There is no way to specify the ABI.
      Default to ELFv1 on big-endian and ELFv2 on little-endian.  */
   if (as->big_endian)
     as->abi = UNW_PPC64_ABI_ELFv1;
   else
     as->abi = UNW_PPC64_ABI_ELFv2;
+#endif
 
   return as;
 #endif

--- a/src/ppc64/Ginit.c
+++ b/src/ppc64/Ginit.c
@@ -48,13 +48,25 @@ uc_addr (ucontext_t *uc, int reg)
   void *addr;
 
   if ((unsigned) (reg - UNW_PPC64_R0) < 32)
+#if defined(__linux__)
     addr = &uc->uc_mcontext.gp_regs[reg - UNW_PPC64_R0];
+#elif defined(__FreeBSD__)
+    addr = &uc->uc_mcontext.mc_gpr[reg - UNW_PPC64_R0];
+#endif
 
   else if ((unsigned) (reg - UNW_PPC64_F0) < 32)
+#if defined(__linux__)
     addr = &uc->uc_mcontext.fp_regs[reg - UNW_PPC64_F0];
+#elif defined(__FreeBSD__)
+    addr = &uc->uc_mcontext.mc_fpreg[reg - UNW_PPC64_F0];
+#endif
 
   else if ((unsigned) (reg - UNW_PPC64_V0) < 32)
+#if defined(__linux__)
     addr = (uc->uc_mcontext.v_regs == 0) ? NULL : &uc->uc_mcontext.v_regs->vrregs[reg - UNW_PPC64_V0][0];
+#elif defined(__FreeBSD__)
+    addr = &uc->uc_mcontext.mc_avec[(reg - UNW_PPC64_V0)*2];
+#endif
 
   else
     {
@@ -80,7 +92,11 @@ uc_addr (ucontext_t *uc, int reg)
         default:
           return NULL;
         }
+#if defined(__linux__)
       addr = &uc->uc_mcontext.gp_regs[gregs_idx];
+#elif defined(__FreeBSD__)
+      addr = &uc->uc_mcontext.mc_gpr[gregs_idx];
+#endif
     }
   return addr;
 }

--- a/src/ppc64/Gstep.c
+++ b/src/ppc64/Gstep.c
@@ -139,8 +139,8 @@ unw_step (unw_cursor_t * cursor)
           c->sigcontext_format = PPC_SCF_LINUX_RT_SIGFRAME;
           c->sigcontext_addr = ucontext;
 
-          sp_loc = DWARF_LOC (ucontext + UC_MCONTEXT_GREGS_R1, 0);
-          ip_loc = DWARF_LOC (ucontext + UC_MCONTEXT_GREGS_NIP, 0);
+          sp_loc = DWARF_LOC ((ucontext + UC_MCONTEXT_GREGS_R1), 0);
+          ip_loc = DWARF_LOC ((ucontext + UC_MCONTEXT_GREGS_NIP), 0);
 
           ret = dwarf_get (&c->dwarf, sp_loc, &c->dwarf.cfa);
           if (ret < 0)
@@ -311,8 +311,15 @@ unw_step (unw_cursor_t * cursor)
           /* Note that there is no .eh_section register column for the
              FPSCR register.  I don't know why this is.  */
 
+#if defined(__linux__)
           v_regs_loc = DWARF_LOC (ucontext + UC_MCONTEXT_V_REGS, 0);
           ret = dwarf_get (&c->dwarf, v_regs_loc, &v_regs_ptr);
+#elif defined(__FreeBSD__)
+          /* Offset into main structure. */
+          v_regs_ptr = (ucontext + UC_MCONTEXT_V_REGS);
+          ret = 0;
+#endif
+
           if (ret < 0)
             {
               Debug (2, "returning %d\n", ret);

--- a/src/ppc64/ucontext_i.h
+++ b/src/ppc64/ucontext_i.h
@@ -28,6 +28,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include <ucontext.h>
 
+#if defined(__linux__)
 /* These values were derived by reading
    /usr/src/linux-2.6.18-1.8/arch/um/include/sysdep-ppc/ptrace.h and
    /usr/src/linux-2.6.18-1.8/arch/powerpc/kernel/ppc32.h
@@ -49,125 +50,177 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #define VSCR_IDX        32
 #define VRSAVE_IDX      33
 
+#define UC_MCONTEXT_V_REGS ( ((void *)&dmy_ctxt.uc_mcontext.v_regs - (void *)&dmy_ctxt) )
+
+#define _UC_MCONTEXT_GPR(x) ( (void *)&dmy_ctxt.uc_mcontext.gp_regs[x] - (void *)&dmy_ctxt) )
+#define _UC_MCONTEXT_FPR(x) ( ((void *)&dmy_ctxt.uc_mcontext.fp_regs[x] - (void *)&dmy_ctxt) )
+#define _UC_MCONTEXT_VR(x)  ( ((void *)&dmy_vrregset.vrregs[x] - (void *)&dmy_vrregset) )
+
 /* These are dummy structures used only for obtaining the offsets of the
    various structure members. */
 static ucontext_t dmy_ctxt;
 static vrregset_t dmy_vrregset;
 
-#define UC_MCONTEXT_GREGS_R0 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[0] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R1 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[1] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R2 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[2] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R3 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[3] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R4 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[4] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R5 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[5] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R6 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[6] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R7 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[7] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R8 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[8] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R9 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[9] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R10 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[10] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R11 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[11] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R12 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[12] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R13 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[13] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R14 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[14] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R15 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[15] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R16 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[16] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R17 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[17] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R18 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[18] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R19 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[19] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R20 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[20] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R21 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[21] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R22 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[22] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R23 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[23] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R24 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[24] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R25 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[25] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R26 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[26] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R27 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[27] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R28 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[28] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R29 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[29] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R30 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[30] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_R31 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[31] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_NIP ((void *)&dmy_ctxt.uc_mcontext.gp_regs[NIP_IDX] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_MSR ((void *)&dmy_ctxt.uc_mcontext.gp_regs[MSR_IDX] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_ORIG_GPR3 ((void *)&dmy_ctxt.uc_mcontext.gp_regs[ORIG_GPR3_IDX] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_CTR ((void *)&dmy_ctxt.uc_mcontext.gp_regs[CTR_IDX] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_LINK ((void *)&dmy_ctxt.uc_mcontext.gp_regs[LINK_IDX] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_XER ((void *)&dmy_ctxt.uc_mcontext.gp_regs[XER_IDX] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_CCR ((void *)&dmy_ctxt.uc_mcontext.gp_regs[CCR_IDX] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_SOFTE ((void *)&dmy_ctxt.uc_mcontext.gp_regs[SOFTE_IDX] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_TRAP ((void *)&dmy_ctxt.uc_mcontext.gp_regs[TRAP_IDX] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_DAR ((void *)&dmy_ctxt.uc_mcontext.gp_regs[DAR_IDX] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_DSISR ((void *)&dmy_ctxt.uc_mcontext.gp_regs[DSISR_IDX] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_GREGS_RESULT ((void *)&dmy_ctxt.uc_mcontext.gp_regs[RESULT_IDX] - (void *)&dmy_ctxt)
+#elif defined(__FreeBSD__)
+/* See /usr/src/sys/powerpc/include/ucontext.h.
+   FreeBSD uses a different structure than Linux.
+*/
 
-#define UC_MCONTEXT_FREGS_R0 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[0] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R1 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[1] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R2 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[2] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R3 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[3] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R4 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[4] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R5 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[5] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R6 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[6] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R7 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[7] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R8 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[8] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R9 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[9] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R10 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[10] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R11 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[11] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R12 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[12] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R13 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[13] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R14 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[14] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R15 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[15] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R16 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[16] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R17 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[17] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R18 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[18] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R19 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[19] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R20 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[20] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R21 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[21] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R22 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[22] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R23 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[23] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R24 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[24] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R25 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[25] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R26 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[26] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R27 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[27] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R28 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[28] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R29 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[29] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R30 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[30] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_R31 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[31] - (void *)&dmy_ctxt)
-#define UC_MCONTEXT_FREGS_FPSCR ((void *)&dmy_ctxt.uc_mcontext.fp_regs[32] - (void *)&dmy_ctxt)
+#define NIP_IDX         36
+#define MSR_IDX         37
+//#define ORIG_GPR3_IDX
+#define CTR_IDX         35
+#define LINK_IDX        32
+#define XER_IDX         34
+#define CCR_IDX         33
+//#define SOFTE_IDX
+//#define TRAP_IDX
+#define DAR_IDX         39
+#define DSISR_IDX       40
+//#define RESULT_IDX
 
-#define UC_MCONTEXT_V_REGS ((void *)&dmy_ctxt.uc_mcontext.v_regs - (void *)&dmy_ctxt)
+#define UC_MCONTEXT_V_REGS (((void *)&dmy_ctxt.mc_avec - (void *)&dmy_ctxt))
 
-#define UC_MCONTEXT_VREGS_R0 ((void *)&dmy_vrregset.vrregs[0] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R1 ((void *)&dmy_vrregset.vrregs[1] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R2 ((void *)&dmy_vrregset.vrregs[2] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R3 ((void *)&dmy_vrregset.vrregs[3] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R4 ((void *)&dmy_vrregset.vrregs[4] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R5 ((void *)&dmy_vrregset.vrregs[5] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R6 ((void *)&dmy_vrregset.vrregs[6] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R7 ((void *)&dmy_vrregset.vrregs[7] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R8 ((void *)&dmy_vrregset.vrregs[8] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R9 ((void *)&dmy_vrregset.vrregs[9] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R10 ((void *)&dmy_vrregset.vrregs[10] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R11 ((void *)&dmy_vrregset.vrregs[11] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R12 ((void *)&dmy_vrregset.vrregs[12] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R13 ((void *)&dmy_vrregset.vrregs[13] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R14 ((void *)&dmy_vrregset.vrregs[14] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R15 ((void *)&dmy_vrregset.vrregs[15] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R16 ((void *)&dmy_vrregset.vrregs[16] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R17 ((void *)&dmy_vrregset.vrregs[17] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R18 ((void *)&dmy_vrregset.vrregs[18] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R19 ((void *)&dmy_vrregset.vrregs[19] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R20 ((void *)&dmy_vrregset.vrregs[20] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R21 ((void *)&dmy_vrregset.vrregs[21] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R22 ((void *)&dmy_vrregset.vrregs[22] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R23 ((void *)&dmy_vrregset.vrregs[23] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R24 ((void *)&dmy_vrregset.vrregs[24] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R25 ((void *)&dmy_vrregset.vrregs[25] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R26 ((void *)&dmy_vrregset.vrregs[26] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R27 ((void *)&dmy_vrregset.vrregs[27] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R28 ((void *)&dmy_vrregset.vrregs[28] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R29 ((void *)&dmy_vrregset.vrregs[29] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R30 ((void *)&dmy_vrregset.vrregs[30] - (void *)&dmy_vrregset)
-#define UC_MCONTEXT_VREGS_R31 ((void *)&dmy_vrregset.vrregs[31] - (void *)&dmy_vrregset)
+#define _UC_MCONTEXT_GPR(_x) ( ((void *)&dmy_ctxt.mc_gpr[_x] - (void *)&dmy_ctxt) )
+#define _UC_MCONTEXT_FPR(_x) ( ((void *)&dmy_ctxt.mc_fpreg[_x] - (void *)&dmy_ctxt) )
+#define _UC_MCONTEXT_VR(_x) ( ((void *)&dmy_ctxt.mc_avec[_x] - (void *)&dmy_ctxt.mc_avec) )
+
+/* These are dummy structures used only for obtaining the offsets of the
+   various structure members. */
+static struct __mcontext dmy_ctxt;
+
+#else
+#error "Not implemented!"
+#endif
+
+#define UC_MCONTEXT_GREGS_R0 _UC_MCONTEXT_GPR(0)
+#define UC_MCONTEXT_GREGS_R1 _UC_MCONTEXT_GPR(1)
+#define UC_MCONTEXT_GREGS_R2 _UC_MCONTEXT_GPR(2)
+#define UC_MCONTEXT_GREGS_R3 _UC_MCONTEXT_GPR(3)
+#define UC_MCONTEXT_GREGS_R4 _UC_MCONTEXT_GPR(4)
+#define UC_MCONTEXT_GREGS_R5 _UC_MCONTEXT_GPR(5)
+#define UC_MCONTEXT_GREGS_R6 _UC_MCONTEXT_GPR(6)
+#define UC_MCONTEXT_GREGS_R7 _UC_MCONTEXT_GPR(7)
+#define UC_MCONTEXT_GREGS_R8 _UC_MCONTEXT_GPR(8)
+#define UC_MCONTEXT_GREGS_R9 _UC_MCONTEXT_GPR(9)
+#define UC_MCONTEXT_GREGS_R10 _UC_MCONTEXT_GPR(10)
+#define UC_MCONTEXT_GREGS_R11 _UC_MCONTEXT_GPR(11)
+#define UC_MCONTEXT_GREGS_R12 _UC_MCONTEXT_GPR(12)
+#define UC_MCONTEXT_GREGS_R13 _UC_MCONTEXT_GPR(13)
+#define UC_MCONTEXT_GREGS_R14 _UC_MCONTEXT_GPR(14)
+#define UC_MCONTEXT_GREGS_R15 _UC_MCONTEXT_GPR(15)
+#define UC_MCONTEXT_GREGS_R16 _UC_MCONTEXT_GPR(16)
+#define UC_MCONTEXT_GREGS_R17 _UC_MCONTEXT_GPR(17)
+#define UC_MCONTEXT_GREGS_R18 _UC_MCONTEXT_GPR(18)
+#define UC_MCONTEXT_GREGS_R19 _UC_MCONTEXT_GPR(19)
+#define UC_MCONTEXT_GREGS_R20 _UC_MCONTEXT_GPR(20)
+#define UC_MCONTEXT_GREGS_R21 _UC_MCONTEXT_GPR(21)
+#define UC_MCONTEXT_GREGS_R22 _UC_MCONTEXT_GPR(22)
+#define UC_MCONTEXT_GREGS_R23 _UC_MCONTEXT_GPR(23)
+#define UC_MCONTEXT_GREGS_R24 _UC_MCONTEXT_GPR(24)
+#define UC_MCONTEXT_GREGS_R25 _UC_MCONTEXT_GPR(25)
+#define UC_MCONTEXT_GREGS_R26 _UC_MCONTEXT_GPR(26)
+#define UC_MCONTEXT_GREGS_R27 _UC_MCONTEXT_GPR(27)
+#define UC_MCONTEXT_GREGS_R28 _UC_MCONTEXT_GPR(28)
+#define UC_MCONTEXT_GREGS_R29 _UC_MCONTEXT_GPR(29)
+#define UC_MCONTEXT_GREGS_R30 _UC_MCONTEXT_GPR(30)
+#define UC_MCONTEXT_GREGS_R31 _UC_MCONTEXT_GPR(31)
+#define UC_MCONTEXT_GREGS_NIP _UC_MCONTEXT_GPR(NIP_IDX)
+#define UC_MCONTEXT_GREGS_MSR _UC_MCONTEXT_GPR(MSR_IDX)
+#ifdef ORIG_GPR3_IDX
+#define UC_MCONTEXT_GREGS_ORIG_GPR3 _UC_MCONTEXT_GPR(ORIG_GPR3_IDX)
+#endif
+#define UC_MCONTEXT_GREGS_CTR _UC_MCONTEXT_GPR(CTR_IDX)
+#define UC_MCONTEXT_GREGS_LINK _UC_MCONTEXT_GPR(LINK_IDX)
+#define UC_MCONTEXT_GREGS_XER _UC_MCONTEXT_GPR(XER_IDX)
+#define UC_MCONTEXT_GREGS_CCR _UC_MCONTEXT_GPR(CCR_IDX)
+#ifdef SOFTE_IDX
+#define UC_MCONTEXT_GREGS_SOFTE _UC_MCONTEXT_GPR(SOFTE_IDX)
+#endif
+#ifdef TRAP_IDX
+#define UC_MCONTEXT_GREGS_TRAP _UC_MCONTEXT_GPR(TRAP_IDX)
+#endif
+#define UC_MCONTEXT_GREGS_DAR _UC_MCONTEXT_GPR(DAR_IDX)
+#define UC_MCONTEXT_GREGS_DSISR _UC_MCONTEXT_GPR(DSISR_IDX)
+#ifdef RESULT_IDX
+#define UC_MCONTEXT_GREGS_RESULT _UC_MCONTEXT_GPR(RESULT_IDX)
+#endif
+
+#define UC_MCONTEXT_FREGS_R0 _UC_MCONTEXT_FPR(0)
+#define UC_MCONTEXT_FREGS_R1 _UC_MCONTEXT_FPR(1)
+#define UC_MCONTEXT_FREGS_R2 _UC_MCONTEXT_FPR(2)
+#define UC_MCONTEXT_FREGS_R3 _UC_MCONTEXT_FPR(3)
+#define UC_MCONTEXT_FREGS_R4 _UC_MCONTEXT_FPR(4)
+#define UC_MCONTEXT_FREGS_R5 _UC_MCONTEXT_FPR(5)
+#define UC_MCONTEXT_FREGS_R6 _UC_MCONTEXT_FPR(6)
+#define UC_MCONTEXT_FREGS_R7 _UC_MCONTEXT_FPR(7)
+#define UC_MCONTEXT_FREGS_R8 _UC_MCONTEXT_FPR(8)
+#define UC_MCONTEXT_FREGS_R9 _UC_MCONTEXT_FPR(9)
+#define UC_MCONTEXT_FREGS_R10 _UC_MCONTEXT_FPR(10)
+#define UC_MCONTEXT_FREGS_R11 _UC_MCONTEXT_FPR(11)
+#define UC_MCONTEXT_FREGS_R12 _UC_MCONTEXT_FPR(12)
+#define UC_MCONTEXT_FREGS_R13 _UC_MCONTEXT_FPR(13)
+#define UC_MCONTEXT_FREGS_R14 _UC_MCONTEXT_FPR(14)
+#define UC_MCONTEXT_FREGS_R15 _UC_MCONTEXT_FPR(15)
+#define UC_MCONTEXT_FREGS_R16 _UC_MCONTEXT_FPR(16)
+#define UC_MCONTEXT_FREGS_R17 _UC_MCONTEXT_FPR(17)
+#define UC_MCONTEXT_FREGS_R18 _UC_MCONTEXT_FPR(18)
+#define UC_MCONTEXT_FREGS_R19 _UC_MCONTEXT_FPR(19)
+#define UC_MCONTEXT_FREGS_R20 _UC_MCONTEXT_FPR(20)
+#define UC_MCONTEXT_FREGS_R21 _UC_MCONTEXT_FPR(21)
+#define UC_MCONTEXT_FREGS_R22 _UC_MCONTEXT_FPR(22)
+#define UC_MCONTEXT_FREGS_R23 _UC_MCONTEXT_FPR(23)
+#define UC_MCONTEXT_FREGS_R24 _UC_MCONTEXT_FPR(24)
+#define UC_MCONTEXT_FREGS_R25 _UC_MCONTEXT_FPR(25)
+#define UC_MCONTEXT_FREGS_R26 _UC_MCONTEXT_FPR(26)
+#define UC_MCONTEXT_FREGS_R27 _UC_MCONTEXT_FPR(27)
+#define UC_MCONTEXT_FREGS_R28 _UC_MCONTEXT_FPR(28)
+#define UC_MCONTEXT_FREGS_R29 _UC_MCONTEXT_FPR(29)
+#define UC_MCONTEXT_FREGS_R30 _UC_MCONTEXT_FPR(30)
+#define UC_MCONTEXT_FREGS_R31 _UC_MCONTEXT_FPR(31)
+#define UC_MCONTEXT_FREGS_FPSCR _UC_MCONTEXT_FPR(32)
+
+
+#define UC_MCONTEXT_VREGS_R0 _UC_MCONTEXT_VR(0)
+#define UC_MCONTEXT_VREGS_R1 _UC_MCONTEXT_VR(1)
+#define UC_MCONTEXT_VREGS_R2 _UC_MCONTEXT_VR(2)
+#define UC_MCONTEXT_VREGS_R3 _UC_MCONTEXT_VR(3)
+#define UC_MCONTEXT_VREGS_R4 _UC_MCONTEXT_VR(4)
+#define UC_MCONTEXT_VREGS_R5 _UC_MCONTEXT_VR(5)
+#define UC_MCONTEXT_VREGS_R6 _UC_MCONTEXT_VR(6)
+#define UC_MCONTEXT_VREGS_R7 _UC_MCONTEXT_VR(7)
+#define UC_MCONTEXT_VREGS_R8 _UC_MCONTEXT_VR(8)
+#define UC_MCONTEXT_VREGS_R9 _UC_MCONTEXT_VR(9)
+#define UC_MCONTEXT_VREGS_R10 _UC_MCONTEXT_VR(10)
+#define UC_MCONTEXT_VREGS_R11 _UC_MCONTEXT_VR(11)
+#define UC_MCONTEXT_VREGS_R12 _UC_MCONTEXT_VR(12)
+#define UC_MCONTEXT_VREGS_R13 _UC_MCONTEXT_VR(13)
+#define UC_MCONTEXT_VREGS_R14 _UC_MCONTEXT_VR(14)
+#define UC_MCONTEXT_VREGS_R15 _UC_MCONTEXT_VR(15)
+#define UC_MCONTEXT_VREGS_R16 _UC_MCONTEXT_VR(16)
+#define UC_MCONTEXT_VREGS_R17 _UC_MCONTEXT_VR(17)
+#define UC_MCONTEXT_VREGS_R18 _UC_MCONTEXT_VR(18)
+#define UC_MCONTEXT_VREGS_R19 _UC_MCONTEXT_VR(19)
+#define UC_MCONTEXT_VREGS_R20 _UC_MCONTEXT_VR(20)
+#define UC_MCONTEXT_VREGS_R21 _UC_MCONTEXT_VR(21)
+#define UC_MCONTEXT_VREGS_R22 _UC_MCONTEXT_VR(22)
+#define UC_MCONTEXT_VREGS_R23 _UC_MCONTEXT_VR(23)
+#define UC_MCONTEXT_VREGS_R24 _UC_MCONTEXT_VR(24)
+#define UC_MCONTEXT_VREGS_R25 _UC_MCONTEXT_VR(25)
+#define UC_MCONTEXT_VREGS_R26 _UC_MCONTEXT_VR(26)
+#define UC_MCONTEXT_VREGS_R27 _UC_MCONTEXT_VR(27)
+#define UC_MCONTEXT_VREGS_R28 _UC_MCONTEXT_VR(28)
+#define UC_MCONTEXT_VREGS_R29 _UC_MCONTEXT_VR(29)
+#define UC_MCONTEXT_VREGS_R30 _UC_MCONTEXT_VR(30)
+#define UC_MCONTEXT_VREGS_R31 _UC_MCONTEXT_VR(31)
+#if defined(__linux__)
 #define UC_MCONTEXT_VREGS_VSCR ((void *)&dmy_vrregset.vscr - (void *)&dmy_vrregset)
 #define UC_MCONTEXT_VREGS_VRSAVE ((void *)&dmy_vrregset.vrsave - (void *)&dmy_vrregset)
+#elif defined(__FreeBSD__)
+#define UC_MCONTEXT_VREGS_VSCR ((void *)&dmy_ctxt.mc_av[0] - (void *)&dmy_ctxt)
+#define UC_MCONTEXT_VREGS_VRSAVE ((void *)&dmy_ctxt.mc_av[1] - (void *)&dmy_ctxt)
+#else
+#error "Not implemented!"
+#endif
 
 #endif

--- a/src/ptrace/_UPT_access_fpreg.c
+++ b/src/ptrace/_UPT_access_fpreg.c
@@ -87,6 +87,9 @@ _UPT_access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
 #elif defined(__aarch64__)
   if ((unsigned) reg < UNW_AARCH64_V0 || (unsigned) reg > UNW_AARCH64_V31)
     return -UNW_EBADREG;
+#elif defined(__powerpc64__)
+  if ((unsigned) reg < UNW_PPC64_F0 || (unsigned) reg > UNW_PPC64_F31)
+    return -UNW_EBADREG;
 #else
 #error Fix me
 #endif
@@ -104,6 +107,8 @@ _UPT_access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
           memcpy(&fpreg.fpr[reg], val, sizeof(unw_fpreg_t));
 #elif defined(__aarch64__)
           memcpy(&fpreg.fp_q[reg], val, sizeof(unw_fpreg_t));
+#elif defined(__powerpc64__)
+          memcpy(&fpreg.fpreg[reg], val, sizeof(unw_fpreg_t));
 #else
 #error Fix me
 #endif
@@ -118,6 +123,8 @@ _UPT_access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
           memcpy(val, &fpreg.fpr[reg], sizeof(unw_fpreg_t));
 #elif defined(__aarch64__)
           memcpy(val, &fpreg.fp_q[reg], sizeof(unw_fpreg_t));
+#elif defined(__powerpc64__)
+          memcpy(val, &fpreg.fpreg[reg], sizeof(unw_fpreg_t));
 #else
 #error Fix me
 #endif

--- a/src/ptrace/_UPT_reg_offset.c
+++ b/src/ptrace/_UPT_reg_offset.c
@@ -32,6 +32,49 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 # include <asm/ptrace_offsets.h>
 #endif
 
+#if defined(__powerpc64__) && defined(__FreeBSD__)
+#define PT_R0   0
+#define PT_R1   1
+#define PT_R2   2
+#define PT_R3   3
+#define PT_R4   4
+#define PT_R5   5
+#define PT_R6   6
+#define PT_R7   7
+#define PT_R8   8
+#define PT_R9   9
+#define PT_R10  10
+#define PT_R11  11
+#define PT_R12  12
+#define PT_R13  13
+#define PT_R14  14
+#define PT_R15  15
+#define PT_R16  16
+#define PT_R17  17
+#define PT_R18  18
+#define PT_R19  19
+#define PT_R20  20
+#define PT_R21  21
+#define PT_R22  22
+#define PT_R23  23
+#define PT_R24  24
+#define PT_R25  25
+#define PT_R26  26
+#define PT_R27  27
+#define PT_R28  28
+#define PT_R29  29
+#define PT_R30  30
+#define PT_R31  31
+#define PT_NIP  32
+#define PT_CTR  35
+#define PT_LNK  36
+#define PT_XER  37
+#define PT_FPR0  48
+#define PT_VR0  82
+#define PT_VSCR (PT_VR0 + 32*2 + 1)
+#define PT_VRSAVE (PT_VR0 + 33*2)
+#endif
+
 const int _UPT_reg_offset[UNW_REG_LAST + 1] =
   {
 #ifdef HAVE_ASM_PTRACE_OFFSETS_H


### PR DESCRIPTION
This is a complete port of libunwind to FreeBSD/powerpc64 platform. It also fixes some issues in existing code, fixing common bugs in a code shared with Linux:
- extra semicolon in Gcreate_addr_space.c,
- order_is_big_endian instead of byte_order_is_big_endian.

The rest of changes are macros for registers.