### PR TITLE
Fix elf get_load_offset when the binary was linked by lld: return the…

### DIFF
--- a/src/elfxx.c
+++ b/src/elfxx.c
@@ -177,7 +177,7 @@ elf_w (get_load_offset) (struct elf_image *ei, unsigned long segbase,
   for (i = 0; i < ehdr->e_phnum; ++i)
     if (phdr[i].p_type == PT_LOAD && (phdr[i].p_offset & pagesize_aligment_mask) == mapoff)
       {
-        offset = segbase - phdr[i].p_vaddr;
+        offset = segbase - phdr[i].p_vaddr + (phdr[i].p_offset & (~pagesize_aligment_mask))
         break;
       }
 


### PR DESCRIPTION
… right offet.

Followup pull request, first part was in PR #230 