### PR TITLE
Added support for unwinding from the vsyscall region

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,10 +34,10 @@ esac
 
 dnl Checks for header files.
 AC_HEADER_STDC
-AC_CHECK_HEADERS(asm/ptrace_offsets.h asm/ptrace.h endian.h sys/endian.h sys/param.h \
-		execinfo.h ia64intrin.h sys/uc_access.h unistd.h signal.h sys/types.h \
-		sys/procfs.h sys/ptrace.h sys/syscall.h byteswap.h elf.h sys/elf.h \
-		link.h sys/link.h)
+AC_CHECK_HEADERS(asm/ptrace_offsets.h asm/ptrace.h asm/vsyscall.h endian.h sys/endian.h \
+		sys/param.h execinfo.h ia64intrin.h sys/uc_access.h unistd.h signal.h \
+		sys/types.h sys/procfs.h sys/ptrace.h sys/syscall.h byteswap.h elf.h \
+		sys/elf.h link.h sys/link.h)
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -25,9 +25,12 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
+#ifdef HAVE_ASM_VSYSCALL_H
+#include <asm/vsyscall.h>
+#endif
+
 #include "libunwind_i.h"
 #include "unwind_i.h"
-#include <asm/vsyscall.h>
 #include <signal.h>
 
 /* Recognise PLT entries such as:

--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -27,6 +27,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "libunwind_i.h"
 #include "unwind_i.h"
+#include <asm/vsyscall.h>
 #include <signal.h>
 
 /* Recognise PLT entries such as:
@@ -51,6 +52,20 @@ is_plt_entry (struct dwarf_cursor *c)
 
   Debug (14, "ip=0x%lx => 0x%016lx 0x%016lx, ret = %d\n", c->ip, w0, w1, ret);
   return ret;
+}
+
+static int
+is_vsyscall (struct dwarf_cursor *c)
+{
+#if defined(VSYSCALL_START) && defined(VSYSCALL_END)
+  return c->ip >= VSYSCALL_START && c->ip < VSYSCALL_END;
+#elif defined(VSYSCALL_ADDR)
+  /* Linux 3.16 removes `VSYSCALL_START` and `VSYSCALL_END`.  Assume
+     a single page is mapped for vsyscalls.  */
+  return c->ip >= VSYSCALL_ADDR && c->ip < VSYSCALL_ADDR + sysconf(_SC_PAGESIZE);
+#else
+  return 0;
+#endif
 }
 
 int
@@ -138,6 +153,15 @@ unw_step (unw_cursor_t *cursor)
           c->frame_info.cfa_reg_offset = 8;
           c->frame_info.cfa_reg_rsp = -1;
           c->frame_info.frame_type = UNW_X86_64_FRAME_STANDARD;
+          c->dwarf.loc[RIP] = DWARF_LOC (c->dwarf.cfa, 0);
+          c->dwarf.cfa += 8;
+        }
+      else if (is_vsyscall (&c->dwarf))
+        {
+          Debug (2, "in vsyscall region\n");
+          c->frame_info.cfa_reg_offset = 8;
+          c->frame_info.cfa_reg_rsp = -1;
+          c->frame_info.frame_type = UNW_X86_64_FRAME_GUESSED;
           c->dwarf.loc[RIP] = DWARF_LOC (c->dwarf.cfa, 0);
           c->dwarf.cfa += 8;
         }


### PR DESCRIPTION
This change fixes unwinding from the vsyscall region. Although vsyscall has been phased out, it is still possible to call into it at an address where libunwind is unable to step out of. Here is a reproducer
```
#include <stdio.h>
#include <sys/time.h>
#include <asm/vsyscall.h>

int (*f)(struct timeval *tv, struct timezone *tz) = (void*) VSYSCALL_ADDR; 

int main() {

    struct timeval current_time;
    f(&current_time, NULL);
    printf("seconds : %ld\nmicro seconds : %ld\n",
           current_time.tv_sec, current_time.tv_usec);

    return 0;
}
```