### PR TITLE
Correct some issues in documentation

### DIFF
--- a/doc/libunwind-dynamic.man
+++ b/doc/libunwind-dynamic.man
@@ -1,5 +1,5 @@
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:44 MDT 2007
+.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +10,7 @@
 
 .fi
 ..
-.TH "LIBUNWIND\-DYNAMIC" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "LIBUNWIND\-DYNAMIC" "3" "29 August 2021" "Programming Library " "Programming Library "
 .SH NAME
 libunwind\-dynamic
 \-\- libunwind\-support for runtime\-generated code 
@@ -84,7 +84,7 @@ once the stack\-pointer is restored, all values saved in the
 deallocated portion of the stack frame become invalid and hence 
 libunwind
 needs to know about it. The portion of the frame 
-state not saved on the stack is assume to remain valid through the end 
+state not saved on the stack is assumed to remain valid through the end 
 of the region. For this reason, there is usually no need to describe 
 instructions which restore the contents of callee\-saved registers. 
 .PP
@@ -137,7 +137,7 @@ bytes).
 .TP
 unw_word_t gp
  The global\-pointer value in use 
-for this procedure. The exact meaing of the global\-pointer is 
+for this procedure. The exact meaning of the global\-pointer is 
 architecture\-specific and on some architecture, it is not used at 
 all. 
 .TP
@@ -184,7 +184,7 @@ members:
 unw_word_t name_ptr
  The address of a 
 (human\-readable) name of the procedure or 0 if no such name is 
-available. If non\-zero, The string stored at this address must be 
+available. If non\-zero, the string stored at this address must be 
 ASCII NUL terminated. For source languages that use name\-mangling 
 (such as C++ or Java) the string stored at this address should be 
 the \fIdemangled\fP
@@ -216,7 +216,7 @@ descriptors\&'' below for more details.
 .PP
 This format is generally used when the dynamically generated code was 
 derived from static code and the unwind\-info for the dynamic and the 
-static versions is identical. For example, this format can be useful 
+static versions are identical. For example, this format can be useful 
 when loading statically\-generated code into an address\-space in a 
 non\-standard fashion (i.e., through some means other than 
 dlopen()).
@@ -228,7 +228,7 @@ This structure contains the following members:
 unw_word_t name_ptr
  The address of a 
 (human\-readable) name of the procedure or 0 if no such name is 
-available. If non\-zero, The string stored at this address must be 
+available. If non\-zero, the string stored at this address must be 
 ASCII NUL terminated. For source languages that use name\-mangling 
 (such as C++ or Java) the string stored at this address should be 
 the \fIdemangled\fP
@@ -287,7 +287,7 @@ loaded from remote memory.
 .PP
 A region descriptor is a variable length structure that describes how 
 each instruction in the region affects the frame state. Of course, 
-most instructions in a region usualy do not change the frame state and 
+most instructions in a region usually do not change the frame state and 
 for those, nothing needs to be recorded in the region descriptor. A 
 region descriptor is a structure of type 
 unw_dyn_region_info_t
@@ -381,7 +381,7 @@ values described below.
 int8_t qp
  The qualifying predicate that controls 
 whether or not this directive is active. This is useful for 
-predicated architecturs such as IA\-64 or ARM, where the contents of 
+predicated architectures such as IA\-64 or ARM, where the contents of 
 another (callee\-saved) register determines whether or not an 
 instruction is executed (takes effect). If the directive is always 
 active, this member should be set to the manifest constant 
@@ -429,7 +429,7 @@ sorted, it is recommended that such implementations first check
 whether the list happens to be sorted already and, if not, sort the 
 directives explicitly before the first use. With this approach, the 
 overhead of explicit sorting is only paid when there is a real benefit 
-and if the runtime code\-generator happens to generated sorted lists 
+and if the runtime code\-generator happens to generate sorted lists 
 naturally, the performance penalty is limited to a simple O(N) check. 
 .PP
 .SS OPERATIONS TAGS

