### PR TITLE
mips: fix regression after "Handle Gstep according the N64/N32 ABI"

### DIFF
--- a/src/mips/Gstep.c
+++ b/src/mips/Gstep.c
@@ -214,11 +214,14 @@ unw_step (unw_cursor_t *cursor)
   if (unlikely (ret == -UNW_ESTOPUNWIND))
     return ret;
 
-#if _MIPS_SIM == _ABI64
   if (unlikely (ret < 0))
     {
+#if _MIPS_SIM == _ABI64
       return _step_n64(c);
-    }
+#else
+      return ret;
 #endif
+    }
+
   return (c->dwarf.ip == 0) ? 0 : 1;
 }


### PR DESCRIPTION
unw_step should return zero for _MIPS_SIM != _ABI64 when dwarf_step failed.
This restores unw_step behaviour before 5eec9a2ecb9a93996d566bbfbcdbe006f64b7e16
for _ABIN32 and _ABIO32 interfaces.