### PR TITLE
Use #if defined where applicable

### DIFF
--- a/src/ptrace/_UPT_access_fpreg.c
+++ b/src/ptrace/_UPT_access_fpreg.c
@@ -26,7 +26,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "_UPT_internal.h"
 
-#if HAVE_DECL_PTRACE_POKEUSER || HAVE_TTRACE
+#if HAVE_DECL_PTRACE_POKEUSER || defined(HAVE_TTRACE)
 int
 _UPT_access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
                    int write, void *arg)

--- a/src/ptrace/_UPT_access_mem.c
+++ b/src/ptrace/_UPT_access_mem.c
@@ -26,7 +26,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "_UPT_internal.h"
 
-#if HAVE_DECL_PTRACE_POKEDATA || HAVE_TTRACE
+#if HAVE_DECL_PTRACE_POKEDATA || defined(HAVE_TTRACE)
 int
 _UPT_access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val,
                  int write, void *arg)

--- a/src/ptrace/_UPT_access_reg.c
+++ b/src/ptrace/_UPT_access_reg.c
@@ -77,7 +77,7 @@ badreg:
   Debug (1, "bad register %s [%u] (error: %s)\n", unw_regname(reg), reg, strerror (errno));
   return -UNW_EBADREG;
 }
-#elif HAVE_DECL_PTRACE_POKEUSER || HAVE_TTRACE
+#elif HAVE_DECL_PTRACE_POKEUSER || defined(HAVE_TTRACE)
 int
 _UPT_access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val,
                  int write, void *arg)


### PR DESCRIPTION
In all places except these three, we are using `#ifdef HAVE_TTRACE` or `#if defined(HAVE_TTRACE)`, implying config file must have `#define HAVE_TTRACE` rather than `#define HAVE_TTRACE 0 // or 1`.