### PR TITLE
Allow an alternate LOG_DRIVER to be specified

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -428,6 +428,12 @@ case "$ac_cv_search_backtrace" in
   *) BACKTRACELIB="";;
 esac
 
+AC_ARG_WITH([testdriver],
+            [AS_HELP_STRING([--with-testdriver],
+                            [use designated test driver instead of default LOG_DRIVER])],
+                            [],
+                            [with_testdriver=\$\(top_srcdir\)/config/test-driver])
+AC_SUBST([UNW_TESTDRIVER], $with_testdriver)
 
 AC_SUBST(build_arch)
 AC_SUBST(target_os)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,8 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CFLAGS = -fno-optimize-sibling-calls
 
+LOG_DRIVER = $(SHELL) $(UNW_TESTDRIVER)
+
 EXTRA_DIST =	run-ia64-test-dyn1 run-ptrace-mapper run-ptrace-misc	\
 		run-check-namespace run-coredump-unwind \
 		run-coredump-unwind-mdi check-namespace.sh.in \


### PR DESCRIPTION
Specifying --with-testdriver=TESTDRIVER at configure time allows the
substitution of a alternative LOG_DRIVER to be specified to enable remote
testing of a cross-built target.  See the automake documentation on Custom Test
Drivers for more information.

This is a part of the QNX's ongoing port of libunwind.