### PR TITLE
Add more POSIX polyfills for nix cross-build on win

### DIFF
--- a/include/win/sys/mman.h
+++ b/include/win/sys/mman.h
@@ -16,6 +16,7 @@
 #define MAP_PRIVATE          2
 #define PROT_READ            4
 #define PROT_WRITE           8
+#define PROT_EXEC            16
 
 void* mmap(void *, size_t, int, int, int, size_t);
 int   munmap(void *, size_t);

--- a/include/win/sys/stat.h
+++ b/include/win/sys/stat.h
@@ -1,0 +1,35 @@
+// This is an incomplete & imprecice implementation of the Posix
+// standard file by the same name
+
+// Since this is only intended for VC++ compilers
+// use #pragma once instead of guard macros
+#pragma once
+
+#ifdef _MSC_VER // Only for cross compilation to windows
+
+#include <sys/types.h>
+
+#define S_IFMT  00170000
+#define S_IFDIR  0040000
+
+#define S_ISDIR(m)      (((m) & S_IFMT) == S_IFDIR)
+
+struct stat
+{
+    unsigned short st_dev;
+    unsigned short st_ino;
+    unsigned short st_mode;
+    short st_nlink;
+    short st_uid;
+    short st_gid;
+    unsigned short st_rdev;
+    unsigned short st_size;
+    time_t st_atime;
+    time_t st_mtime;
+    time_t st_ctime;
+};
+
+int stat(const char *path, struct stat *buf);
+int fstat(int fd, struct stat *buf);
+
+#endif // _MSC_VER

--- a/src/win/pal-single-threaded.c
+++ b/src/win/pal-single-threaded.c
@@ -13,10 +13,10 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include "libunwind_i.h"
 #include "compiler.h"
-
 
 int getpagesize(void)
 {
@@ -111,4 +111,14 @@ int close(int fd)
 unw_accessors_t * unw_get_accessors_int (unw_addr_space_t as)
 {
     return unw_get_accessors(as);
+}
+
+int stat(const char *path, struct stat *buf)
+{
+    return 0;
+}
+
+int fstat(int fd, struct stat *buf)
+{
+    return 0;
 }


### PR DESCRIPTION
A few definitions required by v1.6.0 were missing in abstraction layer.