### PR TITLE
Remove bashisms from tests/check-namespace.sh

### DIFF
--- a/tests/check-namespace.sh.in
+++ b/tests/check-namespace.sh.in
@@ -93,7 +93,7 @@ filter_misc () {
 	ignore _gp
     fi
 
-    if [ ${os} == "solaris2.11" ]; then
+    if [ ${os} = "solaris2.11" ]; then
         ignore _PROCEDURE_LINKAGE_TABLE_
         ignore _etext
     fi


### PR DESCRIPTION
Stray errors were being reported on travis.ci because /bin/sh was not bash.

Fixes #374.