### PR TITLE
Disable Ltest-init-local-signal on ia64

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -57,13 +57,17 @@ endif
 			Gtest-resume-sig Ltest-resume-sig		 \
 			Gtest-resume-sig-rt Ltest-resume-sig-rt		 \
 			Gtest-trace Ltest-trace				 \
-			Ltest-init-local-signal				 \
 			Ltest-mem-validate				 \
 			test-async-sig test-flush-cache test-init-remote \
 			test-mem test-reg-state Ltest-varargs		 \
 			Ltest-nomalloc Ltest-nocalloc Lrs-race
  noinst_PROGRAMS_cdep += forker Gperf-simple Lperf-simple \
 			Gperf-trace Lperf-trace
+
+# unw_init_local2() is not implemented on ia64
+if !ARCH_IA64
+ check_PROGRAMS_cdep += Ltest-init-local-signal
+endif
 
 if BUILD_PTRACE
  check_SCRIPTS_cdep += run-ptrace-mapper run-ptrace-misc


### PR DESCRIPTION
A similar change is already used for some time on Debian to make the tests build on ia64 so that they can be run, otherwise the build fails with
```
/usr/bin/ld: Ltest-init-local-signal.o: in function `handler':
./tests/Ltest-init-local-signal.c:33: undefined reference to `_Uia64_init_local2'
```

A proper fix would be to implement `unw_init_local2()` in https://github.com/libunwind/libunwind/blob/master/src/ia64/Ginit_local.c (which looks quite different from `Ginit_local.c` on other architectures) by someone who understands why ia64 is special here.