### PR TITLE
RFC: disallow tail-call optimization in tests

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,5 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
+AM_CFLAGS = -fno-optimize-sibling-calls
 
 EXTRA_DIST =	run-ia64-test-dyn1 run-ptrace-mapper run-ptrace-misc	\
 		run-check-namespace run-coredump-unwind \


### PR DESCRIPTION
This disallows frame reuse for tail and other sibling calls. I'm not aware of any place where a sibling call optimization would actually be used by the compiler (the failing test I was looking at turned out to be due to inlining, not a sibling call), but I though this might help ensure future compatibility for counting the expected number of stack / unwind frames. Feel free to request this be done differently, or just close it, if it doesn't sound useful enough now.