### PR TITLE
Fix to malloc call in tdep_get_elf_image

### DIFF
--- a/src/os-linux.c
+++ b/src/os-linux.c
@@ -26,6 +26,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <limits.h>
 #include <stdio.h>
 #include <sys/stat.h>
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
 
 #include "libunwind_i.h"
 #include "os-linux.h"
@@ -41,7 +44,8 @@ tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
   char root[sizeof ("/proc/0123456789/root")], *cp;
   char *full_path;
   struct stat st;
-
+  const unsigned long full_path_buff_sz = 1024;
+  char                full_path_buff[full_path_buff_sz];
 
   if (maps_init (&mi, pid) < 0)
     return -1;
@@ -69,7 +73,16 @@ tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
 
   if (!stat(root, &st) && S_ISDIR(st.st_mode))
     {
-      full_path = (char*) malloc (strlen (root) + strlen (mi.path) + 1);
+      unsigned long _len = strlen(root) + strlen(mi.path) + 1;
+      if(_len >= full_path_buff_sz)
+        {
+          full_path = (char*) malloc(_len);
+        }
+      else
+        {
+          snprintf(full_path_buff, full_path_buff_sz, "%s%s", root, mi.path);
+          full_path = &full_path_buff[0];
+        }
       if (!full_path)
         full_path = mi.path;
       else
@@ -85,7 +98,7 @@ tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
     }
   rc = elf_map_image (ei, full_path);
 
-  if (full_path && full_path != mi.path)
+  if (full_path && full_path != mi.path && full_path != &full_path_buff[0])
     free (full_path);
 
   maps_close (&mi);


### PR DESCRIPTION
- call to `malloc` in `get_elf_image` causes (semi-rare) deadlock within a signal handler

Example usage:

```cpp
template <size_t Depth, size_t Offset = 1, bool WFuncOffset = true>
inline auto
get_unw_backtrace()
{
    static_assert(Depth > 0, "Error !(Depth > 0)");
    static_assert(Offset >= 0, "Error !(Offset >= 0)");

    unw_cursor_t  cursor{};
    unw_context_t context{};

    // destination
    std::array<char[512], Depth> btrace{};
    for(auto& itr : btrace)
        itr[0] = '\0';

    // Initialize cursor to current frame for local unwinding.
    unw_getcontext(&context);
    if(unw_init_local(&cursor, &context) < 0)
    {
        return btrace;
    }

    size_t tot_idx = 0;
    while(unw_step(&cursor) > 0)
    {
        unw_word_t ip{};   // stack pointer
        unw_word_t off{};  // offset
        auto       _idx = ++tot_idx;
        if(_idx >= Depth + Offset)
            break;
        unw_get_reg(&cursor, UNW_REG_IP, &ip);
        if(ip == 0)
            break;
        constexpr size_t NameSize = (WFuncOffset) ? 496 : 512;
        char             name[NameSize];
        name[0] = '\0';
        if(unw_get_proc_name(&cursor, name, sizeof(name), &off) == 0)
        {
            if(_idx >= Offset)
            {
                auto _lidx = _idx - Offset;
                if(WFuncOffset && off != 0)
                    snprintf(btrace[_lidx], sizeof(btrace[_lidx]), "%s +0x%lx", name,
                             (long) off);
                else
                    snprintf(btrace[_lidx], sizeof(btrace[_lidx]), "%s", name);
            }
        }
    }
    return btrace;
}

void handler(int)
{
    auto _backtrace = get_unw_backtrace<64, 1, false>();
    // ... etc. ...
}
```