### PR TITLE
Fix Clang builds

### DIFF
--- a/include/libunwind-ptrace.h
+++ b/include/libunwind-ptrace.h
@@ -27,6 +27,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #define libunwind_ptrace_h
 
 #include <libunwind.h>
+#include <sys/types.h>
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {


### PR DESCRIPTION
While cross-compiling strace against libunwind for ARM, the configure
script of strace failed with:

libunwind-ptrace.h:40:27: error: a parameter list without types is only
allowed in a function definition

it turns out that we do not have a definition for what pid_t should be,
so include sys/types.h to remedy that.