### PR TITLE
Fix table indexing in `dwarf_search_unwind_table`

### DIFF
--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -966,7 +966,7 @@ dwarf_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
   if (as == unw_local_addr_space)
     {
       e = lookup (table, table_len, ip - ip_base - di->load_offset);
-      if (e && &e[1] < &table[table_len])
+      if (e && &e[1] < &table[table_len / sizeof (unw_word_t)])
 	last_ip = e[1].start_ip_offset + ip_base + di->load_offset;
       else
 	last_ip = di->end_ip;


### PR DESCRIPTION
`table_len` is used as an index into `table`, assuming it represents the number of entries. However, it is defined as the number of entries multiplied by `sizeof(unw_word_t)`. This is accounted for in other places that use `table_len`, e.g. in `lookup`, which divides out the size of `unw_word_t`, but the indexing expression uses `table_len` directly. So when `table` has say 2 entries, we're actually looking at index 15 rather than 1 in the comparison. This can cause the conditional to erroneously evaluate to true, allowing the following line to segfault.

This was observed with JIT compiled code from Julia with LLVM on FreeBSD. It manifested as https://github.com/JuliaLang/julia/issues/41943. Unfortunately we weren't able to come up with a minimal reproducer, as it happened seemingly sporadically in the Julia tests.

cc @vtjnash 