### PR TITLE
README: document ppc32 support

### DIFF
--- a/README
+++ b/README
@@ -11,6 +11,7 @@ several architecture/operating-system combinations:
 | Linux   | x86          | ✓      |
 | Linux   | ARM          | ✓      |
 | Linux   | AArch64      | ✓      |
+| Linux   | PPC32        | ✓      |
 | Linux   | PPC64        | ✓      |
 | Linux   | SuperH       | ✓      |
 | Linux   | IA-64        | ✓      |


### PR DESCRIPTION
PPC32 support was confirmed in #127, but this info was not added to the README.

To make things clear, add ppc32 to the supported arch/os table.