### PR TITLE
x86_64: Stop aliasing RSP and CFA

### DIFF
--- a/include/dwarf.h
+++ b/include/dwarf.h
@@ -231,6 +231,7 @@ typedef enum
     DWARF_WHERE_REG,            /* register saved in another register */
     DWARF_WHERE_EXPR,           /* register saved */
     DWARF_WHERE_VAL_EXPR,       /* register has computed value */
+    DWARF_WHERE_CFA,            /* register is set to the computed cfa value */
   }
 dwarf_where_t;
 
@@ -313,7 +314,7 @@ typedef struct dwarf_cursor
     void *as_arg;               /* argument to address-space callbacks */
     unw_addr_space_t as;        /* reference to per-address-space info */
 
-    unw_word_t cfa;     /* canonical frame address; aka frame-/stack-pointer */
+    unw_word_t cfa;     /* canonical frame address; aka frame-pointer */
     unw_word_t ip;              /* instruction pointer */
     unw_word_t args_size;       /* size of arguments */
     unw_word_t eh_args[UNW_TDEP_NUM_EH_REGS];

--- a/include/libunwind_i.h
+++ b/include/libunwind_i.h
@@ -346,6 +346,10 @@ static inline void invalidate_edi (struct elf_dyn_info *edi)
 
 #include "tdep/libunwind_i.h"
 
+#ifndef TDEP_DWARF_SP
+#define TDEP_DWARF_SP UNW_TDEP_SP
+#endif
+
 #ifndef tdep_get_func_addr
 # define tdep_get_func_addr(as,addr,v)          (*(v) = addr, 0)
 #endif

--- a/include/tdep-x86/dwarf-config.h
+++ b/include/tdep-x86/dwarf-config.h
@@ -43,9 +43,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 typedef struct dwarf_loc
   {
     unw_word_t val;
-#ifndef UNW_LOCAL_ONLY
     unw_word_t type;            /* see X86_LOC_TYPE_* macros.  */
-#endif
   }
 dwarf_loc_t;
 

--- a/src/x86/Gos-freebsd.c
+++ b/src/x86/Gos-freebsd.c
@@ -138,6 +138,7 @@ x86_handle_signal_frame (unw_cursor_t *cursor)
     c->dwarf.loc[ST0] = DWARF_NULL_LOC;
   } else if (c->sigcontext_format == X86_SCF_FREEBSD_SYSCALL) {
     c->dwarf.loc[EIP] = DWARF_LOC (c->dwarf.cfa, 0);
+    c->dwarf.loc[ESP] = DWARF_VAL_LOC (c, c->dwarf.cfa + 4);
     c->dwarf.loc[EAX] = DWARF_NULL_LOC;
     c->dwarf.cfa += 4;
     c->dwarf.use_prev_instr = 1;

--- a/src/x86/Gregs.c
+++ b/src/x86/Gregs.c
@@ -53,7 +53,6 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
       break;
 
     case UNW_X86_CFA:
-    case UNW_X86_ESP:
       if (write)
         return -UNW_EREADONLYREG;
       *valp = c->dwarf.cfa;
@@ -81,6 +80,7 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
     case UNW_X86_ECX: loc = c->dwarf.loc[ECX]; break;
     case UNW_X86_EBX: loc = c->dwarf.loc[EBX]; break;
 
+    case UNW_X86_ESP: loc = c->dwarf.loc[ESP]; break;
     case UNW_X86_EBP: loc = c->dwarf.loc[EBP]; break;
     case UNW_X86_ESI: loc = c->dwarf.loc[ESI]; break;
     case UNW_X86_EDI: loc = c->dwarf.loc[EDI]; break;

--- a/src/x86/Gstep.c
+++ b/src/x86/Gstep.c
@@ -47,7 +47,7 @@ unw_step (unw_cursor_t *cursor)
     {
       /* DWARF failed, let's see if we can follow the frame-chain
          or skip over the signal trampoline.  */
-      struct dwarf_loc ebp_loc, eip_loc;
+      struct dwarf_loc ebp_loc, eip_loc, esp_loc;
 
       /* We could get here because of missing/bad unwind information.
          Validate all addresses before dereferencing. */
@@ -77,6 +77,7 @@ unw_step (unw_cursor_t *cursor)
                  c->dwarf.cfa);
 
           ebp_loc = DWARF_LOC (c->dwarf.cfa, 0);
+          esp_loc = DWARF_VAL_LOC (c, c->dwarf.cfa + 8);
           eip_loc = DWARF_LOC (c->dwarf.cfa + 4, 0);
           c->dwarf.cfa += 8;
 
@@ -87,6 +88,7 @@ unw_step (unw_cursor_t *cursor)
             c->dwarf.loc[i] = DWARF_NULL_LOC;
 
           c->dwarf.loc[EBP] = ebp_loc;
+          c->dwarf.loc[ESP] = esp_loc;
           c->dwarf.loc[EIP] = eip_loc;
           c->dwarf.use_prev_instr = 1;
         }

