### PR TITLE
Fix for unw_backtrace fast path does not work on x86_64 [https://github.com/libunwind/libunwind/issues/440]

### DIFF
--- a/src/aarch64/Gstash_frame.c
+++ b/src/aarch64/Gstash_frame.c
@@ -58,16 +58,19 @@ tdep_stash_frame (struct dwarf_cursor *d, struct dwarf_reg_state *rs)
       && rs->ret_addr_column == LR
       && (rs->reg.where[FP] == DWARF_WHERE_UNDEF
           || rs->reg.where[FP] == DWARF_WHERE_SAME
+          || rs->reg.where[FP] == DWARF_WHERE_CFA
           || (rs->reg.where[FP] == DWARF_WHERE_CFAREL
               && labs(rs->reg.val[FP]) < (1 << 29)
               && rs->reg.val[FP]+1 != 0))
       && (rs->reg.where[LR] == DWARF_WHERE_UNDEF
           || rs->reg.where[LR] == DWARF_WHERE_SAME
+          || rs->reg.where[LR] == DWARF_WHERE_CFA
           || (rs->reg.where[LR] == DWARF_WHERE_CFAREL
               && labs(rs->reg.val[LR]) < (1 << 29)
               && rs->reg.val[LR]+1 != 0))
       && (rs->reg.where[SP] == DWARF_WHERE_UNDEF
           || rs->reg.where[SP] == DWARF_WHERE_SAME
+          || rs->reg.where[SP] == DWARF_WHERE_CFA
           || (rs->reg.where[SP] == DWARF_WHERE_CFAREL
               && labs(rs->reg.val[SP]) < (1 << 29)
               && rs->reg.val[SP]+1 != 0)))
@@ -82,6 +85,12 @@ tdep_stash_frame (struct dwarf_cursor *d, struct dwarf_reg_state *rs)
       f->lr_cfa_offset = rs->reg.val[LR];
     if (rs->reg.where[SP] == DWARF_WHERE_CFAREL)
       f->sp_cfa_offset = rs->reg.val[SP];
+    if (rs->reg.where[FP] == DWARF_WHERE_CFA)
+      f->fp_cfa_offset = 0;
+    if (rs->reg.where[LR] == DWARF_WHERE_CFA)
+      f->lr_cfa_offset = 0;
+    if (rs->reg.where[SP] == DWARF_WHERE_CFA)
+      f->sp_cfa_offset = 0;
     Debug (4, " standard frame\n");
   }
   else

--- a/src/arm/Gstash_frame.c
+++ b/src/arm/Gstash_frame.c
@@ -58,16 +58,19 @@ tdep_stash_frame (struct dwarf_cursor *d, struct dwarf_reg_state *rs)
       && rs->ret_addr_column == LR
       && (rs->reg.where[R7] == DWARF_WHERE_UNDEF
           || rs->reg.where[R7] == DWARF_WHERE_SAME
+          || rs->reg.where[R7] == DWARF_WHERE_CFA
           || (rs->reg.where[R7] == DWARF_WHERE_CFAREL
               && labs(rs->reg.val[R7]) < (1 << 29)
               && rs->reg.val[R7]+1 != 0))
       && (rs->reg.where[LR] == DWARF_WHERE_UNDEF
           || rs->reg.where[LR] == DWARF_WHERE_SAME
+          || rs->reg.where[R7] == DWARF_WHERE_CFA
           || (rs->reg.where[LR] == DWARF_WHERE_CFAREL
               && labs(rs->reg.val[LR]) < (1 << 29)
               && rs->reg.val[LR]+1 != 0))
       && (rs->reg.where[SP] == DWARF_WHERE_UNDEF
           || rs->reg.where[SP] == DWARF_WHERE_SAME
+          || rs->reg.where[SP] == DWARF_WHERE_CFA
           || (rs->reg.where[SP] == DWARF_WHERE_CFAREL
               && labs(rs->reg.val[SP]) < (1 << 29)
               && rs->reg.val[SP]+1 != 0)))
@@ -82,6 +85,12 @@ tdep_stash_frame (struct dwarf_cursor *d, struct dwarf_reg_state *rs)
       f->lr_cfa_offset = rs->reg.val[LR];
     if (rs->reg.where[SP] == DWARF_WHERE_CFAREL)
       f->sp_cfa_offset = rs->reg.val[SP];
+    if (rs->reg.where[R7] == DWARF_WHERE_CFA)
+      f->r7_cfa_offset = 0;
+    if (rs->reg.where[LR] == DWARF_WHERE_CFA)
+      f->lr_cfa_offset = 0;
+    if (rs->reg.where[SP] == DWARF_WHERE_CFA)
+      f->sp_cfa_offset = 0;
     Debug (4, " standard frame\n");
   }
   else

--- a/src/x86_64/Gstash_frame.c
+++ b/src/x86_64/Gstash_frame.c
@@ -71,11 +71,13 @@ tdep_stash_frame (struct dwarf_cursor *d, struct dwarf_reg_state *rs)
       && DWARF_GET_LOC(d->loc[rs->ret_addr_column]) == d->cfa-8
       && (rs->reg.where[RBP] == DWARF_WHERE_UNDEF
           || rs->reg.where[RBP] == DWARF_WHERE_SAME
+          || rs->reg.where[RBP] == DWARF_WHERE_CFA
           || (rs->reg.where[RBP] == DWARF_WHERE_CFAREL
               && labs((long) rs->reg.val[RBP]) < (1 << 14)
               && rs->reg.val[RBP]+1 != 0))
       && (rs->reg.where[RSP] == DWARF_WHERE_UNDEF
           || rs->reg.where[RSP] == DWARF_WHERE_SAME
+          || rs->reg.where[RSP] == DWARF_WHERE_CFA
           || (rs->reg.where[RSP] == DWARF_WHERE_CFAREL
               && labs((long) rs->reg.val[RSP]) < (1 << 14)
               && rs->reg.val[RSP]+1 != 0)))
@@ -88,6 +90,10 @@ tdep_stash_frame (struct dwarf_cursor *d, struct dwarf_reg_state *rs)
       f->rbp_cfa_offset = rs->reg.val[RBP];
     if (rs->reg.where[RSP] == DWARF_WHERE_CFAREL)
       f->rsp_cfa_offset = rs->reg.val[RSP];
+    if (rs->reg.where[RBP] == DWARF_WHERE_CFA)
+      f->rbp_cfa_offset = 0;
+    if (rs->reg.where[RSP] == DWARF_WHERE_CFA)
+      f->rsp_cfa_offset = 0;
     Debug (4, " standard frame\n");
   }
 


### PR DESCRIPTION
I recently it the issue describe in  https://github.com/libunwind/libunwind/issues/440 .
This PR is an attempt to fix it.