### PR TITLE
Add unw_backtrace2 function

### DIFF
--- a/doc/unw_backtrace.man
+++ b/doc/unw_backtrace.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
+.\" Manual page created with latex2man on Thu Dec  8 12:01:30 2022
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_BACKTRACE" "3" "29 August 2021" "Programming Library " "Programming Library "
+.TH "UNW\\_BACKTRACE" "3" "08 December 2022" "Programming Library " "Programming Library "
 .SH NAME
 unw_backtrace
 \-\- return backtrace for the calling program 
@@ -24,6 +26,11 @@ unw_backtrace
 int
 unw_backtrace(void **buffer,
 int size);
+.br
+int
+unw_backtrace2(void **buffer,
+int size,
+unw_context_t *ctxt);
 .br
 .PP
 #include <execinfo.h>
@@ -60,6 +67,12 @@ calling backtrace()
 is linked against libunwind,
 it may end up 
 calling unw_backtrace().
+.PP
+If the unw_context_t
+is known to be a signal frame (i.e., from the third argument 
+in a sigaction handler on linux), unw_backtrace2
+can be used to collect 
+only the frames before the signal frame. 
 .PP
 .SH RETURN VALUE
 

--- a/doc/unw_backtrace.man
+++ b/doc/unw_backtrace.man
@@ -1,7 +1,7 @@
 .\" *********************************** start of \input{common.tex}
 .\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Dec  8 12:01:30 2022
+.\" Manual page created with latex2man on Thu Jan  5 15:33:00 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -12,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_BACKTRACE" "3" "08 December 2022" "Programming Library " "Programming Library "
+.TH "UNW\\_BACKTRACE" "3" "05 January 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_backtrace
 \-\- return backtrace for the calling program 
@@ -30,7 +30,8 @@ int size);
 int
 unw_backtrace2(void **buffer,
 int size,
-unw_context_t *ctxt);
+unw_context_t *ctxt,
+int flag);
 .br
 .PP
 #include <execinfo.h>
@@ -68,11 +69,16 @@ is linked against libunwind,
 it may end up 
 calling unw_backtrace().
 .PP
+In case you want to obtain the backtrace from a specific unw_context_t,
+you can call unw_backtrace2
+with that context passing 0
+for flag. 
 If the unw_context_t
 is known to be a signal frame (i.e., from the third argument 
 in a sigaction handler on linux), unw_backtrace2
 can be used to collect 
-only the frames before the signal frame. 
+only the frames before the signal frame passing the UNW_INIT_SIGNAL_FRAME
+flag. 
 .PP
 .SH RETURN VALUE
 

