### PR TITLE
Fix `single-bit-bitfield-constant-conversion` warning

### DIFF
--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -220,7 +220,7 @@ unw_step (unw_cursor_t *cursor)
                             Debug (2, "new_ip 0x%lx looks valid\n", new_ip);
                             rip_fixup_success = 1;
                             c->frame_info.cfa_reg_offset = 8;
-                            c->frame_info.cfa_reg_rsp = 1;
+                            c->frame_info.cfa_reg_rsp = -1;
                             c->frame_info.rbp_cfa_offset = -1;
                             c->frame_info.rsp_cfa_offset = -1;
                             c->frame_info.frame_type = UNW_X86_64_FRAME_OTHER;


### PR DESCRIPTION
```sh
# with clang-16 rc1
$ CC=clang-16 sh -c 'autoreconf -i && ./configure && make'
...
x86_64/Gstep.c:223:55: warning: implicit truncation from 'int' to a one-bit wide bit-field changes value from 1 to -1 [-Wsingle-bit-bitfield-constant-conversion]
                            c->frame_info.cfa_reg_rsp = 1;
                                                      ^ ~
```