### PR TITLE
README: Remove outdated information

### DIFF
--- a/README
+++ b/README
@@ -17,7 +17,7 @@ This library supports several architecture/operating-system combinations:
 | Linux   | IA-64        | ✓      |
 | Linux   | PARISC       | Works well, but C library missing unwind-info |
 | Linux   | Tilegx       | 64-bit mode only |
-| Linux   | MIPS         | Newly added |
+| Linux   | MIPS         | ✓      |
 | Linux   | RISC-V       | 64-bit only |
 | Linux   | LoongArch    | 64-bit only |
 | HP-UX   | IA-64        | Mostly works, but known to have serious limitations |
@@ -94,18 +94,6 @@ libunwind should be configured and installed on HP-UX like this:
 
 Caveat: Unwinding of 32-bit (ILP32) binaries is not supported at the moment.
 
-### Workaround for older versions of GCC
-
-GCC v3.0 and GCC v3.2 ship with a bad version of `sys/types.h`.  The
-workaround is to issue the following commands before running
-`configure`:
-
-    $ mkdir $top_dir/include/sys
-    $ cp /usr/include/sys/types.h $top_dir/include/sys
-
-GCC v3.3.2 or later have been fixed and do not require this
-workaround.
-
 ### Building for PowerPC64 / Linux
 
 For building for power64 you should use:
@@ -141,27 +129,6 @@ After building the library, you can run a set of regression tests with:
 
     $ make check
 
-### Expected results on IA-64 Linux
-
-Unless you have a very recent C library and compiler installed, it is
-currently expected to have the following tests fail on IA-64 Linux:
-
-* `Gtest-init` (should pass starting with glibc-2.3.x/gcc-3.4)
-* `Ltest-init` (should pass starting with glibc-2.3.x/gcc-3.4)
-* `test-ptrace` (should pass starting with glibc-2.3.x/gcc-3.4)
-* `run-ia64-test-dyn1` (should pass starting with glibc-2.3.x)
-
-This does not mean that libunwind cannot be used with older compilers
-or C libraries, it just means that for certain corner cases, unwinding
-will fail.  Since they're corner cases, it is not likely for
-applications to trigger them.
-
-Note: If you get lots of errors in `Gia64-test-nat` and `Lia64-test-nat`, it's
-almost certainly a sign of an old assembler.  The GNU assembler used
-to encode previous-stack-pointer-relative offsets incorrectly.
-This bug was fixed on 21-Sep-2004 so any later assembler will be
-fine.
-
 ### Expected results on x86 Linux
 
 The following tests are expected to fail on x86 Linux:
@@ -176,10 +143,6 @@ The following tests are expected to fail on x86-64 Linux:
   and <http://gcc.gnu.org/bugzilla/show_bug.cgi?id=18749>)
 
 ### Expected results on PARISC Linux
-
-Caveat: GCC v3.4 or newer is needed on PA-RISC Linux.  Earlier
-versions of the compiler failed to generate the exception-handling
-program header (`GNU_EH_FRAME`) needed for unwinding.
 
 The following tests are expected to fail on x86-64 Linux:
 


### PR DESCRIPTION
Documentation tends to get outdated, and "Newly added" does not age well.

Remove descriptions of toolchain problems that were fixed ~20 years ago.