--- a/doc/libunwind-dynamic.tex
+++ b/doc/libunwind-dynamic.tex
@@ -64,7 +64,7 @@ gets restored.  The reason this point needs to be described is that
 once the stack-pointer is restored, all values saved in the
 deallocated portion of the stack frame become invalid and hence
 \Prog{libunwind} needs to know about it.  The portion of the frame
-state not saved on the stack is assume to remain valid through the end
+state not saved on the stack is assumed to remain valid through the end
 of the region.  For this reason, there is usually no need to describe
 instructions which restore the contents of callee-saved registers.
 
@@ -101,7 +101,7 @@ structure as the sole argument.  The members of the
   \Var{end\_ip}-\Var{start\_ip} is the size of the procedure in
   bytes).
 \item[\Type{unw\_word\_t} \Var{gp}] The global-pointer value in use
-  for this procedure.  The exact meaing of the global-pointer is
+  for this procedure.  The exact meaning of the global-pointer is
   architecture-specific and on some architecture, it is not used at
   all.
 \item[\Type{int32\_t} \Var{format}] The format of the unwind-info.
@@ -132,7 +132,7 @@ members:
 
 \item[\Type{unw\_word\_t} \Var{name\_ptr}] The address of a
   (human-readable) name of the procedure or 0 if no such name is
-  available.  If non-zero, The string stored at this address must be
+  available.  If non-zero, the string stored at this address must be
   ASCII NUL terminated.  For source languages that use name-mangling
   (such as C++ or Java) the string stored at this address should be
   the \emph{demangled} version of the name.
@@ -158,7 +158,7 @@ members:
 
 This format is generally used when the dynamically generated code was
 derived from static code and the unwind-info for the dynamic and the
-static versions is identical.  For example, this format can be useful
+static versions are identical.  For example, this format can be useful
 when loading statically-generated code into an address-space in a
 non-standard fashion (i.e., through some means other than
 \Func{dlopen}()).  In this format, the details of a group of procedures
@@ -168,7 +168,7 @@ This structure contains the following members:
 
 \item[\Type{unw\_word\_t} \Var{name\_ptr}] The address of a
   (human-readable) name of the procedure or 0 if no such name is
-  available.  If non-zero, The string stored at this address must be
+  available.  If non-zero, the string stored at this address must be
   ASCII NUL terminated.  For source languages that use name-mangling
   (such as C++ or Java) the string stored at this address should be
   the \emph{demangled} version of the name.
@@ -214,7 +214,7 @@ loaded from remote memory.
 
 A region descriptor is a variable length structure that describes how
 each instruction in the region affects the frame state.  Of course,
-most instructions in a region usualy do not change the frame state and
+most instructions in a region usually do not change the frame state and
 for those, nothing needs to be recorded in the region descriptor.  A
 region descriptor is a structure of type
 \Type{unw\_dyn\_region\_info\_t} and has the following members:
@@ -278,7 +278,7 @@ structure has the following members:
   of the \Type{unw\_dyn\_operation\_t} values described below.
 \item[\Type{int8\_t} \Var{qp}] The qualifying predicate that controls
   whether or not this directive is active.  This is useful for
-  predicated architecturs such as IA-64 or ARM, where the contents of
+  predicated architectures such as IA-64 or ARM, where the contents of
   another (callee-saved) register determines whether or not an
   instruction is executed (takes effect).  If the directive is always
   active, this member should be set to the manifest constant
@@ -315,7 +315,7 @@ sorted, it is recommended that such implementations first check
 whether the list happens to be sorted already and, if not, sort the
 directives explicitly before the first use.  With this approach, the
 overhead of explicit sorting is only paid when there is a real benefit
-and if the runtime code-generator happens to generated sorted lists
+and if the runtime code-generator happens to generate sorted lists
 naturally, the performance penalty is limited to a simple O(N) check.
 
 \subsection{Operations tags}

--- a/doc/libunwind.man
+++ b/doc/libunwind.man
@@ -1,5 +1,5 @@
 '\" t
