### PR TITLE
Re-enabling s390x travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
 
 jobs:
   include:
-#    - <<: *linux-s390x
+    - <<: *linux-s390x
     - <<: *windows-remote-only
       env: TARGET=x86_64-linux-gnu    HOST=x64
     - <<: *windows-remote-only

--- a/configure.ac
+++ b/configure.ac
@@ -249,6 +249,7 @@ case $target_arch in
   arm*) enable_cxx_exceptions=no;;
   mips*) enable_cxx_exceptions=no;;
   tile*) enable_cxx_exceptions=no;;
+  s390x*) enable_cxx_exceptions=no;;
   *) enable_cxx_exceptions=yes;;
 esac
 ])


### PR DESCRIPTION
Earlier we added s390x support to Travis CI however it was removed through this commit: https://github.com/libunwind/libunwind/commit/c19a3cd2ff9330852a5ca7a1987f21153da3ecb8 due to failure of test case Ltest-cxx-exceptions
https://travis-ci.org/github/libunwind/libunwind/jobs/729066993

Now the mentioned code changes will resolve this test failure as well as re-enable s390x travis support.
Please review.