### PR TITLE
Fix Travis CI link

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 # libunwind
 
-[![Build Status](https://travis-ci.org/libunwind/libunwind.svg?branch=master)](https://travis-ci.org/libunwind/libunwind)
+[![Build Status](https://api.travis-ci.com/libunwind/libunwind.svg?branch=master)](https://app.travis-ci.com/github/libunwind/libunwind)
 
 This library supports several architecture/operating-system combinations:
 


### PR DESCRIPTION
Travis has moved from .org to .com and the auto-redirect 404s, so update the links.