### PR TITLE
fix byte_order_is_valid function logic

### DIFF
--- a/include/libunwind_i.h
+++ b/include/libunwind_i.h
@@ -121,8 +121,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 static inline int
 byte_order_is_valid(int byte_order)
 {
-    return byte_order != UNW_BIG_ENDIAN
-        && byte_order != UNW_LITTLE_ENDIAN;
+    return byte_order == UNW_BIG_ENDIAN
+        || byte_order == UNW_LITTLE_ENDIAN;
 }
 
 static inline int


### PR DESCRIPTION
byte_order_is_valid is an inline function extracted from unw_create_addr_space in libunwind 1.6, currently its logic mismatches the function intention.

Signed-off-by: hubin <hubin73@huawei.com>