### PR TITLE
Fix a few warnings

### DIFF
--- a/include/libunwind_i.h
+++ b/include/libunwind_i.h
@@ -132,7 +132,7 @@ byte_order_is_big_endian(int byte_order)
 }
 
 static inline int
-target_is_big_endian()
+target_is_big_endian(void)
 {
     return byte_order_is_big_endian(UNW_BYTE_ORDER);
 }

--- a/src/dwarf/Gexpr.c
+++ b/src/dwarf/Gexpr.c
@@ -578,7 +578,8 @@ if (stackerror)                                 \
 
         case DW_OP_neg:
           Debug (15, "OP_neg\n");
-          push (~pop () + 1);
+          unw_word_t tmp UNUSED = pop ();
+          push (~tmp + 1);
           break;
 
         case DW_OP_not:

--- a/src/mi/init.c
+++ b/src/mi/init.c
@@ -41,7 +41,7 @@ long unwi_debug_level;
 #endif /* UNW_DEBUG */
 long unw_page_size;
 static void
-unw_init_page_size ()
+unw_init_page_size (void)
 {
   errno = 0;
   long result = sysconf (_SC_PAGESIZE);

--- a/src/x86_64/Gtrace.c
+++ b/src/x86_64/Gtrace.c
@@ -404,7 +404,7 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
   int maxdepth = 0;
   int depth = 0;
   int ret;
-  int validate = 0;
+  int validate UNUSED = 0;
 
   /* Check input parametres. */
   if (unlikely(! cursor || ! buffer || ! size || (maxdepth = *size) <= 0))

--- a/tests/test-coredump-unwind.c
+++ b/tests/test-coredump-unwind.c
@@ -244,8 +244,7 @@ void handle_sigsegv(int sig, siginfo_t *info, void *ucontext)
   {
     /* glibc extension */
     void *array[50];
-    int size;
-    size = backtrace(array, 50);
+    int size UNUSED = backtrace(array, 50);
 #if defined __linux__ && HAVE_EXECINFO_H
     backtrace_symbols_fd(array, size, 2);
 #endif


### PR DESCRIPTION
Noticed a few warnings (as errors) in mono build with clang14/15.

This patch fixes `-Wstrict-prototypes` and `-Wunused-value`.