### PR TITLE
Prefer EXTBL unwinding on ARM

### DIFF
--- a/include/tdep-arm/libunwind_i.h
+++ b/include/tdep-arm/libunwind_i.h
@@ -256,6 +256,7 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
 #define tdep_init_done                  UNW_OBJ(init_done)
 #define tdep_init                       UNW_OBJ(init)
 #define arm_find_proc_info              UNW_OBJ(find_proc_info)
+#define arm_find_proc_info2             UNW_OBJ(find_proc_info2)
 #define arm_put_unwind_info             UNW_OBJ(put_unwind_info)
 /* Platforms that support UNW_INFO_FORMAT_TABLE need to define
    tdep_search_unwind_table.  */
@@ -297,6 +298,9 @@ extern void tdep_init (void);
 extern int arm_find_proc_info (unw_addr_space_t as, unw_word_t ip,
                                unw_proc_info_t *pi, int need_unwind_info,
                                void *arg);
+extern int arm_find_proc_info2 (unw_addr_space_t as, unw_word_t ip,
+                                unw_proc_info_t *pi, int need_unwind_info,
+                                void *arg, int methods);
 extern void arm_put_unwind_info (unw_addr_space_t as,
                                   unw_proc_info_t *pi, void *arg);
 extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,

--- a/src/arm/Gex_tables.c
+++ b/src/arm/Gex_tables.c
@@ -506,18 +506,20 @@ arm_phdr_cb (struct dl_phdr_info *info, size_t size, void *data)
 }
 
 HIDDEN int
-arm_find_proc_info (unw_addr_space_t as, unw_word_t ip,
-                    unw_proc_info_t *pi, int need_unwind_info, void *arg)
+arm_find_proc_info2 (unw_addr_space_t as, unw_word_t ip,
+                     unw_proc_info_t *pi, int need_unwind_info, void *arg,
+                     int methods)
 {
   int ret = -1;
   intrmask_t saved_mask;
 
   Debug (14, "looking for IP=0x%lx\n", (long) ip);
 
-  if (UNW_TRY_METHOD(UNW_ARM_METHOD_DWARF))
+  if (UNW_TRY_METHOD (UNW_ARM_METHOD_DWARF) && (methods & UNW_ARM_METHOD_DWARF))
     ret = dwarf_find_proc_info (as, ip, pi, need_unwind_info, arg);
 
-  if (ret < 0 && UNW_TRY_METHOD (UNW_ARM_METHOD_EXIDX))
+  if (ret < 0 && UNW_TRY_METHOD (UNW_ARM_METHOD_EXIDX) &&
+      (methods & UNW_ARM_METHOD_EXIDX))
     {
       struct arm_cb_data cb_data;
 
@@ -538,6 +540,14 @@ arm_find_proc_info (unw_addr_space_t as, unw_word_t ip,
     }
 
   return ret;
+}
+
+HIDDEN int
+arm_find_proc_info (unw_addr_space_t as, unw_word_t ip,
+                    unw_proc_info_t *pi, int need_unwind_info, void *arg)
+{
+    return arm_find_proc_info2 (as, ip, pi, need_unwind_info, arg,
+                                UNW_ARM_METHOD_ALL);
 }
 
 HIDDEN void


### PR DESCRIPTION
This commit is by @yuyichao. We've been using it as a local patch for Julia (available [here](https://github.com/JuliaLang/julia/commit/8624e4ad9a5a4717ecd169899090ccdf5f8a5aed#diff-5e23f944dcfb9e5b600d942c6c3dba6b24ec73e638741ec3cc192cfdefb29c5d)) since 2016, currently applied to libunwind 1.3.2. I've adapted it to current libunwind master, hopefully correctly.

> It is part of the C++ ABI so a EXTBL unwind info that's not `CANT_UNWIND` should always be reliable/correct. Ignore `ESTOPUNWIND` so that a `CANT_UNWIND` info can fallback to unwinding using the debug info instead.