### PR TITLE
Add introspection for march=armv8-a+sve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Makefile.in
 
 INSTALL
 aclocal.m4
+m4/
 autom4te.cache/
 aux
 config.log

--- a/configure.ac
+++ b/configure.ac
@@ -389,6 +389,10 @@ if test x$GCC = xyes -a x$intel_compiler != xyes -a x$qcc_compiler != xyes -a x$
   LIBCRTS="-lgcc_s"
 fi
 
+AC_MSG_CHECKING([if compiler supports -march=native])
+AM_CONDITIONAL([COMPILER_SUPPORTS_MARCH_NATIVE], ["$CC" -march=native -S -o /dev/null -xc /dev/null > /dev/null 2>&1])
+AM_COND_IF([COMPILER_SUPPORTS_MARCH_NATIVE], [AC_MSG_NOTICE(yes)], [AC_MSG_NOTICE(no)])
+
 AC_MSG_CHECKING([for __builtin___clear_cache])
 AC_LINK_IFELSE(
   [AC_LANG_PROGRAM([[]], [[__builtin___clear_cache(0, 0)]])],

--- a/configure.ac
+++ b/configure.ac
@@ -390,11 +390,11 @@ if test x$GCC = xyes -a x$intel_compiler != xyes -a x$qcc_compiler != xyes -a x$
 fi
 
 OLD_CFLAGS="${CFLAGS}"
-CFLAGS="${CFLAGS} -march=native"
-AC_MSG_CHECKING([if compiler supports -march=native])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [supports_march_native=yes],[supports_march_native=no])
-AM_CONDITIONAL(COMPILER_SUPPORTS_MARCH_NATIVE, [test x$supports_march_native = xyes])
-AC_MSG_RESULT([$supports_march_native])
+CFLAGS="${CFLAGS} -march=armv8-a+sve"
+AC_MSG_CHECKING([if compiler supports -march=armv8-a+sve])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [supports_march_armv8_a_sve=yes],[supports_march_armv8_a_sve=no])
+AM_CONDITIONAL(COMPILER_SUPPORTS_MARCH_ARMV8_A_SVE, [test x$supports_march_armv8_a_sve = xyes])
+AC_MSG_RESULT([$supports_march_armv8_a_sve])
 CFLAGS="${OLD_CFLAGS}"
 
 AC_MSG_CHECKING([for __builtin___clear_cache])

--- a/configure.ac
+++ b/configure.ac
@@ -389,9 +389,13 @@ if test x$GCC = xyes -a x$intel_compiler != xyes -a x$qcc_compiler != xyes -a x$
   LIBCRTS="-lgcc_s"
 fi
 
+OLD_CFLAGS="${CFLAGS}"
+CFLAGS="${CFLAGS} -march=native"
 AC_MSG_CHECKING([if compiler supports -march=native])
-AM_CONDITIONAL([COMPILER_SUPPORTS_MARCH_NATIVE], ["$CC" -march=native -S -o /dev/null -xc /dev/null > /dev/null 2>&1])
-AM_COND_IF([COMPILER_SUPPORTS_MARCH_NATIVE], [AC_MSG_NOTICE(yes)], [AC_MSG_NOTICE(no)])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [supports_march_native=yes],[supports_march_native=no])
+AM_CONDITIONAL(COMPILER_SUPPORTS_MARCH_NATIVE, [test x$supports_march_native = xyes])
+AC_MSG_RESULT([$supports_march_native])
+CFLAGS="${OLD_CFLAGS}"
 
 AC_MSG_CHECKING([for __builtin___clear_cache])
 AC_LINK_IFELSE(

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -172,8 +172,11 @@ Lx64_test_dwarf_expressions_SOURCES =  Lx64-test-dwarf-expressions.c \
 
 Garm64_test_sve_signal_SOURCES = Garm64-test-sve-signal.c
 Larm64_test_sve_signal_SOURCES = Larm64-test-sve-signal.c
-Garm64_test_sve_signal_CFLAGS = -fno-inline -march=native
-Larm64_test_sve_signal_CFLAGS = -fno-inline -march=native
+
+if COMPILER_SUPPORTS_MARCH_NATIVE
+ Garm64_test_sve_signal_CFLAGS = -fno-inline -march=native
+ Larm64_test_sve_signal_CFLAGS = -fno-inline -march=native
+endif
 
 Gtest_init_SOURCES = Gtest-init.cxx
 Ltest_init_SOURCES = Ltest-init.cxx

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -173,9 +173,9 @@ Lx64_test_dwarf_expressions_SOURCES =  Lx64-test-dwarf-expressions.c \
 Garm64_test_sve_signal_SOURCES = Garm64-test-sve-signal.c
 Larm64_test_sve_signal_SOURCES = Larm64-test-sve-signal.c
 
-if COMPILER_SUPPORTS_MARCH_NATIVE
- Garm64_test_sve_signal_CFLAGS = -fno-inline -march=native
- Larm64_test_sve_signal_CFLAGS = -fno-inline -march=native
+if COMPILER_SUPPORTS_MARCH_ARMV8_A_SVE
+ Garm64_test_sve_signal_CFLAGS = -fno-inline -march=armv8-a+sve
+ Larm64_test_sve_signal_CFLAGS = -fno-inline -march=armv8-a+sve
 endif
 
 Gtest_init_SOURCES = Gtest-init.cxx


### PR DESCRIPTION
Fix #470


```sh
checking if compiler supports -march=armv8-a+sve... configure: yes # or no, depending on the CI leg
```