### PR TITLE
Autodetect presence of elf_fpregset_t

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AC_CHECK_SIZEOF(off_t)
 CPPFLAGS="${CPPFLAGS} -D_GNU_SOURCE"
 
 AC_CHECK_MEMBERS([struct dl_phdr_info.dlpi_subs],,,[#include <link.h>])
-AC_CHECK_TYPES([struct elf_prstatus, struct prstatus, procfs_status], [], [],
+AC_CHECK_TYPES([struct elf_prstatus, struct prstatus, procfs_status, elf_fpregset_t], [], [],
 [$ac_includes_default
 #if HAVE_SYS_PROCFS_H
 # include <sys/procfs.h>

--- a/src/coredump/_UCD_create.c
+++ b/src/coredump/_UCD_create.c
@@ -219,7 +219,9 @@ _UCD_create(const char *filename)
       }
 
     ui->prstatus = &ui->threads[0].prstatus;
+#ifdef HAVE_ELF_FPREGSET_T
     ui->fpregset = &ui->threads[0].fpregset;
+#endif
 
   return ui;
 
@@ -237,7 +239,9 @@ void _UCD_select_thread(struct UCD_info *ui, int n)
 {
   if (n >= 0 && n < ui->n_threads) {
     ui->prstatus = &ui->threads[n].prstatus;
+#ifdef HAVE_ELF_FPREGSET_T
     ui->fpregset = &ui->threads[n].fpregset;
+#endif
   }
 }
 

--- a/src/coredump/_UCD_get_threadinfo_prstatus.c
+++ b/src/coredump/_UCD_get_threadinfo_prstatus.c
@@ -67,7 +67,9 @@ _save_thread_notes(uint32_t n_namesz, uint32_t n_descsz, uint32_t n_type, char *
   }
   if (n_type == NT_FPREGSET)
   {
+#ifdef HAVE_ELF_FPREGSET_T
     memcpy(&ui->threads[ui->n_threads-1].fpregset, desc, sizeof(elf_fpregset_t));
+#endif
   }
   return UNW_ESUCCESS;
 }

--- a/src/coredump/_UCD_internal.h
+++ b/src/coredump/_UCD_internal.h
@@ -90,7 +90,9 @@ typedef procfs_status UCD_proc_status_t;
 struct UCD_thread_info
   {
     UCD_proc_status_t  prstatus;
+#ifdef HAVE_ELF_FPREGSET_T
     elf_fpregset_t     fpregset;
+#endif
   };
 
 struct UCD_info
@@ -102,7 +104,9 @@ struct UCD_info
     unsigned                phdrs_count;
     void                   *note_phdr;         /* allocated or NULL */
     UCD_proc_status_t      *prstatus;          /* points inside note_phdr */
+#ifdef HAVE_ELF_FPREGSET_T
     elf_fpregset_t         *fpregset;
+#endif
     int                     n_threads;
     struct UCD_thread_info *threads;
     struct elf_dyn_info     edi;


### PR DESCRIPTION
Data of this type was added for the s390x port doesn't exists on all OSes. It
needs to be autodetected and optioned out.

Fixes #378 