### PR TITLE
avoid leaking registers across sigreturn

### DIFF
--- a/src/aarch64/Gstep.c
+++ b/src/aarch64/Gstep.c
@@ -55,7 +55,7 @@ static int
 aarch64_handle_signal_frame (unw_cursor_t *cursor)
 {
   struct cursor *c = (struct cursor *) cursor;
-  int ret;
+  int i, ret;
   unw_word_t sc_addr, sp, sp_addr = c->dwarf.cfa;
   struct dwarf_loc sp_loc = DWARF_LOC (sp_addr, 0);
 
@@ -81,6 +81,9 @@ aarch64_handle_signal_frame (unw_cursor_t *cursor)
   c->sigcontext_addr = sc_addr;
   c->frame_info.frame_type = UNW_AARCH64_FRAME_SIGRETURN;
   c->frame_info.cfa_reg_offset = sc_addr - sp_addr;
+
+  for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
+    c->dwarf.loc[i] = DWARF_NULL_LOC;
 
   /* Update the dwarf cursor.
      Set the location of the registers to the corresponding addresses of the

--- a/src/arm/Gos-freebsd.c
+++ b/src/arm/Gos-freebsd.c
@@ -38,7 +38,7 @@ HIDDEN int
 arm_handle_signal_frame (unw_cursor_t *cursor)
 {
   struct cursor *c = (struct cursor *) cursor;
-  int ret, fmt;
+  int i, ret, fmt;
   unw_word_t sc_addr, sp, sp_addr = c->dwarf.cfa;
   struct dwarf_loc sp_loc = DWARF_LOC (sp_addr, 0);
 
@@ -69,6 +69,9 @@ arm_handle_signal_frame (unw_cursor_t *cursor)
   c->sigcontext_addr = sc_addr;
   c->frame_info.frame_type = UNW_ARM_FRAME_SIGRETURN;
   c->frame_info.cfa_reg_offset = sc_addr - sp_addr;
+
+  for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
+    c->dwarf.loc[i] = DWARF_NULL_LOC;
 
   /* Update the dwarf cursor.
      Set the location of the registers to the corresponding addresses of the

--- a/src/arm/Gos-linux.c
+++ b/src/arm/Gos-linux.c
@@ -33,7 +33,7 @@ HIDDEN int
 arm_handle_signal_frame (unw_cursor_t *cursor)
 {
   struct cursor *c = (struct cursor *) cursor;
-  int ret;
+  int i, ret;
   unw_word_t sc_addr, sp, sp_addr = c->dwarf.cfa;
   struct dwarf_loc sp_loc = DWARF_LOC (sp_addr, 0);
 
@@ -92,6 +92,9 @@ arm_handle_signal_frame (unw_cursor_t *cursor)
   c->sigcontext_addr = sc_addr;
   c->frame_info.frame_type = UNW_ARM_FRAME_SIGRETURN;
   c->frame_info.cfa_reg_offset = sc_addr - sp_addr;
+
+  for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
+    c->dwarf.loc[i] = DWARF_NULL_LOC;
 
   /* Update the dwarf cursor.
      Set the location of the registers to the corresponding addresses of the

--- a/src/loongarch64/Gstep.c
+++ b/src/loongarch64/Gstep.c
@@ -33,7 +33,7 @@ loongarch64_handle_signal_frame (unw_cursor_t *cursor)
   struct cursor *c = (struct cursor *) cursor;
   unw_word_t sc_addr, sp_addr = c->dwarf.cfa;
   unw_word_t ra, fp;
-  int ret;
+  int i, ret;
 
   if (unw_is_signal_frame (cursor)) {
     sc_addr = sp_addr + LINUX_SF_TRAMP_SIZE + sizeof (siginfo_t) +
@@ -50,6 +50,9 @@ loongarch64_handle_signal_frame (unw_cursor_t *cursor)
   c->sigcontext_sp = c->dwarf.cfa;
   c->sigcontext_pc = c->dwarf.ip;
   c->sigcontext_format = LOONGARCH64_SCF_LINUX_RT_SIGFRAME;
+
+  for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
+    c->dwarf.loc[i] = DWARF_NULL_LOC;
 
     /* Update the dwarf cursor.
      Set the location of the registers to the corresponding addresses of the

--- a/src/mips/Gstep.c
+++ b/src/mips/Gstep.c
@@ -32,7 +32,7 @@ mips_handle_signal_frame (unw_cursor_t *cursor)
   struct cursor *c = (struct cursor *) cursor;
   unw_word_t sc_addr, sp_addr = c->dwarf.cfa;
   unw_word_t ra, fp;
-  int ret;
+  int i, ret;
 
   switch (unw_is_signal_frame (cursor)) {
   case 1:
@@ -50,6 +50,9 @@ mips_handle_signal_frame (unw_cursor_t *cursor)
     sc_addr += 4;
 
   c->sigcontext_addr = sc_addr;
+
+  for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
+    c->dwarf.loc[i] = DWARF_NULL_LOC;
 
   /* Update the dwarf cursor. */
   c->dwarf.loc[UNW_MIPS_R0]  = DWARF_LOC (sc_addr + LINUX_SC_R0_OFF, 0);

--- a/src/riscv/Gstep.c
+++ b/src/riscv/Gstep.c
@@ -53,6 +53,9 @@ riscv_handle_signal_frame (unw_cursor_t *cursor)
   return -UNW_EUNSPEC;
 #endif
 
+  for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
+    c->dwarf.loc[i] = DWARF_NULL_LOC;
+
   /* Update the dwarf cursor.
      Set the location of the registers to the corresponding addresses of the
      uc_mcontext / sigcontext structure contents.  */

--- a/src/s390x/Gstep.c
+++ b/src/s390x/Gstep.c
@@ -64,6 +64,9 @@ s390x_handle_signal_frame (unw_cursor_t *cursor)
 
   c->sigcontext_addr = sc_addr;
 
+  for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
+    c->dwarf.loc[i] = DWARF_NULL_LOC;
+
   /* Update the dwarf cursor.
      Set the location of the registers to the corresponding addresses of the
      uc_mcontext / sigcontext structure contents.  */

--- a/src/sh/Gstep.c
+++ b/src/sh/Gstep.c
@@ -31,7 +31,7 @@ static int
 sh_handle_signal_frame (unw_cursor_t *cursor)
 {
   struct cursor *c = (struct cursor *) cursor;
-  int ret;
+  int i, ret;
   unw_word_t sc_addr, sp, sp_addr = c->dwarf.cfa;
   struct dwarf_loc sp_loc = DWARF_LOC (sp_addr, 0);
 
@@ -62,6 +62,9 @@ sh_handle_signal_frame (unw_cursor_t *cursor)
     return -UNW_EUNSPEC;
 
   c->sigcontext_addr = sc_addr;
+
+  for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
+    c->dwarf.loc[i] = DWARF_NULL_LOC;
 
   /* Update the dwarf cursor.
      Set the location of the registers to the corresponding addresses of the

--- a/src/tilegx/Gis_signal_frame.c
+++ b/src/tilegx/Gis_signal_frame.c
@@ -96,6 +96,9 @@ tilegx_handle_signal_frame (unw_cursor_t *cursor)
     C_ABI_SAVE_AREA_SIZE;
   sc_addr = c->sigcontext_addr + LINUX_UC_MCONTEXT_OFF;
 
+  for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
+    c->dwarf.loc[i] = DWARF_NULL_LOC;
+
   /* Update the dwarf cursor.
      Set the location of the registers to the corresponding addresses of the
      uc_mcontext / sigcontext structure contents.  */

--- a/src/x86/Gos-freebsd.c
+++ b/src/x86/Gos-freebsd.c
@@ -124,6 +124,9 @@ x86_handle_signal_frame (unw_cursor_t *cursor)
             return 0;
     }
 
+    for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
+      c->dwarf.loc[i] = DWARF_NULL_LOC;
+
     c->dwarf.loc[EIP] = DWARF_LOC (uc_addr + FREEBSD_UC_MCONTEXT_EIP_OFF, 0);
     c->dwarf.loc[ESP] = DWARF_LOC (uc_addr + FREEBSD_UC_MCONTEXT_ESP_OFF, 0);
     c->dwarf.loc[EAX] = DWARF_LOC (uc_addr + FREEBSD_UC_MCONTEXT_EAX_OFF, 0);

--- a/src/x86/Gos-linux.c
+++ b/src/x86/Gos-linux.c
@@ -73,7 +73,7 @@ HIDDEN int
 x86_handle_signal_frame (unw_cursor_t *cursor)
 {
   struct cursor *c = (struct cursor *) cursor;
-  int ret;
+  int i, ret;
 
   /* c->esp points at the arguments to the handler.  Without
      SA_SIGINFO, the arguments consist of a signal number
@@ -123,6 +123,9 @@ x86_handle_signal_frame (unw_cursor_t *cursor)
       return 0;
     }
 
+  for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
+    c->dwarf.loc[i] = DWARF_NULL_LOC;
+
   c->dwarf.loc[EAX] = DWARF_LOC (sc_addr + LINUX_SC_EAX_OFF, 0);
   c->dwarf.loc[ECX] = DWARF_LOC (sc_addr + LINUX_SC_ECX_OFF, 0);
   c->dwarf.loc[EDX] = DWARF_LOC (sc_addr + LINUX_SC_EDX_OFF, 0);
@@ -130,9 +133,6 @@ x86_handle_signal_frame (unw_cursor_t *cursor)
   c->dwarf.loc[EBP] = DWARF_LOC (sc_addr + LINUX_SC_EBP_OFF, 0);
   c->dwarf.loc[ESI] = DWARF_LOC (sc_addr + LINUX_SC_ESI_OFF, 0);
   c->dwarf.loc[EDI] = DWARF_LOC (sc_addr + LINUX_SC_EDI_OFF, 0);
-  c->dwarf.loc[EFLAGS] = DWARF_NULL_LOC;
-  c->dwarf.loc[TRAPNO] = DWARF_NULL_LOC;
-  c->dwarf.loc[ST0] = DWARF_NULL_LOC;
   c->dwarf.loc[EIP] = DWARF_LOC (sc_addr + LINUX_SC_EIP_OFF, 0);
   c->dwarf.loc[ESP] = DWARF_LOC (sc_addr + LINUX_SC_ESP_OFF, 0);
 

--- a/src/x86_64/Gos-freebsd.c
+++ b/src/x86_64/Gos-freebsd.c
@@ -92,7 +92,7 @@ x86_64_handle_signal_frame (unw_cursor_t *cursor)
 {
   struct cursor *c = (struct cursor *) cursor;
   unw_word_t ucontext;
-  int ret;
+  int i, ret;
 
   if (c->sigcontext_format == X86_64_SCF_FREEBSD_SIGFRAME)
    {
@@ -107,6 +107,9 @@ x86_64_handle_signal_frame (unw_cursor_t *cursor)
        Debug (2, "returning %d\n", ret);
        return ret;
      }
+
+    for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
+      c->dwarf.loc[i] = DWARF_NULL_LOC;
 
     c->dwarf.loc[RAX] = DWARF_LOC (ucontext + UC_MCONTEXT_GREGS_RAX, 0);
     c->dwarf.loc[RDX] = DWARF_LOC (ucontext + UC_MCONTEXT_GREGS_RDX, 0);

--- a/src/x86_64/Gos-solaris.c
+++ b/src/x86_64/Gos-solaris.c
@@ -51,6 +51,7 @@ x86_64_handle_signal_frame (unw_cursor_t *cursor)
 {
   struct cursor *c = (struct cursor *) cursor;
   unw_word_t ucontext = c->dwarf.cfa + sizeof (struct sigframe);
+  int i;
 
   if (c->sigcontext_format != X86_64_SCF_SOLARIS_SIGFRAME)
     return -UNW_EBADFRAME;
@@ -68,6 +69,9 @@ x86_64_handle_signal_frame (unw_cursor_t *cursor)
       Debug (2, "return %d\n", ret);
       return ret;
     }
+
+    for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
+      c->dwarf.loc[i] = DWARF_NULL_LOC;
 
     c->dwarf.loc[RAX] = DWARF_LOC (ucontext + UC_MCONTEXT_GREGS_RAX, 0);
     c->dwarf.loc[RDX] = DWARF_LOC (ucontext + UC_MCONTEXT_GREGS_RDX, 0);

--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -253,7 +253,7 @@ unw_step (unw_cursor_t *cursor)
             }
           /* Mark all registers unsaved */
           for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
-          c->dwarf.loc[i] = DWARF_NULL_LOC;
+            c->dwarf.loc[i] = DWARF_NULL_LOC;
 
           c->dwarf.loc[RBP] = rbp_loc;
           c->dwarf.loc[RSP] = rsp_loc;


### PR DESCRIPTION
Mostly just relevant for fp registers, which are frequently mostly just
ignored otherwise. So I don't think this should change anything noticeable normally, but only for a very unusual unwind.