### PR TITLE
Add RISC-V machine value in remote unwind

### DIFF
--- a/include/remote/freebsd-elf_common.h
+++ b/include/remote/freebsd-elf_common.h
@@ -169,6 +169,7 @@ typedef struct {
 #define EM_TINYJ	61	/* Advanced Logic Corp. TinyJ processor. */
 #define EM_X86_64	62	/* Advanced Micro Devices x86-64 */
 #define	EM_AMD64	EM_X86_64	/* Advanced Micro Devices x86-64 (compat) */
+#define EM_RISCV	243	/* RISC-V. */
 
 /* Non-standard or deprecated. */
 #define EM_486		6	/* Intel i486. */


### PR DESCRIPTION
This value is present in mono copy, but we were missing it upstream.