### PR TITLE
Bump actions/checkout@v2 to @v3

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -33,7 +33,7 @@ jobs:
           - O0
           - O3
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup
         run: |
           HOST=${{ matrix.HOST }}
@@ -93,7 +93,7 @@ jobs:
           - {target: mips64el,toolchain: g++-mips64el-linux-gnuabi64, host: mips64el-linux-gnuabi64,qemu: mips64el }
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install QEMU
         # this ensure install latest qemu on ubuntu, apt get version is old
         env:

--- a/.github/workflows/CI-win.yml
+++ b/.github/workflows/CI-win.yml
@@ -27,7 +27,7 @@ jobs:
           - {toolchain: Visual Studio 17 2022, arch: x64, server: 2022, TARGET: aarch64-linux-gnu}
           - {toolchain: Visual Studio 17 2022, arch: x64, server: 2022, TARGET: x86_64-linux-gnu}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
         shell: cmd
         env:


### PR DESCRIPTION
Github has recommended this to move from an unsupported node.js version.