### PR TITLE
RFC: mark unw_getcontext functions as returns_twice

### DIFF
--- a/include/libunwind-hppa.h
+++ b/include/libunwind-hppa.h
@@ -116,7 +116,7 @@ unw_tdep_proc_info_t;
 #include "libunwind-common.h"
 
 #define unw_tdep_getcontext             UNW_ARCH_OBJ (getcontext)
-extern int unw_tdep_getcontext (unw_tdep_context_t *);
+extern int unw_tdep_getcontext (unw_tdep_context_t *) __attribute__((returns_twice));
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }

--- a/include/libunwind-ia64.h
+++ b/include/libunwind-ia64.h
@@ -162,7 +162,7 @@ typedef ucontext_t unw_tdep_context_t;
 # define unw_tdep_getcontext            getcontext
 #else
 # define unw_tdep_getcontext            UNW_ARCH_OBJ (getcontext)
-  extern int unw_tdep_getcontext (unw_tdep_context_t *);
+  extern int unw_tdep_getcontext (unw_tdep_context_t *) __attribute__((returns_twice));
 #endif
 
 /* This is a helper routine to search an ia64 unwind table.  If the

--- a/include/libunwind-mips.h
+++ b/include/libunwind-mips.h
@@ -148,7 +148,7 @@ unw_tdep_proc_info_t;
    registers.  FIXME: Not ideal, may not be sufficient for all libunwind
    use cases.  */
 #define unw_tdep_getcontext UNW_ARCH_OBJ(getcontext)
-extern int unw_tdep_getcontext (ucontext_t *uc);
+extern int unw_tdep_getcontext (ucontext_t *uc) __attribute__((returns_twice));
 
 #define unw_tdep_is_fpreg               UNW_ARCH_OBJ(is_fpreg)
 extern int unw_tdep_is_fpreg (int);

--- a/include/libunwind-ppc32.h
+++ b/include/libunwind-ppc32.h
@@ -184,8 +184,9 @@ typedef ucontext_t unw_tdep_context_t;
 /* XXX this is not ideal: an application should not be prevented from
    using the "getcontext" name just because it's using libunwind.  We
    can't just use __getcontext() either, because that isn't exported
-   by glibc...  */
-#define unw_tdep_getcontext(uc)         (getcontext (uc), 0)
+   by glibc...
+   Returns -UNW_EUNSPEC on error (incidentally). */
+#define unw_tdep_getcontext(uc)         (getcontext (uc))
 
 #include "libunwind-dynamic.h"
 

--- a/include/libunwind-ppc64.h
+++ b/include/libunwind-ppc64.h
@@ -248,8 +248,9 @@ typedef ucontext_t unw_tdep_context_t;
 /* XXX this is not ideal: an application should not be prevented from
    using the "getcontext" name just because it's using libunwind.  We
    can't just use __getcontext() either, because that isn't exported
-   by glibc...  */
-#define unw_tdep_getcontext(uc)         (getcontext (uc), 0)
+   by glibc...
+   Returns -UNW_EUNSPEC on error (incidentally). */
+#define unw_tdep_getcontext(uc)         (getcontext (uc))
 
 #include "libunwind-dynamic.h"
 

--- a/include/libunwind-s390x.h
+++ b/include/libunwind-s390x.h
@@ -134,7 +134,7 @@ unw_tdep_proc_info_t;
 #define unw_tdep_getcontext             UNW_ARCH_OBJ(getcontext)
 #define unw_tdep_is_fpreg               UNW_ARCH_OBJ(is_fpreg)
 
-extern int unw_tdep_getcontext (unw_tdep_context_t *);
+extern int unw_tdep_getcontext (unw_tdep_context_t *) __attribute__((returns_twice));
 extern int unw_tdep_is_fpreg (int);
 
 #if defined(__cplusplus) || defined(c_plusplus)

--- a/include/libunwind-sh.h
+++ b/include/libunwind-sh.h
@@ -86,7 +86,8 @@ sh_regnum_t;
 
 typedef ucontext_t unw_tdep_context_t;
 
-#define unw_tdep_getcontext(uc)         (getcontext (uc), 0)
+/* Returns -UNW_EUNSPEC on error (incidentally). */
+#define unw_tdep_getcontext(uc)         (getcontext (uc))
 
 typedef struct unw_tdep_save_loc
   {

--- a/include/libunwind-tilegx.h
+++ b/include/libunwind-tilegx.h
@@ -149,6 +149,7 @@ typedef struct
 
 #include "libunwind-common.h"
 
+/* Returns -UNW_EUNSPEC on error (incidentally). */
 #define unw_tdep_getcontext  getcontext
 
 #define unw_tdep_is_fpreg    UNW_ARCH_OBJ(is_fpreg)

--- a/include/libunwind-x86.h
+++ b/include/libunwind-x86.h
@@ -175,7 +175,7 @@ unw_tdep_proc_info_t;
 #include "libunwind-common.h"
 
 #define unw_tdep_getcontext             UNW_ARCH_OBJ(getcontext)
-extern int unw_tdep_getcontext (unw_tdep_context_t *);
+extern int unw_tdep_getcontext (unw_tdep_context_t *) __attribute__((returns_twice));
 
 #define unw_tdep_is_fpreg               UNW_ARCH_OBJ(is_fpreg)
 extern int unw_tdep_is_fpreg (int);

--- a/include/libunwind-x86_64.h
+++ b/include/libunwind-x86_64.h
@@ -131,7 +131,7 @@ unw_tdep_proc_info_t;
 #define unw_tdep_getcontext             UNW_ARCH_OBJ(getcontext)
 #define unw_tdep_is_fpreg               UNW_ARCH_OBJ(is_fpreg)
 
-extern int unw_tdep_getcontext (unw_tdep_context_t *);
+extern int unw_tdep_getcontext (unw_tdep_context_t *) __attribute__((returns_twice));
 extern int unw_tdep_is_fpreg (int);
 
 #if defined(__cplusplus) || defined(c_plusplus)


### PR DESCRIPTION
This instructs the compiler to avoid optimizations in the callee that
would potentially interact poorly with interpreting the state, such as
frame-pointer-elimination on certain platforms, alloca lifetime
analysis/slot reuse, and so on.

It also passes along the return value from getcontext, when used (which
fortuitously is already UNW_ESUCCESS or -UNW_EUNSPEC), instead of
forcing it to be 0.