### PR TITLE
Gia64-test-nat.c: #include <signal.h> for sigaction()

### DIFF
--- a/tests/Gia64-test-nat.c
+++ b/tests/Gia64-test-nat.c
@@ -26,6 +26,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 /* This file tests corner-cases of NaT-bit handling.  */
 
 #include <errno.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This fixes

```
Gia64-test-nat.c: In function ‘enable_sighandler’:
Gia64-test-nat.c:185:20: error: storage size of ‘act’ isn’t known
   struct sigaction act;
                    ^~~
Gia64-test-nat.c:189:18: error: ‘SA_SIGINFO’ undeclared (first use in this function)
   act.sa_flags = SA_SIGINFO | SA_NODEFER;
                  ^~~~~~~~~~
Gia64-test-nat.c:189:18: note: each undeclared identifier is reported only once for each function it appears in
Gia64-test-nat.c:189:31: error: ‘SA_NODEFER’ undeclared (first use in this function)
   act.sa_flags = SA_SIGINFO | SA_NODEFER;
                               ^~~~~~~~~~
Gia64-test-nat.c:190:7: warning: implicit declaration of function ‘sigaction’ [-Wimplicit-function-declaration]
   if (sigaction (SIGSEGV, &act, NULL) < 0)
       ^~~~~~~~~
Gia64-test-nat.c:190:18: error: ‘SIGSEGV’ undeclared (first use in this function)
   if (sigaction (SIGSEGV, &act, NULL) < 0)
                  ^~~~~~~
Gia64-test-nat.c:185:20: warning: unused variable ‘act’ [-Wunused-variable]
   struct sigaction act;
                    ^~~
Gia64-test-nat.c: In function ‘disable_sighandler’:
Gia64-test-nat.c:197:20: error: storage size of ‘act’ isn’t known
   struct sigaction act;
                    ^~~
Gia64-test-nat.c:200:20: error: ‘SIG_DFL’ undeclared (first use in this function)
   act.sa_handler = SIG_DFL;
                    ^~~~~~~
Gia64-test-nat.c:201:18: error: ‘SA_SIGINFO’ undeclared (first use in this function)
   act.sa_flags = SA_SIGINFO | SA_NODEFER;
                  ^~~~~~~~~~
Gia64-test-nat.c:201:31: error: ‘SA_NODEFER’ undeclared (first use in this function)
   act.sa_flags = SA_SIGINFO | SA_NODEFER;
                               ^~~~~~~~~~
Gia64-test-nat.c:202:18: error: ‘SIGSEGV’ undeclared (first use in this function)
   if (sigaction (SIGSEGV, &act, NULL) < 0)
                  ^~~~~~~
Gia64-test-nat.c:197:20: warning: unused variable ‘act’ [-Wunused-variable]
   struct sigaction act;
                    ^~~
```