-.\" Manual page created with latex2man on Thu Jan 12 06:50:29 PST 2017
+.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +10,7 @@
 
 .fi
 ..
-.TH "LIBUNWIND" "3" "12 January 2017" "Programming Library " "Programming Library "
+.TH "LIBUNWIND" "3" "29 August 2021" "Programming Library " "Programming Library "
 .SH NAME
 libunwind
 \-\- a (mostly) platform\-independent unwind API 
@@ -215,8 +215,9 @@ frame as the only argument.
 Normally, libunwind
 supports both local and remote unwinding 
 (the latter will be explained in the next section). However, if you 
-tell libunwind that your program only needs local unwinding, then a 
-special implementation can be selected which may run much faster than 
+tell libunwind
+that your program only needs local unwinding, then 
+a special implementation can be selected which may run much faster than 
 the generic implementation which supports both kinds of unwinding. To 
 select this optimized version, simply define the macro 
 UNW_LOCAL_ONLY
@@ -357,7 +358,7 @@ targeting a cross\-platform will result in a link\-time error
 All libunwind
 routines are thread\-safe. What this means is 
 that multiple threads may use libunwind
-simulatenously. 
+simultaneously. 
 However, any given cursor may be accessed by only one thread at 
 any given time. 
 .PP
@@ -431,11 +432,11 @@ select the exact caching policy in use for a given address\-space
 object. In particular, by selecting the policy 
 UNW_CACHE_NONE,
 it is possible to turn off caching 
-completely, therefore eliminating the risk of stale data alltogether 
+completely, therefore eliminating the risk of stale data altogether 
 (at the cost of slower execution). By default, caching is enabled for 
 local unwinding only. The cache size can be dynamically changed with 
 unw_set_cache_size(),
-which also fluches the current cache. 
+which also flushes the current cache. 
 .PP
 .SH FILES
 

--- a/doc/libunwind.tex
+++ b/doc/libunwind.tex
@@ -128,8 +128,8 @@ frame as the only argument.
 
 Normally, \Prog{libunwind} supports both local and remote unwinding
 (the latter will be explained in the next section).  However, if you
-tell libunwind that your program only needs local unwinding, then a
-special implementation can be selected which may run much faster than
+tell \Prog{libunwind} that your program only needs local unwinding, then
+a special implementation can be selected which may run much faster than
 the generic implementation which supports both kinds of unwinding.  To
 select this optimized version, simply define the macro
 \Const{UNW\_LOCAL\_ONLY} before including the headerfile
@@ -238,7 +238,7 @@ targeting a cross-platform will result in a link-time error
 
 
 All \Prog{libunwind} routines are thread-safe.  What this means is
-that multiple threads may use \Prog{libunwind} simulatenously.
+that multiple threads may use \Prog{libunwind} simultaneously.
 However, any given cursor may be accessed by only one thread at
 any given time.
 
@@ -293,10 +293,10 @@ entire address space, if desired).  This functionality is provided by
 select the exact caching policy in use for a given address-space
 object.  In particular, by selecting the policy
 \Const{UNW\_CACHE\_NONE}, it is possible to turn off caching
-completely, therefore eliminating the risk of stale data alltogether
+completely, therefore eliminating the risk of stale data altogether
 (at the cost of slower execution).  By default, caching is enabled for
 local unwinding only.  The cache size can be dynamically changed with
-\Func{unw\_set\_cache\_size}(), which also fluches the current cache.
+\Func{unw\_set\_cache\_size}(), which also flushes the current cache.
 
 
 \section{Files}

--- a/doc/unw_backtrace.man
+++ b/doc/unw_backtrace.man
@@ -1,5 +1,5 @@
 '\" t
-.\" Manual page created with latex2man on Fri Aug 31 13:39:04 EEST 2012
+.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +10,7 @@
 
 .fi
 ..
-.TH "UNW\\_BACKTRACE" "3" "31 August 2012" "Programming Library " "Programming Library "
+.TH "UNW\\_BACKTRACE" "3" "29 August 2021" "Programming Library " "Programming Library "
 .SH NAME
 unw_backtrace
 \-\- return backtrace for the calling program 
