### PR TITLE
Show contents of test-suite.log on test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ script:
 - ulimit -c unlimited
 - if [ $HOST = 'x86_64-linux-gnu' ]; then make check -j32; fi
 
+after_failure: cat tests/test-suite.log 2>/dev/null
+
 jobs:
   include:
     - <<: *linux-s390x

--- a/README
+++ b/README
@@ -55,7 +55,7 @@ such dependencies
 In general, this library can be built and installed with the following
 commands:
 
-    $ ./autogen.sh # Needed only for building from git. Depends on libtool.
+    $ autoreconf -i # Needed only for building from git. Depends on libtool.
     $ ./configure
     $ make
     $ make install prefix=PREFIX

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-test -n "$srcdir" || srcdir=`dirname "$0"`
-test -n "$srcdir" || srcdir=.
-(
-  cd "$srcdir" &&
-  autoreconf --force -v --install
-) || exit
-test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"


### PR DESCRIPTION
With intetntional failure, the bottom part of failing leg looks like this: https://travis-ci.com/github/kasperk81/libunwind/jobs/520324857#L1485 (click on it and it shows contents of `test-suite.log`). Only applicable to the job which failed due to test failure.

SEcond commit is removing autogen.sh wrapper and updating README.md.