--- a/src/x86_64/Gos-freebsd.c
+++ b/src/x86_64/Gos-freebsd.c
@@ -133,6 +133,7 @@ x86_64_handle_signal_frame (unw_cursor_t *cursor)
     c->dwarf.loc[RCX] = c->dwarf.loc[R10];
     /*  rsp_loc = DWARF_LOC(c->dwarf.cfa - 8, 0);       */
     /*  rbp_loc = c->dwarf.loc[RBP];                    */
+    c->dwarf.loc[RSP] = DWARF_VAL_LOC (c, c->dwarf.cfa + 8);
     c->dwarf.loc[RIP] = DWARF_LOC (c->dwarf.cfa, 0);
     ret = dwarf_get (&c->dwarf, c->dwarf.loc[RIP], &c->dwarf.ip);
     Debug (1, "Frame Chain [RIP=0x%Lx] = 0x%Lx\n",

--- a/src/x86_64/Gregs.c
+++ b/src/x86_64/Gregs.c
@@ -79,7 +79,6 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
       break;
 
     case UNW_X86_64_CFA:
-    case UNW_X86_64_RSP:
       if (write)
         return -UNW_EREADONLYREG;
       *valp = c->dwarf.cfa;
@@ -107,6 +106,7 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
     case UNW_X86_64_RCX: loc = c->dwarf.loc[RCX]; break;
     case UNW_X86_64_RBX: loc = c->dwarf.loc[RBX]; break;
 
+    case UNW_X86_64_RSP: loc = c->dwarf.loc[RSP]; break;
     case UNW_X86_64_RBP: loc = c->dwarf.loc[RBP]; break;
     case UNW_X86_64_RSI: loc = c->dwarf.loc[RSI]; break;
     case UNW_X86_64_RDI: loc = c->dwarf.loc[RDI]; break;

--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -223,7 +223,7 @@ unw_step (unw_cursor_t *cursor)
                   Debug (2, "RIP fixup didn't work, falling back\n");
                   unw_word_t rbp1 = 0;
                   rbp_loc = DWARF_LOC(rbp, 0);
-                  rsp_loc = DWARF_NULL_LOC;
+                  rsp_loc = DWARF_VAL_LOC(c, rbp + 16);
                   rip_loc = DWARF_LOC (rbp + 8, 0);
                   ret = dwarf_get (&c->dwarf, rbp_loc, &rbp1);
                   Debug (1, "[RBP=0x%lx] = 0x%lx (cfa = 0x%lx) -> 0x%lx\n",


### PR DESCRIPTION
This commit is by @Keno. We've been using it as a local patch for Julia (available [here](https://github.com/JuliaLang/julia/commit/55d7571a5dc2686c98a804d95ba36f5548f53f18)), applied to libunwind 1.3.2. I've adapted it to current libunwind master, hopefully correctly.

> RSP and CFA are different concepts. RSP refers to the physical register, CFA is a virtual register that serves as the base address for various other saved registers. It is true that in many frames these are set to alias, however this is not a requirement. For example, a function that performs a stack switch would likely change the rsp in the middle of the function, but would keep the CFA at the original RSP such that saved registers may be appropriately recovered.
>
> We are seeing incorrect unwinds in the Julia runtime when running julia under rr. This is because injects code (with correct CFI) that performs just such a stack switch [1]. GDB manages to unwind this correctly, but libunwind incorrectly sets the rsp to the CFA address, causing a misunwind.
>
> Tested on x86_64, patches for other architectures are ported, but not tested.
>
> [1] https://github.com/rr-debugger/rr/blob/469c22059a4a1798d33a8a224457faf22b2c178c/src/preload/syscall_hook.S#L454