### PR TITLE
Correct build failure

### DIFF
--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -816,7 +816,7 @@ aarch64_strip_pac_local(unw_word_t in_addr)
 {
   unw_word_t out_addr = in_addr;
 
-#ifdef __aarch64__
+#if defined(__aarch64__) && !defined(UNW_REMOTE_ONLY)
   // Strip the PAC with XPACLRI instruction
   register unsigned long long x30 __asm__("x30") = in_addr;
   __asm__("hint 0x7" : "+r" (x30));


### PR DESCRIPTION
The following pull request, targeting aarch64, introduced a build
failure:

  https://github.com/libunwind/libunwind/pull/360
  (f67ef2867bc5e74cdadb3acb790c3fc6161b22e9)

The failing build was with the msvc compiler.  According to

  https://docs.microsoft.com/en-us/cpp/assembler/inline/inline-assembler?view=msvc-170

the compiler only supports inline asm on x86.

Since the inline assembly is only for local unwinding, this patch fixes
the build by only compiling the inline assembly if UNW_REMOTE_ONLY is
not defined.  This works because the msvc build has UNW_REMOTE_ONLY set
in the CMakeLists.txt file.