### PR TITLE
Declare that only DWARF CIE version 3 and below are supported

### DIFF
--- a/include/dwarf.h
+++ b/include/dwarf.h
@@ -140,7 +140,7 @@ typedef enum
 dwarf_expr_op_t;
 
 #define DWARF_CIE_VERSION       3
-#define DWARF_CIE_VERSION_MAX   4
+#define DWARF_CIE_VERSION_MAX   3
 
 #define DWARF_CFA_OPCODE_MASK   0xc0
 #define DWARF_CFA_OPERAND_MASK  0x3f


### PR DESCRIPTION
DWARF version 4 introduces new fields in the Common Information Entry (CIE) structure. That causes wrong parsing of that version of the structure. This fix causes the library to report an error instead of silently and wrongly parsing the structure.

Closes #256.