### PR TITLE
[GCC pedantic] Fix "error: comma at end of enumerator list" when linking to libunwind

### DIFF
--- a/include/libunwind-aarch64.h
+++ b/include/libunwind-aarch64.h
@@ -168,7 +168,7 @@ typedef enum
 
     UNW_TDEP_IP = UNW_AARCH64_X30,
     UNW_TDEP_SP = UNW_AARCH64_SP,
-    UNW_TDEP_EH = UNW_AARCH64_X0,
+    UNW_TDEP_EH = UNW_AARCH64_X0
 
   }
 aarch64_regnum_t;

--- a/include/libunwind-common.h.in
+++ b/include/libunwind-common.h.in
@@ -101,7 +101,7 @@ unw_caching_policy_t;
 
 typedef enum
   {
-    UNW_INIT_SIGNAL_FRAME = 1,          /* We know this is a signal frame */
+    UNW_INIT_SIGNAL_FRAME = 1           /* We know this is a signal frame */
   }
 unw_init_local2_flags_t;
 

--- a/include/libunwind-dynamic.h
+++ b/include/libunwind-dynamic.h
@@ -77,7 +77,7 @@ typedef enum
     UNW_INFO_FORMAT_TABLE,              /* unw_dyn_table_t */
     UNW_INFO_FORMAT_REMOTE_TABLE,       /* unw_dyn_remote_table_t */
     UNW_INFO_FORMAT_ARM_EXIDX,          /* ARM specific unwind info */
-    UNW_INFO_FORMAT_IP_OFFSET,          /* Like UNW_INFO_FORMAT_REMOTE_TABLE, but
+    UNW_INFO_FORMAT_IP_OFFSET           /* Like UNW_INFO_FORMAT_REMOTE_TABLE, but
                                            table entries are considered
                                            relative to di->start_ip, rather
                                            than di->segbase */


### PR DESCRIPTION
When building a package with `-Werror=pedantic` against libunwind, the build will fail:
```
/home/cmsbuild/jenkins_a/workspace/ib-run-pr-tests/testBuildDir/slc7_aarch64_gcc9/external/libunwind/1.5-fdd3db4a8c586939d8a46938c317cb36/include/libunwind-aarch64.h:161:33: error: comma at end of enumerator list [-Werror=pedantic]
  161 |     UNW_TDEP_EH = UNW_AARCH64_X0,
      |                                 ^
```