### PR TITLE
fix aarch64 getcontext functionality

### DIFF
--- a/include/libunwind-aarch64.h
+++ b/include/libunwind-aarch64.h
@@ -224,10 +224,10 @@ typedef ucontext_t unw_tdep_context_t;
 #include "libunwind-common.h"
 #include "libunwind-dynamic.h"
 
-#define unw_tdep_getcontext(uc) (({					\
+#define unw_tdep_getcontext(uc) ({					\
   unw_tdep_context_t *unw_ctx = (uc);					\
-  register uint64_t *unw_base __asm__ ("x0") = (uint64_t*) unw_ctx->uc_mcontext.regs;		\
-  __asm__ __volatile__ (						\
+  register uint64_t unw_base __asm__ ("x0") = (uint64_t) unw_ctx->uc_mcontext.regs; \
+  __asm__ __volatile__ (					        \
      "stp x0, x1, [%[base], #0]\n" \
      "stp x2, x3, [%[base], #16]\n" \
      "stp x4, x5, [%[base], #32]\n" \
@@ -243,11 +243,14 @@ typedef ucontext_t unw_tdep_context_t;
      "stp x24, x25, [%[base], #192]\n" \
      "stp x26, x27, [%[base], #208]\n" \
      "stp x28, x29, [%[base], #224]\n" \
-     "str x30, [%[base], #240]\n" \
      "mov x1, sp\n" \
-     "stp x1, x30, [%[base], #248]\n" \
+     "stp x30, x1, [%[base], #240]\n" \
+     "adr x1, ret%=\n" \
+     "str x1, [%[base], #256]\n" \
+     "mov %[base], #0\n" \
+     "ret%=:\n" \
      : [base] "+r" (unw_base) : : "x1", "memory"); \
-  }), 0)
+  (int)unw_base; })
 #define unw_tdep_is_fpreg		UNW_ARCH_OBJ(is_fpreg)
 
 extern int unw_tdep_is_fpreg (int);


### PR DESCRIPTION
I was surprised to notice this was using the wrong value for PC (it was using LR / x30 instead), causing many tests to fail. Additionally, it was returning `0` instead of `x0`. Using PC for PC gets most tests to pass (the remaining failing ones are mostly pthreads unw_get_proc_info failed: UNW_ENOINFO)

current ToT master:
```
PASS: test-static-link                                                                                                                                                            
PASS: test-proc-info                                                                                                                                                              
PASS: test-strerror                                                                                                                                                               
PASS: Gtest-bt                                                                                                                                                                    
PASS: Ltest-init                                                                                                                                                                  
PASS: Ltest-bt                                                                                                                                                                    
PASS: Gtest-init                                                                                                                                                                  
PASS: Gtest-resume-sig                                                                                                                                                            
PASS: Ltest-resume-sig-rt                                                                                                                                                         
PASS: Ltest-resume-sig                                                                                                                                                            
PASS: Gtest-resume-sig-rt                                                                                                                                                         
FAIL: Ltest-trace                                                                                                                                                                 
PASS: test-reg-state                                                                                                                                                              
PASS: test-init-remote                                                                                                                                                            
PASS: test-flush-cache                                                                                                                                                            
PASS: Ltest-varargs                                                                                                                                                               
PASS: test-mem                                                                                                                                                                    
PASS: Ltest-nomalloc                                                                                                                                                              
PASS: Ltest-nocalloc                                                                                                                                                              
PASS: test-setjmp                                                                        
FAIL: Gtest-trace                                                                                                                                                                 
PASS: Lrs-race                                                                                                                                                                    
FAIL: run-ptrace-misc                                                                                                                                                             
FAIL: test-ptrace                                                                                                                                                                 
../config/test-driver: line 107: 3738629 Segmentation fault      (core dumped) "$@" > $log_file 2>&1                                                                              
FAIL: Gtest-exc                                                                                                                                                                   
../config/test-driver: line 107: 3738632 Segmentation fault      (core dumped) "$@" > $log_file 2>&1                                                                              
FAIL: Ltest-exc                                                                                                                                                                   
FAIL: run-check-namespace                                                                                                                                                         
../config/test-driver: line 107: 3738666 Segmentation fault      (core dumped) "$@" > $log_file 2>&1                                                                              
FAIL: Gtest-concurrent                                                                                                                                                            
../config/test-driver: line 107: 3738723 Segmentation fault      (core dumped) "$@" > $log_file 2>&1                                                                              
FAIL: Ltest-concurrent                                                                                                                                                            
../config/test-driver: line 107: 3738890 Segmentation fault      (core dumped) "$@" > $log_file 2>&1                                                                              
FAIL: test-async-sig                                                                                                                                                              
FAIL: Ltest-mem-validate                                                                                                                                                          
FAIL: run-coredump-unwind                                                                                                                                                         
../config/test-driver: line 107: 3738834 Segmentation fault      (core dumped) "$@" > $log_file 2>&1                                                                              
FAIL: Ltest-init-local-signal                                                                                                                                                     
FAIL: run-ptrace-mapper                                                                                                                                                           
============================================================================                                                                                                      
Testsuite summary for libunwind 1.5-rc1                                                                                                                                           
============================================================================                                                                                                      
# TOTAL: 34                                                                                                                                                                       
# PASS:  20                                                                                                                                                                       
# SKIP:  0                                                                                                                                                                        
# XFAIL: 0                                                                                                                                                                        
# FAIL:  14                                                                                                                                                                       
# XPASS: 0                                                                                                                                                                        
# ERROR: 0                                                                               
============================================================================                                                                                                      
See tests/test-suite.log                                                                 
Please report to libunwind-devel@nongnu.org                                                                                                                                       
============================================================================             
```

after this PR:
```
PASS: test-static-link
PASS: test-proc-info
PASS: test-strerror
PASS: Gtest-bt
PASS: Ltest-bt
PASS: Ltest-exc
PASS: Ltest-init
PASS: Gtest-exc
PASS: Gtest-init
PASS: Ltest-resume-sig
PASS: Ltest-trace
PASS: Ltest-resume-sig-rt
PASS: Gtest-resume-sig-rt
PASS: Gtest-resume-sig
PASS: Gtest-trace
PASS: Ltest-init-local-signal
PASS: test-mem
PASS: test-flush-cache
PASS: test-init-remote
PASS: test-reg-state
PASS: Ltest-nomalloc
PASS: Ltest-varargs
PASS: Ltest-nocalloc
PASS: Ltest-concurrent
PASS: Gtest-concurrent
PASS: test-setjmp
PASS: Lrs-race
FAIL: run-ptrace-misc
FAIL: test-ptrace
FAIL: Ltest-mem-validate
FAIL: run-coredump-unwind
FAIL: run-check-namespace
FAIL: run-ptrace-mapper
PASS: test-async-sig
============================================================================
Testsuite summary for libunwind 1.5-rc1
============================================================================
# TOTAL: 34
# PASS:  28
# SKIP:  0
# XFAIL: 0
# FAIL:  6
# XPASS: 0
# ERROR: 0
============================================================================
See tests/test-suite.log
Please report to libunwind-devel@nongnu.org
============================================================================
```