### PR TITLE
restore FP registers across signals on aarch64

### DIFF
--- a/src/aarch64/Gstep.c
+++ b/src/aarch64/Gstep.c
@@ -122,6 +122,8 @@ aarch64_handle_signal_frame (unw_cursor_t *cursor)
   c->dwarf.loc[UNW_AARCH64_SP]  = DWARF_LOC (sc_addr + LINUX_SC_SP_OFF, 0);
   c->dwarf.loc[UNW_AARCH64_PC]  = DWARF_LOC (sc_addr + LINUX_SC_PC_OFF, 0);
   c->dwarf.loc[UNW_AARCH64_PSTATE]  = DWARF_LOC (sc_addr + LINUX_SC_PSTATE_OFF, 0);
+  for (i = 0; i < 32; ++i)
+    c->dwarf.loc[UNW_AARCH64_V0 + i] = DWARF_LOC (sc_addr + LINUX_SC_V0_OFF + i * 0x10, 0);
 
   /* Set SP/CFA and PC/IP.  */
   dwarf_get (&c->dwarf, c->dwarf.loc[UNW_AARCH64_SP], &c->dwarf.cfa);

--- a/src/aarch64/offsets.h
+++ b/src/aarch64/offsets.h
@@ -47,3 +47,45 @@
 #define LINUX_SC_SP_OFF         0x100
 #define LINUX_SC_PC_OFF         0x108
 #define LINUX_SC_PSTATE_OFF     0x110
+#define LINUX_SC_RESERVED_OFF   0x120
+/* { u32 magic; u32 size; u32 fpsr; u32 fpcr; uint128 vregs[]; } */
+#define LINUX_SC_V0_OFF         (LINUX_SC_RESERVED_OFF + 0x010)
+#define LINUX_SC_V1_OFF         (LINUX_SC_RESERVED_OFF + 0x020)
+#define LINUX_SC_V2_OFF         (LINUX_SC_RESERVED_OFF + 0x030)
+#define LINUX_SC_V3_OFF         (LINUX_SC_RESERVED_OFF + 0x040)
+#define LINUX_SC_V4_OFF         (LINUX_SC_RESERVED_OFF + 0x050)
+#define LINUX_SC_V5_OFF         (LINUX_SC_RESERVED_OFF + 0x060)
+#define LINUX_SC_V6_OFF         (LINUX_SC_RESERVED_OFF + 0x070)
+#define LINUX_SC_V7_OFF         (LINUX_SC_RESERVED_OFF + 0x080)
+#define LINUX_SC_V8_OFF         (LINUX_SC_RESERVED_OFF + 0x090)
+#define LINUX_SC_V9_OFF         (LINUX_SC_RESERVED_OFF + 0x0a0)
+#define LINUX_SC_V10_OFF        (LINUX_SC_RESERVED_OFF + 0x0b0)
+#define LINUX_SC_V11_OFF        (LINUX_SC_RESERVED_OFF + 0x0c0)
+#define LINUX_SC_V12_OFF        (LINUX_SC_RESERVED_OFF + 0x0d0)
+#define LINUX_SC_V13_OFF        (LINUX_SC_RESERVED_OFF + 0x0e0)
+#define LINUX_SC_V14_OFF        (LINUX_SC_RESERVED_OFF + 0x0f0)
+#define LINUX_SC_V15_OFF        (LINUX_SC_RESERVED_OFF + 0x100)
+#define LINUX_SC_V16_OFF        (LINUX_SC_RESERVED_OFF + 0x110)
+#define LINUX_SC_V17_OFF        (LINUX_SC_RESERVED_OFF + 0x120)
+#define LINUX_SC_V18_OFF        (LINUX_SC_RESERVED_OFF + 0x130)
+#define LINUX_SC_V19_OFF        (LINUX_SC_RESERVED_OFF + 0x140)
+#define LINUX_SC_V20_OFF        (LINUX_SC_RESERVED_OFF + 0x150)
+#define LINUX_SC_V21_OFF        (LINUX_SC_RESERVED_OFF + 0x160)
+#define LINUX_SC_V22_OFF        (LINUX_SC_RESERVED_OFF + 0x170)
+#define LINUX_SC_V23_OFF        (LINUX_SC_RESERVED_OFF + 0x180)
+#define LINUX_SC_V24_OFF        (LINUX_SC_RESERVED_OFF + 0x190)
+#define LINUX_SC_V25_OFF        (LINUX_SC_RESERVED_OFF + 0x1a0)
+#define LINUX_SC_V26_OFF        (LINUX_SC_RESERVED_OFF + 0x1b0)
+#define LINUX_SC_V27_OFF        (LINUX_SC_RESERVED_OFF + 0x1c0)
+#define LINUX_SC_V28_OFF        (LINUX_SC_RESERVED_OFF + 0x1d0)
+#define LINUX_SC_V29_OFF        (LINUX_SC_RESERVED_OFF + 0x1e0)
+#define LINUX_SC_V30_OFF        (LINUX_SC_RESERVED_OFF + 0x1f0)
+#define LINUX_SC_V31_OFF        (LINUX_SC_RESERVED_OFF + 0x200)
+/* followed then by:
+ *	size		description
+ *	 0x10		esr_context
+ *	0x8a0		sve_context (vl <= 64) (optional)
+ *	 0x20		extra_context (optional)
+ *	 0x10		terminator (null _aarch64_ctx)
+ * per arm64/include/uapi/asm/sigcontext.h
+ */


### PR DESCRIPTION
It looked like this might be lacking, but straightforward (though likely not common to need
them to be available). Most other platforms also do not restore all of the registers, particularly since instructions like VFP and XSAVE have variable layouts based on the CPU or are undocumented.