@@ -44,7 +44,7 @@ addresses in the array
 pointed by buffer\&.
 The routine is only available for local unwinding. 
 .PP
-Note that many (but not all) systems provide practically identical function 
+Note that many (but not all) systems provide a practically identical function 
 called backtrace().
 The prototype for this function is usually obtained 
 by including the <execinfo.h>

--- a/doc/unw_backtrace.tex
+++ b/doc/unw_backtrace.tex
@@ -24,7 +24,7 @@
 the calling program. The routine fills up to \Var{size} addresses in the array
 pointed by \Var{buffer}. The routine is only available for local unwinding.
 
-Note that many (but not all) systems provide practically identical function
+Note that many (but not all) systems provide a practically identical function
 called \Func{backtrace}(). The prototype for this function is usually obtained
 by including the \File{$<$execinfo.h$>$} header file -- a prototype for
 \Func{backtrace}() is not provided by \Prog{libunwind}. \Prog{libunwind} weakly

--- a/doc/unw_get_proc_info.man
+++ b/doc/unw_get_proc_info.man
@@ -1,5 +1,5 @@
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:44 MDT 2007
+.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +10,7 @@
 
 .fi
 ..
-.TH "UNW\\_GET\\_PROC\\_INFO" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_GET\\_PROC\\_INFO" "3" "29 August 2021" "Programming Library " "Programming Library "
 .SH NAME
 unw_get_proc_info
 \-\- get info on current procedure 
@@ -96,7 +96,7 @@ format
 is equal to UNW_INFO_FORMAT_DYNAMIC\&.
 If the 
 unwind\-info consists of a (target\-specific) unwind table, it is 
-equal to to UNW_INFO_FORMAT_TABLE\&.
+equal to UNW_INFO_FORMAT_TABLE\&.
 All other values are 
 reserved for future use by libunwind\&.
 This member exists 
@@ -138,7 +138,7 @@ may return an undefined value in this member.
 Note that for the purposes of libunwind,
 the code of a 
 procedure is assumed to occupy a single, contiguous range of 
-addresses. For this reason, it is alwas possible to describe the 
+addresses. For this reason, it is always possible to describe the 
 extent of a procedure with the start_ip
 and end_ip
 members. If a single function/routine is split into multiple, 

--- a/doc/unw_get_proc_info.tex
+++ b/doc/unw_get_proc_info.tex
@@ -53,7 +53,7 @@ following members:
   procedure.  If the unwind-info consists of dynamic procedure info,
   \Var{format} is equal to \Const{UNW\_INFO\_FORMAT\_DYNAMIC}.  If the
   unwind-info consists of a (target-specific) unwind table, it is
-  equal to to \Const{UNW\_INFO\_FORMAT\_TABLE}.  All other values are
+  equal to \Const{UNW\_INFO\_FORMAT\_TABLE}.  All other values are
   reserved for future use by \Prog{libunwind}.  This member exists
   for use by the \Func{find\_proc\_info}() call-back (see
   \Func{unw\_create\_addr\_space}(3)).  The
@@ -75,7 +75,7 @@ following members:
 \end{description}
 Note that for the purposes of \Prog{libunwind}, the code of a
 procedure is assumed to occupy a single, contiguous range of
-addresses.  For this reason, it is alwas possible to describe the
+addresses.  For this reason, it is always possible to describe the
 extent of a procedure with the \Var{start\_ip} and \Var{end\_ip}
 members.  If a single function/routine is split into multiple,
 discontiguous pieces, \Prog{libunwind} will treat each piece as a

--- a/doc/unw_get_proc_info_by_ip.man
+++ b/doc/unw_get_proc_info_by_ip.man
@@ -1,5 +1,5 @@
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +10,7 @@
 
 .fi
 ..
