### PR TITLE
Improve unwinding through a bad function pointer on x86_64.

### DIFF
--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -231,14 +231,14 @@ unw_step (unw_cursor_t *cursor)
                              */
                             c->dwarf.cfa += 8;
                             /* Optimised x64 binaries don't use RBP it seems? */
-                            rbp_loc = DWARF_LOC (rbp, 0);
-                            rsp_loc = DWARF_LOC (rsp, 0);
+                            rbp_loc = c->dwarf.loc[RBP];
+                            rsp_loc = DWARF_VAL_LOC (c, rsp + 8);
                             rip_loc = DWARF_LOC (rsp, 0);
                           }
                         else
                           Debug (2, "new_ip 0x%lx dwarf_get(&c->dwarf, DWARF_MEM_LOC(c->dwarf, new_ip), &not_used) != 0\n", new_ip);
                       }
-		                else
+                    else
                         Debug (2, "rsp 0x%lx dwarf_get(&c->dwarf, DWARF_MEM_LOC(c->dwarf, rsp), &new_ip) != 0\n", rsp);
                   }
               /*


### PR DESCRIPTION
When unwinding through a call to a bad function pointer, assume that RBP and RSP were not modified.

Add a unit test (which fails before this patch and succeeds with it).

Before the patch:
```
Backtrace across SIGSEGV handler:
segv_handler: got signal 11
        explicit backtrace:
0000557614b8457e <do_backtrace+0x2e>              (sp=00007ffecf001620)
        proc=0x557614b84550-0x557614b847e6
        handler=0x0 lsda=0x0 gp=0x557614b86fe8
0000557614b84873 <segv_handler+0x13>              (sp=00007ffecf001770)
        proc=0x557614b84860-0x557614b8489d
        handler=0x0 lsda=0x0 gp=0x557614b86fe8
00007fac4003daa0 <__sigaction+0x40>               (sp=00007ffecf001780)
        proc=0x7fac4003da9f-0x7fac4003daa9
        handler=0x0 lsda=0x0 gp=0x7fac401f3fe8
0000000000000123                                  (sp=00007ffecf002468)
        proc=0x123-0x124
        handler=0x0 lsda=0x0 gp=0x0
0000557614b843cf <main+0x1ff>                     (sp=0000557614b843cf)
        proc=0x557614b841d0-0x557614b84452
        handler=0x0 lsda=0x0 gp=0x557614b86fe8
4800002c3a058d48                                  (sp=0000557614b8449f)
        proc=0x4800002c3a058d48-0x4800002c3a058d49
        handler=0x0 lsda=0x0 gp=0x0
FAILURE: unw_step() returned -1 for ip=4800002c3a058d48
```
After the patch:
```
Backtrace across SIGSEGV handler:
segv_handler: got signal 11
        explicit backtrace:
00005616e0b5b57e <do_backtrace+0x2e>              (sp=00007ffe498a9760)
        proc=0x5616e0b5b550-0x5616e0b5b7e6
        handler=0x0 lsda=0x0 gp=0x5616e0b5dfe8
00005616e0b5b873 <segv_handler+0x13>              (sp=00007ffe498a98b0)
        proc=0x5616e0b5b860-0x5616e0b5b89d
        handler=0x0 lsda=0x0 gp=0x5616e0b5dfe8
00007fcfa563daa0 <__sigaction+0x40>               (sp=00007ffe498a98c0)
        proc=0x7fcfa563da9f-0x7fcfa563daa9
        handler=0x0 lsda=0x0 gp=0x7fcfa57f3fe8
0000000000000123                                  (sp=00007ffe498aa598)
        proc=0x123-0x124
        handler=0x0 lsda=0x0 gp=0x0
00005616e0b5b3cf <main+0x1ff>                     (sp=00007ffe498aa5a0)
        proc=0x5616e0b5b1d0-0x5616e0b5b452
        handler=0x0 lsda=0x0 gp=0x5616e0b5dfe8
00007fcfa562920a <__libc_init_first+0x8a>         (sp=00007ffe498aa670)
        proc=0x7fcfa5629190-0x7fcfa562923c
        handler=0x0 lsda=0x0 gp=0x7fcfa57f3fe8
00007fcfa56292bc <__libc_start_main+0x7c>         (sp=00007ffe498aa710)
        proc=0x7fcfa5629240-0x7fcfa5629380
        handler=0x0 lsda=0x0 gp=0x7fcfa57f3fe8
00005616e0b5b481 <_start+0x21>                    (sp=00007ffe498aa760)
        proc=0x5616e0b5b460-0x5616e0b5b482
        handler=0x0 lsda=0x0 gp=0x5616e0b5dfe8
```
