### PR TITLE
Add refined read-only permissions to CI actions

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -1,5 +1,8 @@
 name: CI - Unix
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/CI-win.yml
+++ b/.github/workflows/CI-win.yml
@@ -1,5 +1,8 @@
 name: CI - Windows
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
As suggested, add refined permissions to GH workflow actions for security.

Closes #474 