### PR TITLE
Fix `make distcheck` due to missing coredump header

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,7 +71,9 @@ libunwind_coredump_la_SOURCES = \
 libunwind_coredump_la_LDFLAGS = $(COMMON_SO_LDFLAGS) \
 				-version-info $(COREDUMP_SO_VERSION)
 libunwind_coredump_la_LIBADD = $(LIBLZMA) $(LIBZ)
-noinst_HEADERS += coredump/_UCD_internal.h coredump/_UCD_lib.h
+noinst_HEADERS += coredump/_UCD_internal.h \
+                  coredump/_UCD_lib.h \
+                  coredump/ucd_file_table.h
 
 ### libunwind-setjmp:
 libunwind_setjmp_la_LDFLAGS		= $(COMMON_SO_LDFLAGS)		     \


### PR DESCRIPTION
A recent change missed adding a new header to the dist list. `make distckeck`
now runs successfully once again.

Fixes #409