### PR TITLE
dwarf_find_unwind_table: Find load_base correctly when current segment does not start at segbase

### DIFF
--- a/src/dwarf/Gfind_unwind_table.c
+++ b/src/dwarf/Gfind_unwind_table.c
@@ -41,7 +41,7 @@ dwarf_find_unwind_table (struct elf_dyn_info *edi, unw_addr_space_t as,
                          unw_word_t ip)
 {
   Elf_W(Phdr) *phdr, *ptxt = NULL, *peh_hdr = NULL, *pdyn = NULL;
-  unw_word_t addr, eh_frame_start, fde_count, load_base;
+  unw_word_t addr, eh_frame_start, fde_count, loadoff, load_base;
   unw_word_t max_load_addr = 0;
   unw_word_t start_ip = to_unw_word (-1);
   unw_word_t end_ip = 0;
@@ -104,7 +104,8 @@ dwarf_find_unwind_table (struct elf_dyn_info *edi, unw_addr_space_t as,
   if (!ptxt)
     return 0;
 
-  load_base = segbase - ptxt->p_vaddr;
+  loadoff = mapoff + (ptxt->p_vaddr - ptxt->p_offset);
+  load_base = segbase - loadoff;
   start_ip += load_base;
   end_ip += load_base;
 


### PR DESCRIPTION
Hi,

I have noticed that libunwind gives me lots of broken stacks and errors when I am trying to unwind a binary linked with ld.lld (from LLVM 10.0.1). And the basic reason that I have found is that ld.lld have a slightly different memory layout than what it expects. Here are some information which can help to understand what I mean:

```
$ readelf -lW /home/user/my_exec | grep -e LOAD -e Type
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
  LOAD           0x000000 0x0000000000200000 0x0000000000200000 0x1791f4 0x1791f4 R   0x1000
  LOAD           0x179200 0x000000000037a200 0x000000000037a200 0x22d5c0 0x22d5c0 R E 0x1000
  LOAD           0x3a67c0 0x00000000005a87c0 0x00000000005a87c0 0x000738 0x30eab0 RW  0x1000
  LOAD           0x3a7270 0x00000000008b8270 0x00000000008b8270 0x002bc8 0x003c00 RW  0x1000

$ cat /proc/1388597/maps | grep /home/user/my_exec
00200000-0037a000 r--p 00000000 fc:03 3758748678                         /home/user/my_exec
0037a000-005a8000 r-xp 00179000 fc:03 3758748678                         /home/user/my_exec
005a8000-005a9000 r--p 003a6000 fc:03 3758748678                         /home/user/my_exec
008b8000-008bb000 rw-p 003a7000 fc:03 3758748678                         /home/user/my_exec
```

The section with code is the second one (`0037a000-005a8000`). Here are the values of some variables that we get from this info:

* From maps: `segbase = 0x37a000`, `mapoff = 0x179000`
* From ELF image: `ptxt->p_vaddr = 0x37a200`, `ptxt->p_offset = 0x179200`

As you can see, `p_vaddr` is a little higher than `segbase`, which is due to alignment requirements of memory mapping. As a result, old formula calculates `load_base = 0x37a000 - 0x37a200 = 0xfffffffffffffe00`, but it should be equal to `0x0`!

My formula basically solves a following equation, where I try to calculate difference between segment start and memory mapping region start in two ways: `ptxt->p_offset - mapoff = ptxt->p_vaddr - loadoff`, and then it substracts resulting `loadoff` from `segbase` to get a real `load_base`.

For the example above, we get `loadoff = 0x179000 + (0x37a200 - 0x179200) = 0x37a000`, resulting in `load_base = 0x37a000 - 0x37a000 = 0x0`.

An example from the same process, but with a DLL unwinding:

```
$ readelf -lW /home/user/libmy_lib.so | grep -e LOAD -e Type
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
  LOAD           0x000000 0x0000000000000000 0x0000000000000000 0x05cef4 0x05cef4 R   0x1000
  LOAD           0x05cf00 0x000000000005df00 0x000000000005df00 0x06e1a0 0x06e1a0 R E 0x1000
  LOAD           0x0cb0a0 0x00000000000cd0a0 0x00000000000cd0a0 0x002678 0x002678 RW  0x1000
  LOAD           0x0cd718 0x00000000000d0718 0x00000000000d0718 0x0017a0 0x001bb0 RW  0x1000

$ cat /proc/1388597/maps | grep /home/user/libmy_lib.so
7ffff56e4000-7ffff5741000 r--p 00000000 fc:03 3893003283                 /home/user/libmy_lib.so
7ffff5741000-7ffff57b1000 r-xp 0005c000 fc:03 3893003283                 /home/user/libmy_lib.so
7ffff57b1000-7ffff57b4000 r--p 000cb000 fc:03 3893003283                 /home/user/libmy_lib.so
7ffff57b4000-7ffff57b6000 rw-p 000cd000 fc:03 3893003283                 /home/user/libmy_lib.so
```

* `segbase = 0x7ffff5741000`, `mapoff = 0x5c000`, `ptxt->p_vaddr = 0x5df00`, `ptxt->p_offset = 0x5cf00`
* Old formula: `load_base = 0x7ffff5741000 - 0x5df00 = 0x7ffff56e3100`, which is not an expected `0x7ffff56e4000`
* My formula: `loadoff = 0x5c000 + (0x5df00 - 0x5cf00) = 0x5d000`, `load_base = 0x7ffff5741000 - 0x5d000 = 0x7ffff56e4000`

I believe we can also floor `ptxt->p_vaddr` to a specified alignment, but I am not sure if this will give expected results...