### PR TITLE
Swap build step order in action file

### DIFF
--- a/.github/workflows/CI-linux.yml
+++ b/.github/workflows/CI-linux.yml
@@ -59,10 +59,6 @@ jobs:
           autoreconf -i
           ./configure --build=$BUILD --host=$HOST
           make -j8
-      - name: Show Logs
-        if: ${{ failure() }}
-        run: |
-          cat tests/test-suite.log 2>/dev/null
       - name: Test (native)
         if: ${{ success() && (matrix.HOST == 'x86_64-linux-gnu' || matrix.HOST == 'x86-linux-gnu') }}
         run: |
@@ -70,6 +66,10 @@ jobs:
           sudo bash -c 'echo core.%p.%p > /proc/sys/kernel/core_pattern'
           ulimit -c unlimited
           make check -j32
+      - name: Show Logs
+        if: ${{ failure() }}
+        run: |
+          cat tests/test-suite.log 2>/dev/null
 
   build-cross-qemu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The check for testing failure was coming before running the tests. It's a lot more useful if it runs after the tests, after the tests/test-suite.log file was created.