-.TH "UNW\\_GET\\_PROC\\_INFO\\_BY\\_IP" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_GET\\_PROC\\_INFO\\_BY\\_IP" "3" "29 August 2021" "Programming Library " "Programming Library "
 .SH NAME
 unw_get_proc_info_by_ip
 \-\- get procedure info by IP 
@@ -42,7 +42,7 @@ even if it is not part of the current call\-chain. However, since it
 is more flexible, it also tends to run slower (and often much slower) 
 than unw_get_proc_info().
 .PP
-The routine expects the followins arguments: as
+The routine expects the following arguments: as
 is the 
 address\-space in which the instruction\-pointer should be looked up. 
 For a look\-up in the local address\-space, 
@@ -68,7 +68,7 @@ argument.
 Note that for the purposes of libunwind,
 the code of a 
 procedure is assumed to occupy a single, contiguous range of 
-addresses. For this reason, it is alwas possible to describe the 
+addresses. For this reason, it is always possible to describe the 
 extent of a procedure with the start_ip
 and end_ip
 members. If a single function/routine is split into multiple, 
@@ -86,7 +86,7 @@ below is returned.
 .SH THREAD AND SIGNAL SAFETY
 
 .PP
-unw_get_proc_info()
+unw_get_proc_info_by_ip()
 is thread\-safe. If the local 
 address\-space is passed in argument as,
 this routine is also 
@@ -108,9 +108,9 @@ UNW_EBADVERSION
  The unwind\-info for the procedure has 
 version or format that is not understood by libunwind\&.
 .PP
-In addition, unw_get_proc_info()
-may return any error 
-returned by the access_mem()
+In addition, unw_get_proc_info_by_ip()
+may return any 
+error returned by the access_mem()
 call\-back (see 
 unw_create_addr_space(3)).
 .PP

--- a/doc/unw_get_proc_info_by_ip.tex
+++ b/doc/unw_get_proc_info_by_ip.tex
@@ -25,7 +25,7 @@ even if it is not part of the current call-chain.  However, since it
 is more flexible, it also tends to run slower (and often much slower)
 than \Func{unw\_get\_proc\_info}().
 
-The routine expects the followins arguments: \Var{as} is the
+The routine expects the following arguments: \Var{as} is the
 address-space in which the instruction-pointer should be looked up.
 For a look-up in the local address-space,
 \Var{unw\_local\_addr\_space} can be passed for this argument.
@@ -41,7 +41,7 @@ argument.
 
 Note that for the purposes of \Prog{libunwind}, the code of a
 procedure is assumed to occupy a single, contiguous range of
-addresses.  For this reason, it is alwas possible to describe the
+addresses.  For this reason, it is always possible to describe the
 extent of a procedure with the \Var{start\_ip} and \Var{end\_ip}
 members.  If a single function/routine is split into multiple,
 discontiguous pieces, \Prog{libunwind} will treat each piece as a
@@ -55,7 +55,7 @@ below is returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_get\_proc\_info}() is thread-safe.  If the local
+\Func{unw\_get\_proc\_info\_by\_ip}() is thread-safe.  If the local
 address-space is passed in argument \Var{as}, this routine is also
 safe to use from a signal handler.
 
@@ -68,8 +68,8 @@ safe to use from a signal handler.
 \item[\Const{UNW\_EBADVERSION}] The unwind-info for the procedure has
   version or format that is not understood by \Prog{libunwind}.
 \end{Description}
