### PR TITLE
Fix the build on FreeBSD

### DIFF
--- a/src/x86_64/Gos-freebsd.c
+++ b/src/x86_64/Gos-freebsd.c
@@ -192,23 +192,23 @@ x86_64_sigreturn (unw_cursor_t *cursor)
   ucontext_t *uc = (ucontext_t *)(c->sigcontext_addr +
     offsetof(struct sigframe, sf_uc));
 
-  uc->uc_mcontext.mc_r8 = c->uc->uc_mcontext.mc_r8;
-  uc->uc_mcontext.mc_r9 = c->uc->uc_mcontext.mc_r9;
-  uc->uc_mcontext.mc_r10 = c->uc->uc_mcontext.mc_r10;
-  uc->uc_mcontext.mc_r11 = c->uc->uc_mcontext.mc_r11;
-  uc->uc_mcontext.mc_r12 = c->uc->uc_mcontext.mc_r12;
-  uc->uc_mcontext.mc_r13 = c->uc->uc_mcontext.mc_r13;
-  uc->uc_mcontext.mc_r14 = c->uc->uc_mcontext.mc_r14;
-  uc->uc_mcontext.mc_r15 = c->uc->uc_mcontext.mc_r15;
-  uc->uc_mcontext.mc_rdi = c->uc->uc_mcontext.mc_rdi;
-  uc->uc_mcontext.mc_rsi = c->uc->uc_mcontext.mc_rsi;
-  uc->uc_mcontext.mc_rbp = c->uc->uc_mcontext.mc_rbp;
-  uc->uc_mcontext.mc_rbx = c->uc->uc_mcontext.mc_rbx;
-  uc->uc_mcontext.mc_rdx = c->uc->uc_mcontext.mc_rdx;
-  uc->uc_mcontext.mc_rax = c->uc->uc_mcontext.mc_rax;
-  uc->uc_mcontext.mc_rcx = c->uc->uc_mcontext.mc_rcx;
-  uc->uc_mcontext.mc_rsp = c->uc->uc_mcontext.mc_rsp;
-  uc->uc_mcontext.mc_rip = c->uc->uc_mcontext.mc_rip;
+  uc->uc_mcontext.mc_r8 = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_r8;
+  uc->uc_mcontext.mc_r9 = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_r9;
+  uc->uc_mcontext.mc_r10 = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_r10;
+  uc->uc_mcontext.mc_r11 = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_r11;
+  uc->uc_mcontext.mc_r12 = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_r12;
+  uc->uc_mcontext.mc_r13 = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_r13;
+  uc->uc_mcontext.mc_r14 = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_r14;
+  uc->uc_mcontext.mc_r15 = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_r15;
+  uc->uc_mcontext.mc_rdi = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_rdi;
+  uc->uc_mcontext.mc_rsi = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_rsi;
+  uc->uc_mcontext.mc_rbp = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_rbp;
+  uc->uc_mcontext.mc_rbx = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_rbx;
+  uc->uc_mcontext.mc_rdx = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_rdx;
+  uc->uc_mcontext.mc_rax = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_rax;
+  uc->uc_mcontext.mc_rcx = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_rcx;
+  uc->uc_mcontext.mc_rsp = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_rsp;
+  uc->uc_mcontext.mc_rip = dwarf_get_uc(&c->dwarf)->uc_mcontext.mc_rip;
 
   Debug (8, "resuming at ip=%llx via sigreturn(%p)\n",
              (unsigned long long) c->dwarf.ip, uc);

--- a/tests/test-ptrace.c
+++ b/tests/test-ptrace.c
@@ -233,7 +233,11 @@ main (int argc, char **argv)
         fprintf(stderr, "Need to specify a command line for the child\n");
         exit (-1);
       }
+#ifdef __FreeBSD__
+      execve (argv[optind], argv + optind, environ);
+#else
       execvpe (argv[optind], argv + optind, environ);
+#endif
       _exit (-1);
     }
   atexit (target_pid_kill);


### PR DESCRIPTION
The first commit here fixes building the library and the second fixes building `test-ptrace.c`. See individual commit messages for explanation. Note that `test-ptrace` still fails on FreeBSD, but at least now it's able to build.

Fixes #294.