### PR TITLE
Update configure.ac to prevent missing symbols

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -265,6 +265,9 @@ case "${target_arch}" in
   (aarch64) enable_debug_frame=yes;;
   (*)   enable_debug_frame=no;;
 esac])
+if test x$remote_only == xyes; then
+  enable_debug_frame=no
+fi
 if test x$enable_debug_frame = xyes; then
   AC_DEFINE([CONFIG_DEBUG_FRAME], [], [Enable Debug Frame])
 fi


### PR DESCRIPTION
nm shows that those two symbols are undefined, it happens when
./configure --target=host is used and when --enable_debug_frame is set.

nm src/.libs/libunwind-aarch64.so.8.0.1
...
                 U _Uelf64_find_section
                 U _Uelf64_load_debuglink
...

This change will prevent build issues until there is remote debug_frame
support on arm.