-In addition, \Func{unw\_get\_proc\_info}() may return any error
-returned by the \Func{access\_mem}() call-back (see
+In addition, \Func{unw\_get\_proc\_info\_by\_ip}() may return any
+error returned by the \Func{access\_mem}() call-back (see
 \Func{unw\_create\_addr\_space}(3)).
 
 \section{See Also}

--- a/doc/unw_get_proc_name.man
+++ b/doc/unw_get_proc_name.man
@@ -1,5 +1,5 @@
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +10,7 @@
 
 .fi
 ..
-.TH "UNW\\_GET\\_PROC\\_NAME" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_GET\\_PROC\\_NAME" "3" "29 August 2021" "Programming Library " "Programming Library "
 .SH NAME
 unw_get_proc_name
 \-\- get name of current procedure 
@@ -59,7 +59,7 @@ between procedure names and ordinary labels. Furthermore, if symbol
 information has been stripped from a program, procedure names may be 
 completely unavailable or may be limited to those exported via a 
 dynamic symbol table. In such cases, unw_get_proc_name()
-may return the name of a label or a preceeding (nearby) procedure. 
+may return the name of a label or a preceding (nearby) procedure. 
 However, the offset returned through offp
 is always relative to 
 the returned name, which ensures that the value (address) of the 

--- a/doc/unw_get_proc_name.tex
+++ b/doc/unw_get_proc_name.tex
@@ -34,7 +34,7 @@ between procedure names and ordinary labels.  Furthermore, if symbol
 information has been stripped from a program, procedure names may be
 completely unavailable or may be limited to those exported via a
 dynamic symbol table.  In such cases, \Func{unw\_get\_proc\_name}()
-may return the name of a label or a preceeding (nearby) procedure.
+may return the name of a label or a preceding (nearby) procedure.
 However, the offset returned through \Var{offp} is always relative to
 the returned name, which ensures that the value (address) of the
 returned name plus the returned offset will always be equal to the

--- a/doc/unw_init_local.man
+++ b/doc/unw_init_local.man
@@ -1,5 +1,5 @@
 '\" t
-.\" Manual page created with latex2man on Wed Aug 16 12:11:05 PDT 2017
+.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +10,7 @@
 
 .fi
 ..
-.TH "UNW\\_INIT\\_LOCAL" "3" "16 August 2017" "Programming Library " "Programming Library "
+.TH "UNW\\_INIT\\_LOCAL" "3" "29 August 2021" "Programming Library " "Programming Library "
 .SH NAME
 unw_init_local
 \-\- initialize cursor for local unwinding 
@@ -44,11 +44,13 @@ As such, the machine\-state pointed to by
 ctxt
 identifies the initial stack frame at which unwinding 
 starts. The machine\-state is expected to be one provided by a call to 
-unw_getcontext; as such, the instruction pointer may point to the 
-instruction after the last instruction of a function, and libunwind 
-will back\-up the instruction pointer before beginning a walk up the 
-call stack. The machine\-state must remain valid for the duration for 
-which the cursor c
+unw_getcontext();
+as such, the instruction pointer may point to 
+the instruction after the last instruction of a function, and 
+libunwind
+will back\-up the instruction pointer before beginning 
+a walk up the call stack. The machine\-state must remain valid for the 
+duration for which the cursor c
 is in use. 
 .PP
 The unw_init_local()
@@ -66,11 +68,13 @@ including <libunwind.h>,
 whereas unw_init_remote()
 is not. 
 .PP
-If the unw_context_t is known to be a signal frame (i.e., from the 
-third argument in a sigaction handler on linux), 
+If the unw_context_t
+is known to be a signal frame (i.e., 
+from the third argument in a sigaction handler on linux), 
 unw_init_local2()
 should be used for correct initialization 
-on some platforms, passing the UNW_INIT_SIGNAL_FRAME flag. 
+on some platforms, passing the UNW_INIT_SIGNAL_FRAME
+flag. 
 .PP
 .SH RETURN VALUE
 

--- a/doc/unw_init_local.tex
+++ b/doc/unw_init_local.tex
@@ -22,11 +22,11 @@ pointed to by \Var{c} with the machine-state in the context structure
 pointed to by \Var{ctxt}.  As such, the machine-state pointed to by
 \Var{ctxt} identifies the initial stack frame at which unwinding
 starts.  The machine-state is expected to be one provided by a call to
-unw_getcontext; as such, the instruction pointer may point to the
-instruction after the last instruction of a function, and libunwind
-will back-up the instruction pointer before beginning a walk up the
-call stack.  The machine-state must remain valid for the duration for
-which the cursor \Var{c} is in use.
+\Func{unw\_getcontext}(); as such, the instruction pointer may point to
+the instruction after the last instruction of a function, and
+\Prog{libunwind} will back-up the instruction pointer before beginning
+a walk up the call stack.  The machine-state must remain valid for the
+duration for which the cursor \Var{c} is in use.
 
 The \Func{unw\_init\_local}() routine can be used only for unwinding in
 the address space of the current process (i.e., for local unwinding).
@@ -37,10 +37,10 @@ available even when \Const{UNW\_LOCAL\_ONLY} has been defined before
 including \File{$<$libunwind.h$>$}, whereas \Func{unw\_init\_remote}()
 is not.
 
-If the unw_context_t is known to be a signal frame (i.e., from the
-third argument in a sigaction handler on linux),
+If the \Type{unw\_context\_t} is known to be a signal frame (i.e.,
+from the third argument in a sigaction handler on linux),
 \Func{unw\_init\_local2}() should be used for correct initialization
-on some platforms, passing the UNW_INIT_SIGNAL_FRAME flag.
+on some platforms, passing the \Const{UNW\_INIT\_SIGNAL\_FRAME} flag.
 
 \section{Return Value}
 

--- a/doc/unw_reg_states_iterate.man
+++ b/doc/unw_reg_states_iterate.man
@@ -1,5 +1,5 @@
 '\" t
-.\" Manual page created with latex2man on Wed Aug 16 11:09:44 PDT 2017
+.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +10,7 @@
 
 .fi
 ..
-.TH "UNW\\_REG\\_STATES\\_ITERATE" "3" "16 August 2017" "Programming Library " "Programming Library "
+.TH "UNW\\_REG\\_STATES\\_ITERATE" "3" "29 August 2021" "Programming Library " "Programming Library "
 .SH NAME
 unw_reg_states_iterate
 \-\- get register state info on current procedure 
@@ -53,7 +53,7 @@ unw_word_t
 end_ip);
 .PP
 The callback function may be invoked several times for each call of unw_reg_states_iterate\&.
