### PR TITLE
Skip init_mem_validate calls during remote unwind

### DIFF
--- a/src/aarch64/Gglobal.c
+++ b/src/aarch64/Gglobal.c
@@ -47,9 +47,9 @@ tdep_init (void)
 
     dwarf_init ();
 
+#ifndef UNW_REMOTE_ONLY
     tdep_init_mem_validate ();
 
-#ifndef UNW_REMOTE_ONLY
     aarch64_local_addr_space_init ();
 #endif
     atomic_store(&tdep_init_done, 1); /* signal that we're initialized... */

--- a/src/loongarch64/Gglobal.c
+++ b/src/loongarch64/Gglobal.c
@@ -46,9 +46,9 @@ tdep_init (void)
 
     dwarf_init ();
 
+#ifndef UNW_REMOTE_ONLY
     tdep_init_mem_validate ();
 
-#ifndef UNW_REMOTE_ONLY
     loongarch64_local_addr_space_init ();
 #endif
     tdep_init_done = 1; /* signal that we're initialized... */

--- a/src/riscv/Gglobal.c
+++ b/src/riscv/Gglobal.c
@@ -115,9 +115,10 @@ tdep_init (void)
 
   mi_init ();
   dwarf_init ();
-  tdep_init_mem_validate ();
 
 #ifndef UNW_REMOTE_ONLY
+  tdep_init_mem_validate ();
+
   riscv_local_addr_space_init ();
 #endif
   atomic_store(&tdep_init_done, 1);  /* signal that we're initialized... */

--- a/src/s390x/Gglobal.c
+++ b/src/s390x/Gglobal.c
@@ -89,9 +89,9 @@ tdep_init (void)
 
     dwarf_init ();
 
+#ifndef UNW_REMOTE_ONLY
     tdep_init_mem_validate ();
 
-#ifndef UNW_REMOTE_ONLY
     s390x_local_addr_space_init ();
 #endif
     atomic_store(&tdep_init_done, 1); /* signal that we're initialized... */


### PR DESCRIPTION
This was failing linux arm64 cross build on windows with remote unwinding as `tdep_init_mem_validate` is not defined when `UNW_REMOTE_ONLY` is.

The fix is to simply follow x86_64/Gglobal.c approach:
https://github.com/libunwind/libunwind/blob/4c01eb4107a0cc69bd35a5f3ed70bfb754fdc311/src/x86_64/Gglobal.c#L96-L99