### PR TITLE
fix build on ARM?

### DIFF
--- a/src/arm/Gex_tables.c
+++ b/src/arm/Gex_tables.c
@@ -381,7 +381,7 @@ arm_exidx_extract (struct dwarf_cursor *c, uint8_t *buf)
   return nbuf;
 }
 
-int
+static int
 arm_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
 			 unw_dyn_info_t *di, unw_proc_info_t *pi,
 			 int need_unwind_info, void *arg)


### PR DESCRIPTION
This file can get included both directly and through Lex_tables, resulting in a symbol conflict when this function then gets defined twice (with simple `./autogen.sh && make`). Marking it `static` (local to each file) lets the build succeed, though I don't know if that's the preferred strategy (vs. some combination of `#ifdef` with `UNW_LOCAL_ONLY` and `UNW_REMOTE_ONLY`).