### PR TITLE
Remove the unused powerpc setcontext() dummies

### DIFF
--- a/src/ppc32/setcontext.S
+++ b/src/ppc32/setcontext.S
@@ -1,9 +1,0 @@
-	.global _UI_setcontext
-
-_UI_setcontext:
-	retq
-
-#ifdef __linux__
-        /* We do not need executable stack.  */
-        .section        .note.GNU-stack,"",@progbits
-#endif

--- a/src/ppc64/setcontext.S
+++ b/src/ppc64/setcontext.S
@@ -1,9 +1,0 @@
-	.global _UI_setcontext
-
-_UI_setcontext:
-        blr
-
-#ifdef __linux__
-        /* We do not need executable stack.  */
-        .section        .note.GNU-stack,"",@progbits
-#endif


### PR DESCRIPTION
They were not even shipped in the tarballs.

It only creates confusion when looking at the source that such files were present, and they contain little that would be useful if anyone would write actual implementations.