### PR TITLE
Fix build failure on ia64

### DIFF
--- a/src/coredump/_UPT_get_dyn_info_list_addr.c
+++ b/src/coredump/_UPT_get_dyn_info_list_addr.c
@@ -29,6 +29,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #if UNW_TARGET_IA64 && defined(__linux__)
 # include "elf64.h"
 # include "os-linux.h"
+# include "../ptrace/_UPT_internal.h"
 
 static inline int
 get_list_addr (unw_addr_space_t as, unw_word_t *dil_addr, void *arg,
@@ -38,7 +39,6 @@ get_list_addr (unw_addr_space_t as, unw_word_t *dil_addr, void *arg,
   struct UPT_info *ui = arg;
   struct map_iterator mi;
   char path[PATH_MAX];
-  unw_dyn_info_t *di;
   unw_word_t res;
   int count = 0;
 
@@ -48,18 +48,17 @@ get_list_addr (unw_addr_space_t as, unw_word_t *dil_addr, void *arg,
       if (off)
         continue;
 
-      invalidate_edi (&ui->edi);
+      invalidate_edi(&ui->edi);
 
-      if (elf_map_image (&ui->ei, path) < 0)
+      if (elf_map_image (&ui->edi.ei, path) < 0)
         /* ignore unmappable stuff like "/SYSV00001b58 (deleted)" */
         continue;
 
       Debug (16, "checking object %s\n", path);
 
-      di = tdep_find_unwind_table (&ui->edi, as, path, lo, off);
-      if (di)
+      if (tdep_find_unwind_table (&ui->edi, as, path, lo, off, 0) > 0)
         {
-          res = _Uia64_find_dyn_list (as, di, arg);
+          res = _Uia64_find_dyn_list (as, &ui->edi.di_cache, arg);
           if (res && count++ == 0)
             {
               Debug (12, "dyn_info_list_addr = 0x%lx\n", (long) res);


### PR DESCRIPTION
    coredump/_UPT_get_dyn_info_list_addr.c

is almost identical to

    ptrace/_UPT_get_dyn_info_list_addr.c

It's clearly an __ia64 implementation copy.