-Each call is associcated with a instruction address range and a set of instructions on how to update register values when returning from the procedure in that address range. For each invocation, the arguments to the callback function are: 
+Each call is associated with an instruction address range and a set of instructions on how to update register values when returning from the procedure in that address range. For each invocation, the arguments to the callback function are: 
 .TP
 void * token
  The token value passed to unw_reg_states_callback\&.

--- a/doc/unw_reg_states_iterate.tex
+++ b/doc/unw_reg_states_iterate.tex
@@ -28,7 +28,7 @@ following definition:
 			\Type{size\_t} \Var{reg\_states\_data\_size},
 			\Type{unw\_word\_t} \Var{start\_ip}, \Type{unw\_word\_t} \Var{end\_ip});
 
-The callback function may be invoked several times for each call of \Func{unw\_reg\_states\_iterate}. Each call is associcated with a instruction address range and a set of instructions on how to update register values when returning from the procedure in that address range.  For each invocation, the arguments to the callback function are:
+The callback function may be invoked several times for each call of \Func{unw\_reg\_states\_iterate}. Each call is associated with an instruction address range and a set of instructions on how to update register values when returning from the procedure in that address range.  For each invocation, the arguments to the callback function are:
 \begin{description}
 \item[\Type{void~*} \Var{token}] The token value passed to \Var{unw\_reg\_states\_callback}. \\
 \item[\Type{void~*} \Var{reg\_states\_data}] A pointer to data about


### PR DESCRIPTION
During a walk-through of the documentation I found a couple of minor issues in the docs.
This PR includes a couple of spelling corrections, fixes of faulty references and added use of the common LaTeX commands.
The PR also includes corresponding regenerated .man-files.

The newest version of latex2man, that the Makefile uses for the generation, seems to create more tags and comments that is not existing in the current docs. To minimize the diff an older latex2man ([v1.24](https://www.informatik-vollmer.de/software/latex2man-1.24.tar.gz)) was used.