### PR TITLE
stop lying about the ARM PC location?

### DIFF
--- a/include/libunwind-arm.h
+++ b/include/libunwind-arm.h
@@ -244,7 +244,7 @@ typedef enum
 
     UNW_TDEP_LAST_REG = UNW_ARM_D31,
 
-    UNW_TDEP_IP = UNW_ARM_R14,  /* A little white lie.  */
+    UNW_TDEP_IP = UNW_ARM_R15,
     UNW_TDEP_SP = UNW_ARM_R13,
     UNW_TDEP_EH = UNW_ARM_R0   /* FIXME.  */
   }

--- a/src/arm/Gresume.c
+++ b/src/arm/Gresume.c
@@ -50,7 +50,7 @@ arm_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
       regs[6] = uc->regs[10];
       regs[7] = uc->regs[11]; /* FP */
       regs[8] = uc->regs[13]; /* SP */
-      regs[9] = uc->regs[14]; /* LR */
+      regs[9] = uc->regs[15]; /* PC */
 
       struct regs_overlay {
               char x[sizeof(regs)];


### PR DESCRIPTION
I am not sure why it should lie about the PC register and use a
different random value (LR), when the actual value is also easily
available. The rate of passing tests seems to be the same.
(I think it may be aliasing the location of LR to IP internally
elsewhere, in unw_step, which ends up hiding the lie—mostly.)