### PR TITLE
Run make check on arm64 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,23 @@ linux-s390x: &linux-s390x
     - ulimit -c unlimited
     - make check -j32
 
+linux-arm64: &linux-arm64
+  dist: focal
+  arch: arm64-graviton2
+  group: edge
+  virt: vm
+  env: OPT=-O2
+  script:
+    - |
+      CFLAGS="$OPT"
+      CXXFLAGS="$OPT"
+      export CFLAGS CXXFLAGS
+    - autoreconf -i
+    - ./configure
+    - make -j32
+    - ulimit -c unlimited
+    - make check -j32
+
 windows-remote-only: &windows-remote-only
   os: windows
   compiler: msvc
@@ -82,3 +99,4 @@ jobs:
       env: WINHOST=Win32 TARGET=arm-linux-gnueabihf
     - <<: *windows-remote-only
       env: WINHOST=x64 TARGET=aarch64-linux-gnu
+    - <<: *linux-arm64


### PR DESCRIPTION
Hi,

Is there any interest in running the tests on Arm? I'm not sure if the intent is to continue using Travis because of the OSS changes, and I see Libunwind has run out of credits as well. But if you do continue it would be nice to run on Arm.

At the moment there are 7 failures, see here for a test run of this change: https://app.travis-ci.com/github/James-A-Clark/libunwind/jobs/565094337. If this is merged I will start looking into them. Likely they are test issues rather than bugs but I haven't looked too closely yet.

Thanks
James