### PR TITLE
Make `sigaltstack()` optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ PT_STEP, PT_SYSCALL], [], [],
 
 dnl Checks for library functions.
 AC_CHECK_FUNCS(dl_iterate_phdr dl_phdr_removals_counter dlmodinfo getunwind \
-		ttrace mincore pipe2)
+		ttrace mincore pipe2 sigaltstack)
 
 AC_MSG_CHECKING([if building with AltiVec])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([[

--- a/tests/Gtest-bt.c
+++ b/tests/Gtest-bt.c
@@ -1,6 +1,7 @@
 /* libunwind - a platform-independent unwind library
    Copyright (C) 2001-2004 Hewlett-Packard Co
 	Contributed by David Mosberger-Tang <davidm@hpl.hp.com>
+   Copyright 2022 Blackberry Limited.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -189,17 +190,21 @@ sighandler (int signal, void *siginfo UNUSED, void *context)
       }
 # endif
 #elif UNW_TARGET_X86
-#if defined __linux__ || defined __sun
+# if defined __linux__ || defined __sun
       printf (" @ %lx", (unsigned long) uc->uc_mcontext.gregs[REG_EIP]);
-#elif defined __FreeBSD__
+# elif defined __FreeBSD__
       printf (" @ %lx", (unsigned long) uc->uc_mcontext.mc_eip);
-#endif
+# endif
 #elif UNW_TARGET_X86_64
-#if defined __linux__ || defined __sun
+# if defined __linux__ || defined __sun
       printf (" @ %lx", (unsigned long) uc->uc_mcontext.gregs[REG_RIP]);
-#elif defined __FreeBSD__
+# elif defined __FreeBSD__
       printf (" @ %lx", (unsigned long) uc->uc_mcontext.mc_rip);
-#endif
+# endif
+#elif UNW_TARGET_AARCH64
+# if defined(__QNXNTO__)
+      fprintf (stderr, " @ %#010lx", (unsigned long) uc->uc_mcontext.cpu.elr);
+# endif /* defined(__QNXNTO__) */
 #endif
       printf ("\n");
     }
@@ -210,7 +215,9 @@ int
 main (int argc, char **argv UNUSED)
 {
   struct sigaction act;
+#ifdef HAVE_SIGALTSTACK
   stack_t stk;
+#endif /* HAVE_SIGALTSTACK */
 
   verbose = (argc > 1);
 
@@ -229,6 +236,7 @@ main (int argc, char **argv UNUSED)
     printf ("\nBacktrace across signal handler:\n");
   kill (getpid (), SIGTERM);
 
+#ifdef HAVE_SIGALTSTACK
   if (verbose)
     printf ("\nBacktrace across signal handler on alternate stack:\n");
   stk.ss_sp = malloc (SIG_STACK_SIZE);
@@ -245,6 +253,7 @@ main (int argc, char **argv UNUSED)
   if (sigaction (SIGTERM, &act, NULL) < 0)
     panic ("sigaction: %s\n", strerror (errno));
   kill (getpid (), SIGTERM);
+#endif /* HAVE_SIGALTSTACK */
 
   if (num_errors > 0)
     {
@@ -255,9 +264,11 @@ main (int argc, char **argv UNUSED)
     printf ("SUCCESS.\n");
 
   signal (SIGTERM, SIG_DFL);
+#ifdef HAVE_SIGALTSTACK
   stk.ss_flags = SS_DISABLE;
   sigaltstack (&stk, NULL);
   free (stk.ss_sp);
+#endif /* HAVE_SIGALTSTACK */
 
   return 0;
 }

--- a/tests/Gtest-trace.c
+++ b/tests/Gtest-trace.c
@@ -228,7 +228,9 @@ int
 main (int argc, char **argv UNUSED)
 {
   struct sigaction act;
+#ifdef HAVE_SIGALTSTACK
   stack_t stk;
+#endif /* HAVE_SIGALTSTACK */
 
   verbose = (argc > 1);
 
@@ -247,6 +249,7 @@ main (int argc, char **argv UNUSED)
     printf ("\nBacktrace across signal handler:\n");
   kill (getpid (), SIGTERM);
 
+#ifdef HAVE_SIGALTSTACK
   if (verbose)
     printf ("\nBacktrace across signal handler on alternate stack:\n");
   stk.ss_sp = malloc (SIG_STACK_SIZE);
@@ -263,6 +266,7 @@ main (int argc, char **argv UNUSED)
   if (sigaction (SIGTERM, &act, NULL) < 0)
     panic ("sigaction: %s\n", strerror (errno));
   kill (getpid (), SIGTERM);
+#endif /* HAVE_SIGALTSTACK */
 
   if (num_errors > 0)
     {
@@ -274,9 +278,11 @@ main (int argc, char **argv UNUSED)
     printf ("SUCCESS.\n");
 
   signal (SIGTERM, SIG_DFL);
+#ifdef HAVE_SIGALTSTACK
   stk.ss_flags = SS_DISABLE;
   sigaltstack (&stk, NULL);
   free (stk.ss_sp);
+#endif /* HAVE_SIGALTSTACK */
 
   return 0;
 }


### PR DESCRIPTION
Some (older) OSes do not support this POSIX function. Make it optional.

Fixes #379.