### PR TITLE
Fix cross-compilation on win

### DIFF
--- a/include/win/unistd.h
+++ b/include/win/unistd.h
@@ -24,5 +24,8 @@ int          getpagesize(void);
 int          open(const char *, int, ...);
 ssize_t      read(int fd, void *buf, size_t count);
 ssize_t      write(int, const void *, size_t);
+long         sysconf(int name);
+
+#define _SC_PAGESIZE 11
 
 #endif // _MSC_VER

--- a/src/win/pal-single-threaded.c
+++ b/src/win/pal-single-threaded.c
@@ -32,6 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <errno.h>
 #include "libunwind_i.h"
 #include "compiler.h"
 
@@ -40,6 +41,17 @@ int getpagesize(void)
     // 4096 is truth for most targets
     // Unlikely to matter in dump debugging
     return 4096;
+}
+
+long sysconf(int name)
+{
+    if (name == _SC_PAGESIZE)
+    {
+        return getpagesize();
+    }
+
+    errno = EINVAL;
+    return -1;
 }
 
 void* mmap(void *addr, size_t length, int prot, int flags, int fd, size_t offset)

--- a/src/win/pal-single-threaded.c
+++ b/src/win/pal-single-threaded.c
@@ -129,6 +129,13 @@ ssize_t read(int fd, void *buf, size_t count)
     return -1;
 }
 
+ssize_t write(int fd, const void *buf, size_t nbyte)
+{
+    // For dump debugging we shouldn't need to open files
+    // Especially since we didn't implement open()
+    return -1;
+}
+
 int close(int fd)
 {
     // For dump debugging we shouldn't need to open files


### PR DESCRIPTION
* Define sysconf on win for cross-compile
* Add dummy `write` method implementation