### PR TITLE
DWARF: avoid a data race

### DIFF
--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -960,13 +960,11 @@ find_reg_state (struct dwarf_cursor *c, dwarf_state_record_t *sr)
 	  cache->links[c->prev_rs].hint = index + 1;
 	  c->prev_rs = index;
 	}
+      if (ret >= 0)
+        tdep_reuse_frame (c, cache->links[index].signal_frame);
       put_rs_cache (c->as, cache, &saved_mask);
     }
-  if (ret < 0)
-      return ret;
-  if (cache)
-    tdep_reuse_frame (c, cache->links[index].signal_frame);
-  return 0;
+  return ret;
 }
 
 /* The function finds the saved locations and applies the register


### PR DESCRIPTION
This race condition was identified by TSAN.  The following is a
truncated report from TSAN:

~~~
Write of size 1 at ...
  #0 rs_new libunwind/src/dwarf/Gparser.c
  #1 find_reg_state libunwind/src/dwarf/Gparser.c
  ...

Previous read of size 1 at ...
  #0 find_reg_state libunwind/src/dwarf/Gparser.c
  ...
~~~

The cache is accessed via `get_rs_cache` which will acquire the lock,
and then at the end of the second `if (cache)` block, will release the
lock via the `put_rs_cache`.  We subsequently will read the cache entry
for the parameter for `tdep_reuse_frame`.

Rather than hoisting the `tdep_reuse_frame`, we could re-acquire the
lock, however, this seems unnecessary and would increase lock contention
for just the error path handling.

Thanks to @wmi0 for help with this issue.