### PR TITLE
Don't force {exec_prefix}/lib64 libdir on ppc64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -213,12 +213,6 @@ fi
 AM_CONDITIONAL(USE_DWARF, [test x$use_dwarf = xyes])
 AC_MSG_RESULT([$use_dwarf])
 
-if test x$target_arch = xppc64; then
-        libdir='${exec_prefix}/lib64'
-        AC_MSG_NOTICE([PowerPC64 detected, lib will be installed ${libdir}]);
-        AC_SUBST([libdir])
-fi
-
 AC_MSG_CHECKING([whether to restrict build to remote support])
 if test x$target_arch != x$host_arch; then
   CPPFLAGS="${CPPFLAGS} -DUNW_REMOTE_ONLY"


### PR DESCRIPTION
See also https://sources.debian.org/patches/libunwind/1.3.2-2/20140507-ppc_lib64.patch/