### PR TITLE
check-namespace.sh: adjust aarch64 symbols

### DIFF
--- a/tests/check-namespace.sh.in
+++ b/tests/check-namespace.sh.in
@@ -126,7 +126,8 @@ check_local_unw_abi () {
 
     match _U${plat}_flush_cache
     match _U${plat}_get_accessors
-    match _U${plat}_getcontext
+    match _U${plat}_get_elf_image
+    match _U${plat}_get_exe_image_path
     match _U${plat}_regname
     match _U${plat}_strerror
 
@@ -139,76 +140,66 @@ check_local_unw_abi () {
 
     case ${plat} in
 	arm)
-	    match _U${plat}_get_elf_image
-	    match _U${plat}_get_exe_image_path
+	    match _U${plat}_getcontext
 	    match _U${plat}_is_fpreg
 	    match _UL${plat}_search_unwind_table
 	    match _UL${plat}_dwarf_search_unwind_table
 	    match _UL${plat}_dwarf_find_unwind_table
 	    ;;
 	hppa)
+	    match _U${plat}_getcontext
 	    match _UL${plat}_dwarf_search_unwind_table
 	    match _UL${plat}_dwarf_find_unwind_table
-	    match _U${plat}_get_elf_image
-	    match _U${plat}_get_exe_image_path
 	    match _U${plat}_setcontext
 	    ;;
 	ia64)
+	    match _U${plat}_getcontext
 	    match _UL${plat}_search_unwind_table
-	    match _U${plat}_get_elf_image
-	    match _U${plat}_get_exe_image_path
 	    ;;
 	x86)
-	    match _U${plat}_get_elf_image
-	    match _U${plat}_get_exe_image_path
+	    match _U${plat}_getcontext
 	    match _U${plat}_is_fpreg
 	    match _UL${plat}_dwarf_search_unwind_table
 	    match _UL${plat}_dwarf_find_unwind_table
 	    ;;
 	x86_64)
-	    match _U${plat}_get_elf_image
-	    match _U${plat}_get_exe_image_path
+	    match _U${plat}_getcontext
 	    match _U${plat}_is_fpreg
 	    match _UL${plat}_dwarf_search_unwind_table
 	    match _UL${plat}_dwarf_find_unwind_table
 	    match _U${plat}_setcontext
 	    ;;
 	ppc*)
+	    match _U${plat}_getcontext
 	    match _U${plat}_get_func_addr
-	    match _U${plat}_get_elf_image
-	    match _U${plat}_get_exe_image_path
 	    match _U${plat}_is_fpreg
 	    match _UL${plat}_dwarf_search_unwind_table
 	    match _UL${plat}_dwarf_find_unwind_table
 	    ;;
-        tilegx)
-            match _U${plat}_is_fpreg
+	tilegx)
+	    match _U${plat}_getcontext
+	    match _U${plat}_is_fpreg
 	    match _UL${plat}_dwarf_search_unwind_table
 	    match _UL${plat}_dwarf_find_unwind_table
-            match _UL${plat}_local_addr_space_init
-            match _U${plat}_get_elf_image
-	    match _U${plat}_get_exe_image_path
-            match ${plat}_lock
-            ;;
+	    match _UL${plat}_local_addr_space_init
+	    match ${plat}_lock
+	    ;;
 	s390x)
-	    match _U${plat}_get_elf_image
-	    match _U${plat}_get_exe_image_path
+	    match _U${plat}_getcontext
 	    match _U${plat}_is_fpreg
 	    match _UL${plat}_dwarf_search_unwind_table
 	    match _UL${plat}_dwarf_find_unwind_table
 	    match _U${plat}_setcontext
 	    ;;
 	riscv)
-	    match _U${plat}_get_elf_image
-	    match _U${plat}_get_exe_image_path
+	    match _U${plat}_getcontext
 	    match _U${plat}_is_fpreg
 	    match _UL${plat}_dwarf_search_unwind_table
 	    match _UL${plat}_dwarf_find_unwind_table
 	    match _U${plat}_setcontext
 	    ;;
 	loongarch64)
-	    match _U${plat}_get_elf_image
-	    match _U${plat}_get_exe_image_path
+	    match _U${plat}_getcontext
 	    match _U${plat}_is_fpreg
 	    match _UL${plat}_dwarf_search_unwind_table
 	    match _UL${plat}_dwarf_find_unwind_table
@@ -305,15 +296,15 @@ check_generic_unw_abi () {
 	    match _U${plat}_dwarf_search_unwind_table
 	    match _U${plat}_dwarf_find_unwind_table
 	    ;;
-        tilegx)
-            match _U${plat}_dwarf_search_unwind_table
+	tilegx)
+	    match _U${plat}_dwarf_search_unwind_table
 	    match _U${plat}_dwarf_find_unwind_table
-            match _U${plat}_get_elf_image
+	    match _U${plat}_get_elf_image
 	    match _U${plat}_get_exe_image_path
-            match _U${plat}_is_fpreg
-            match _U${plat}_local_addr_space_init
-            match ${plat}_lock
-            ;;
+	    match _U${plat}_is_fpreg
+	    match _U${plat}_local_addr_space_init
+	    match ${plat}_lock
+	    ;;
 	s390x)
 	    match _U${plat}_is_fpreg
 	    match _U${plat}_get_elf_image
@@ -339,6 +330,8 @@ check_generic_unw_abi () {
 	    match _U${plat}_is_fpreg
 	    match _U${plat}_dwarf_search_unwind_table
 	    match _U${plat}_dwarf_find_unwind_table
+	    match _U${plat}_get_elf_image
+	    match _U${plat}_get_exe_image_path
 	    ;;
     esac
 


### PR DESCRIPTION
Some symbols for aarch64 were missing, and some were marked as extraneous in this ABI checker.

Fixes #389.