### PR TITLE
Define the FP register size on PPC to be double

### DIFF
--- a/include/libunwind-ppc64.h
+++ b/include/libunwind-ppc64.h
@@ -72,7 +72,7 @@ typedef uint64_t unw_word_t;
 typedef int64_t unw_sword_t;
 #endif
 
-typedef long double unw_tdep_fpreg_t;
+typedef double unw_tdep_fpreg_t;
 
 /*
  * Vector register (in PowerPC64 used for AltiVec registers)


### PR DESCRIPTION
According to GLIBC headers those are in fact double (4 Byte) not long double (8 Byte)

Fixes #208 

Note that there are still problems: The vector registers are also accessed via `unw_tdep_fpreg_t` which was likely not correct before and will now read/write even less.
I'd also strongly suggest to add compile time checks that the defines for such types that are "blindly" casted to memory locations in existing structs are actually correct. I'm not sure if `static_assert` exists in C but something like this could be used to check for some types or at least same sizes wherever such a cast from one pointer type to another is made.