### PR TITLE
Make some structs non-empty

### DIFF
--- a/include/libunwind-aarch64.h
+++ b/include/libunwind-aarch64.h
@@ -37,11 +37,7 @@ extern "C" {
 #include <stdalign.h>
 
 #ifndef UNW_EMPTY_STRUCT
-#  ifdef __GNUC__
-#    define UNW_EMPTY_STRUCT
-#  else
-#    define UNW_EMPTY_STRUCT uint8_t unused;
-#  endif
+#  define UNW_EMPTY_STRUCT uint8_t unused;
 #endif
 
 #define UNW_TARGET      aarch64

--- a/include/libunwind-arm.h
+++ b/include/libunwind-arm.h
@@ -33,11 +33,7 @@ extern "C" {
 #include <stddef.h>
 
 #ifndef UNW_EMPTY_STRUCT
-#  ifdef __GNUC__
-#    define UNW_EMPTY_STRUCT
-#  else
-#    define UNW_EMPTY_STRUCT uint8_t unused;
-#  endif
+#  define UNW_EMPTY_STRUCT uint8_t unused;
 #endif
 
 #define UNW_TARGET      arm

--- a/include/libunwind-x86.h
+++ b/include/libunwind-x86.h
@@ -158,6 +158,7 @@ x86_regnum_t;
 typedef struct unw_tdep_save_loc
   {
     /* Additional target-dependent info on a save location.  */
+    char unused;
   }
 unw_tdep_save_loc_t;
 
@@ -169,6 +170,7 @@ typedef ucontext_t unw_tdep_context_t;
 typedef struct
   {
     /* no x86-specific auxiliary proc-info */
+    char unused;
   }
 unw_tdep_proc_info_t;
 

--- a/include/libunwind-x86.h
+++ b/include/libunwind-x86.h
@@ -34,6 +34,10 @@ extern "C" {
 #include <inttypes.h>
 #include <ucontext.h>
 
+#ifndef UNW_EMPTY_STRUCT
+#  define UNW_EMPTY_STRUCT uint8_t unused;
+#endif
+
 #define UNW_TARGET      x86
 #define UNW_TARGET_X86  1
 
@@ -158,7 +162,7 @@ x86_regnum_t;
 typedef struct unw_tdep_save_loc
   {
     /* Additional target-dependent info on a save location.  */
-    char unused;
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_save_loc_t;
 
@@ -170,7 +174,7 @@ typedef ucontext_t unw_tdep_context_t;
 typedef struct
   {
     /* no x86-specific auxiliary proc-info */
-    char unused;
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_proc_info_t;
 


### PR DESCRIPTION
GCC shows warnings like this when compiling libraries or programs linking to
libunwind:

```
/buildworker/worker/package_linuxaarch64/build/usr/include/libunwind-aarch64.h:60:9: warning: empty struct has size 0 in C, size 1 in C++ [-Wc++-compat]
 typedef struct
         ^~~~~~
/buildworker/worker/package_linuxaarch64/build/usr/include/libunwind-aarch64.h:169:16: warning: empty struct has size 0 in C, size 1 in C++ [-Wc++-compat]
 typedef struct unw_tdep_save_loc
                ^~~~~~~~~~~~~~~~~
```

The pattern of using a dummy field is already used in other platforms.

CC: @vtjnash 