### PR TITLE
tests/run-coredump-unwind: Skip test if no coredump has been created

### DIFF
--- a/tests/run-coredump-unwind
+++ b/tests/run-coredump-unwind
@@ -49,6 +49,10 @@ fi
     ./crasher backing_files
 ) 2>/dev/null
 COREFILE=$TEMPDIR/core*
+if ! test -f "$COREFILE"; then
+    echo "crasher process did not produce coredump, test skipped"
+    exit 77
+fi
 
 # magic option -testcase enables checking for the specific contents of the stack
 ./test-coredump-unwind $COREFILE -testcase `cat $TEMPDIR/backing_files`


### PR DESCRIPTION
In some build environments, coredumps are not created even if the corresponding ulimit is positive. This change skips the test if the coredump is missing.