### PR TITLE
skip latex2man check with --disable-documentation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -446,7 +446,7 @@ AC_SUBST(DLLIB)
 AC_SUBST(BACKTRACELIB)
 
 AC_PATH_PROG([LATEX2MAN],[latex2man])
-if test "x$LATEX2MAN" = "x"; then
+if test "x$LATEX2MAN" = "x" && test "x$enable_documentation" = "xyes"; then
   AC_MSG_WARN([latex2man not found. Install latex2man. Disabling docs.])
   enable_documentation="no";
 fi


### PR DESCRIPTION
```sh
autoreconf -i
./configure --disable-documentation
```

was warning `configure: WARNING: latex2man not found. Install latex2man. Disabling docs.`.