--- a/doc/unw_backtrace.tex
+++ b/doc/unw_backtrace.tex
@@ -13,6 +13,7 @@
 \File{\#include $<$libunwind.h$>$}\\
 
 \Type{int} \Func{unw\_backtrace}(\Type{void~**}\Var{buffer}, \Type{int}~\Var{size});\\
+\Type{int} \Func{unw\_backtrace2}(\Type{void~**}\Var{buffer}, \Type{int}~\Var{size}, \Type{unw_context_t~*}\Var{ctxt});\\
 
 \File{\#include $<$execinfo.h$>$}\\
 
@@ -31,6 +32,10 @@ by including the \File{$<$execinfo.h$>$} header file -- a prototype for
 aliases \Func{backtrace}() to \Func{unw\_backtrace}(), so when a program
 calling \Func{backtrace}() is linked against \Prog{libunwind}, it may end up
 calling \Func{unw\_backtrace}().
+
+If the \Type{unw\_context_t} is known to be a signal frame (i.e., from the third argument
+in a sigaction handler on linux), \Func{unw\_backtrace2} can be used to collect
+only the frames before the signal frame.
 
 \section{Return Value}
 

--- a/doc/unw_backtrace.tex
+++ b/doc/unw_backtrace.tex
@@ -13,7 +13,7 @@
 \File{\#include $<$libunwind.h$>$}\\
 
 \Type{int} \Func{unw\_backtrace}(\Type{void~**}\Var{buffer}, \Type{int}~\Var{size});\\
-\Type{int} \Func{unw\_backtrace2}(\Type{void~**}\Var{buffer}, \Type{int}~\Var{size}, \Type{unw_context_t~*}\Var{ctxt});\\
+\Type{int} \Func{unw\_backtrace2}(\Type{void~**}\Var{buffer}, \Type{int}~\Var{size}, \Type{unw_context_t~*}\Var{ctxt}, \Type{int}~\Var{flag});\\
 
 \File{\#include $<$execinfo.h$>$}\\
 
@@ -33,9 +33,11 @@ aliases \Func{backtrace}() to \Func{unw\_backtrace}(), so when a program
 calling \Func{backtrace}() is linked against \Prog{libunwind}, it may end up
 calling \Func{unw\_backtrace}().
 
+In case you want to obtain the backtrace from a specific \Type{unw\_context\_t},
+you can call \Func{unw\_backtrace2} with that context passing \Const{0} for flag. 
 If the \Type{unw\_context_t} is known to be a signal frame (i.e., from the third argument
 in a sigaction handler on linux), \Func{unw\_backtrace2} can be used to collect
-only the frames before the signal frame.
+only the frames before the signal frame passing the \Const{UNW\_INIT\_SIGNAL\_FRAME} flag.
 
 \section{Return Value}
 

--- a/doc/unw_backtrace2.man
+++ b/doc/unw_backtrace2.man
@@ -1,0 +1,1 @@
+.so man3/unw_backtrace.3

--- a/include/libunwind-common.h.in
+++ b/include/libunwind-common.h.in
@@ -316,6 +316,6 @@ extern int unw_get_proc_name_by_ip (unw_addr_space_t, unw_word_t, char *,
 				    size_t, unw_word_t *, void *);
 extern const char *unw_strerror (int);
 extern int unw_backtrace (void **, int);
-extern int unw_backtrace2 (void **, int, unw_context_t*);
+extern int unw_backtrace2 (void **, int, unw_context_t*, int);
 
 extern unw_addr_space_t unw_local_addr_space;

--- a/include/libunwind-common.h.in
+++ b/include/libunwind-common.h.in
@@ -316,5 +316,6 @@ extern int unw_get_proc_name_by_ip (unw_addr_space_t, unw_word_t, char *,
 				    size_t, unw_word_t *, void *);
 extern const char *unw_strerror (int);
 extern int unw_backtrace (void **, int);
+extern int unw_backtrace2 (void **, int, unw_context_t*);
 
 extern unw_addr_space_t unw_local_addr_space;

--- a/src/mi/backtrace.c
+++ b/src/mi/backtrace.c
@@ -77,7 +77,7 @@ unw_backtrace (void **buffer, int size)
 }
 
 int
-unw_backtrace2 (void **buffer, int size, unw_context_t* uc2)
+unw_backtrace2 (void **buffer, int size, unw_context_t* uc2, int flag)
 {
   if (size == 0)
     return 0;
@@ -89,7 +89,7 @@ unw_backtrace2 (void **buffer, int size, unw_context_t* uc2)
   // need to copy, because the context will be modified by tdep_trace
   unw_context_t uc = *(unw_context_t*)uc2;
 
-  if (unlikely (unw_init_local2 (&cursor, &uc, UNW_INIT_SIGNAL_FRAME) < 0))
+  if (unlikely (unw_init_local2 (&cursor, &uc, flag) < 0))
     return 0;
 
   // get the first ip from the context
@@ -110,7 +110,7 @@ unw_backtrace2 (void **buffer, int size, unw_context_t* uc2)
   // and add 1 to it (the one we retrieved above)
   if (unlikely (tdep_trace (&cursor, buffer, &n) < 0))
     {
-      return slow_backtrace (buffer, remaining_size, &uc, UNW_INIT_SIGNAL_FRAME) + 1;
+      return slow_backtrace (buffer, remaining_size, &uc, flag) + 1;
     }
 
   return n + 1;

--- a/src/mi/backtrace.c
+++ b/src/mi/backtrace.c
@@ -96,7 +96,7 @@ unw_backtrace2 (void **buffer, int size, unw_context_t* uc2)
 
   if (unlikely (tdep_trace (&cursor, buffer, &n) < 0))
     {
-      return slow_backtrace (buffer, n, &uc, UNW_INIT_SIGNAL_FRAME);
+      return slow_backtrace (buffer, size, &uc, UNW_INIT_SIGNAL_FRAME);
     }
 
   return n;

--- a/tests/Gtest-trace.c
+++ b/tests/Gtest-trace.c
@@ -140,6 +140,64 @@ do_backtrace (void)
 }
 
 void
+do_backtrace_with_context(void *context)
+{
+  unw_word_t ip;
+  int ret = -UNW_ENOINFO;
+  int depth = 0;
+  int i, m;
+
+  if (verbose)
+    printf ("\tnormal trace:\n");
+
+  if (unw_init_local2 (&cursor, (unw_context_t*)context, UNW_INIT_SIGNAL_FRAME) < 0)
+    panic ("unw_init_local2 failed!\n");
+
+  do
+    {
+      unw_get_reg (&cursor, UNW_REG_IP, &ip);
+      addresses[0][depth] = (void *) ip;
+    }
+  while ((ret = unw_step (&cursor)) > 0 && ++depth < 128);
+
+  if (ret < 0)
+    {
+      unw_get_reg (&cursor, UNW_REG_IP, &ip);
+      printf ("FAILURE: unw_step() returned %d for ip=%lx\n", ret, (long) ip);
+      ++num_errors;
+    }
+
+  if (verbose)
+    for (i = 0; i < depth; ++i)
+      printf ("\t #%-3d ip=%p\n", i, addresses[0][i]);
+
+  if (verbose)
+    printf ("\n\tvia unw_backtrace2():\n");
+
+  m = unw_backtrace2 (addresses[1], 128, (unw_context_t*)context);
+
+  if (verbose)
+    for (i = 0; i < m; ++i)
+	printf ("\t #%-3d ip=%p\n", i, addresses[1][i]);
+
+  if (m != depth+1)
+    {
+      printf ("FAILURE: unw_step() loop and unw_backtrace2() depths differ: %d vs. %d\n", depth, m);
+      ++num_errors;
+    }
+
+  if (m == depth + 1)
+    for (i = 0; i < depth; ++i)
+      /* Allow one in difference in comparison, trace returns adjusted addresses. */
+      if (labs((unw_word_t) addresses[0][i] - (unw_word_t) addresses[1][i]) > 1)
+	{
+          printf ("FAILURE: unw_step() loop and uwn_backtrace2() addresses differ at %d: %p vs. %p\n",
+                  i, addresses[0][i], addresses[1][i]);
+          ++num_errors;
+	}
+}
+
+void
 foo (long val UNUSED)
 {
   do_backtrace ();
@@ -222,6 +280,7 @@ sighandler (int signal, void *siginfo UNUSED, void *context)
       printf ("\n");
     }
   do_backtrace();
+  do_backtrace_with_context(context);
 }
 
 int

--- a/tests/Gtest-trace.c
+++ b/tests/Gtest-trace.c
@@ -174,7 +174,7 @@ do_backtrace_with_context(void *context)
   if (verbose)
     printf ("\n\tvia unw_backtrace2():\n");
 
-  m = unw_backtrace2 (addresses[1], 128, (unw_context_t*)context);
+  m = unw_backtrace2 (addresses[1], 128, (unw_context_t*)context, UNW_INIT_SIGNAL_FRAME);
 
   if (verbose)
     for (i = 0; i < m; ++i)

--- a/tests/check-namespace.sh.in
+++ b/tests/check-namespace.sh.in
@@ -137,6 +137,7 @@ check_local_unw_abi () {
 
     match unw_backtrace
     @CONFIG_WEAK_BACKTRACE_TRUE@match backtrace
+    match unw_backtrace2
 
     case ${plat} in
 	arm)


### PR DESCRIPTION
Today we have `uwn_backtrace` which collects instruction pointers and put them in the array (pointer) passed as parameter.

When we are in signal handler (and maybe sub-functions), the array will contain the signal handler instruction pointer (and the sub-functions) in addition to the thread `user-callstack`.

Since we are in  signal handler, we can provide the context and then get rid of the non essential frames.


This PR adds a new version of `backtrace`, which will collect instruction pointer starting from a context given by a signal handler.