### PR TITLE
Use size_t to match R.H.S

### DIFF
--- a/src/os-linux.c
+++ b/src/os-linux.c
@@ -74,7 +74,7 @@ tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
 
   if (!stat(root, &st) && S_ISDIR(st.st_mode))
     {
-      unsigned long _len = strlen(root) + strlen(mi.path) + 1;
+      size_t _len = strlen(root) + strlen(mi.path) + 1;
       if(_len >= FULL_PATH_BUFF_SZ)
         {
           full_path = (char*) malloc(_len);


### PR DESCRIPTION
This fixes an error on Windows x64, when upgrading libunwind in dotnet/runtime to 1.7.0-rc2:

```powershell
  C:\git\runtime\src\native\external\libunwind\src\os-linux.c(77): error C2220: the following warning is treated as an error
  C:\git\runtime\src\native\external\libunwind\src\os-linux.c(77): warning C4267: 'initializing': conversion from 'size_t' to '
  unsigned long', possible loss of data
```