### PR TITLE
Add optimization options in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,34 @@ sudo: required
 language: c
 compiler: gcc
 env:
-- HOST=x86_64-linux-gnu
-- HOST=x86-linux-gnu
-- HOST=arm-linux-gnueabihf
-- HOST=aarch64-linux-gnu
-- HOST=mipsel-linux-gnu
-# Currently experiencing build failures here
-#- HOST=powerpc64-linux-gnu
+- HOST=x86_64-linux-gnu OPT=-O0
+- HOST=x86-linux-gnu OPT=-O0
+- HOST=arm-linux-gnueabihf OPT=-O0
+- HOST=aarch64-linux-gnu OPT=-O0
+- HOST=mipsel-linux-gnu OPT=-O0
+- HOST=powerpc64-linux-gnu OPT=-O0
+- HOST=x86_64-linux-gnu OPT=-O2
+- HOST=x86-linux-gnu OPT=-O2
+- HOST=arm-linux-gnueabihf OPT=-O2
+- HOST=aarch64-linux-gnu OPT=-O2
+- HOST=mipsel-linux-gnu OPT=-O2
+- HOST=powerpc64-linux-gnu OPT=-O2
+- HOST=x86_64-linux-gnu OPT=-O3
+- HOST=x86-linux-gnu OPT=-O3
+- HOST=arm-linux-gnueabihf OPT=-O3
+- HOST=aarch64-linux-gnu OPT=-O3
+- HOST=mipsel-linux-gnu OPT=-O3
+- HOST=powerpc64-linux-gnu OPT=-O3
 
 linux-s390x: &linux-s390x
   os: linux
   arch: s390x
-  env: BUILD=s390x-linux-gnu HOST=s390x-linux-gnu
+  env: HOST=s390x-linux-gnu BUILD=s390x-linux-gnu
   script:
+    - |
+      CFLAGS="$OPT"
+      CXXFLAGS="$OPT"
+      export CFLAGS CXXFLAGS
     - autoreconf -i
     - ./configure
     - make -j32
@@ -45,6 +60,10 @@ script:
     CXX=$HOST-g++
     export CC CXX
   fi
+- |
+  CFLAGS="$CFLAGS $OPT"
+  CXXFLAGS="$CXXFLAGS $OPT"
+  export CFLAGS CXXFLAGS
 - autoreconf -i
 - ./configure CC=$CC CXX=$CXX CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" --build=$BUILD --host=$HOST
 - make -j32
@@ -58,8 +77,8 @@ jobs:
   include:
     - <<: *linux-s390x
     - <<: *windows-remote-only
-      env: TARGET=x86_64-linux-gnu    WINHOST=x64
+      env: WINHOST=x64 TARGET=x86_64-linux-gnu
     - <<: *windows-remote-only
-      env: TARGET=arm-linux-gnueabihf WINHOST=Win32
+      env: WINHOST=Win32 TARGET=arm-linux-gnueabihf
     - <<: *windows-remote-only
-      env: TARGET=aarch64-linux-gnu   WINHOST=x64
+      env: WINHOST=x64 TARGET=aarch64-linux-gnu


### PR DESCRIPTION
Currently CI only tests (implicit) -O0. This adds -O0, -O2 and -O3 explicitly. CI builds the whole matrix less than three minutes so it won't be a hassle but keep us up to date.

cc @zhaofengli 