### PR TITLE
Provide syscall wrappers for `mmap` and `munmap`

### DIFF
--- a/src/aarch64/Gtrace.c
+++ b/src/aarch64/Gtrace.c
@@ -70,7 +70,7 @@ trace_cache_free (void *arg)
   }
   tls_cache_destroyed = 1;
   tls_cache = NULL;
-  munmap (cache->frames, (1u << cache->log_size) * sizeof(unw_tdep_frame_t));
+  mi_munmap (cache->frames, (1u << cache->log_size) * sizeof(unw_tdep_frame_t));
   mempool_free (&trace_cache_pool, cache);
   Debug(5, "freed cache %p\n", cache);
 }
@@ -152,7 +152,7 @@ trace_cache_expand (unw_trace_cache_t *cache)
   }
 
   Debug(5, "expanded cache from 2^%lu to 2^%lu buckets\n", cache->log_size, new_log_size);
-  munmap(cache->frames, old_size * sizeof(unw_tdep_frame_t));
+  mi_munmap(cache->frames, old_size * sizeof(unw_tdep_frame_t));
   cache->frames = new_frames;
   cache->log_size = new_log_size;
   cache->used = 0;

--- a/src/arm/Gtrace.c
+++ b/src/arm/Gtrace.c
@@ -70,7 +70,7 @@ trace_cache_free (void *arg)
   }
   tls_cache_destroyed = 1;
   tls_cache = NULL;
-  munmap (cache->frames, (1u << cache->log_size) * sizeof(unw_tdep_frame_t));
+  mi_munmap (cache->frames, (1u << cache->log_size) * sizeof(unw_tdep_frame_t));
   mempool_free (&trace_cache_pool, cache);
   Debug(5, "freed cache %p\n", cache);
 }
@@ -153,7 +153,7 @@ trace_cache_expand (unw_trace_cache_t *cache)
 
   Debug(5, "expanded cache from 2^%u to 2^%u buckets\n", cache->log_size,
         new_log_size);
-  munmap(cache->frames, old_size * sizeof(unw_tdep_frame_t));
+  mi_munmap(cache->frames, old_size * sizeof(unw_tdep_frame_t));
   cache->frames = new_frames;
   cache->log_size = new_log_size;
   cache->used = 0;

--- a/src/coredump/_UCD_elf_map_image.c
+++ b/src/coredump/_UCD_elf_map_image.c
@@ -55,7 +55,7 @@ CD_elf_map_image(struct UCD_info *ui, coredump_phdr_t *phdr)
       if (remainder_len > 0)
         {
           void *remainder_base = (char*) ei->image + phdr->p_filesz;
-          munmap(remainder_base, remainder_len);
+          mi_munmap(remainder_base, remainder_len);
         }
     } else {
       ucd_file_t *ucd_file =  ucd_file_table_at(&ui->ucd_file_table, phdr->p_backing_file_index);
@@ -76,7 +76,7 @@ CD_elf_map_image(struct UCD_info *ui, coredump_phdr_t *phdr)
   /* Check ELF header for sanity */
   if (!elf_w(valid_object)(ei))
     {
-      munmap(ei->image, ei->size);
+      mi_munmap(ei->image, ei->size);
       ei->image = NULL;
       ei->size = 0;
       return NULL;

--- a/src/coredump/_UCD_elf_map_image.c
+++ b/src/coredump/_UCD_elf_map_image.c
@@ -43,10 +43,10 @@ CD_elf_map_image(struct UCD_info *ui, coredump_phdr_t *phdr)
        * these pages are allocated, but non-accessible.
        */
       /* addr, length, prot, flags, fd, fd_offset */
-      ei->image = mmap(NULL, phdr->p_memsz, PROT_READ, MAP_PRIVATE, ui->coredump_fd, phdr->p_offset);
+      ei->image = mi_mmap(NULL, phdr->p_memsz, PROT_READ, MAP_PRIVATE, ui->coredump_fd, phdr->p_offset);
       if (ei->image == MAP_FAILED)
         {
-          Debug(0, "error %d in mmap(): %s\n", errno, strerror(errno));
+          Debug(0, "error in mmap()\n");
           ei->image = NULL;
           return NULL;
         }

--- a/src/coredump/ucd_file_table.c
+++ b/src/coredump/ucd_file_table.c
@@ -124,10 +124,10 @@ ucd_file_map (ucd_file_t *ucd_file)
       _ucd_file_open (ucd_file);
 	}
 
-  ucd_file->image = mmap(NULL, ucd_file->size, PROT_READ, MAP_PRIVATE, ucd_file->fd, 0);
+  ucd_file->image = mi_mmap(NULL, ucd_file->size, PROT_READ, MAP_PRIVATE, ucd_file->fd, 0);
   if (ucd_file->image == MAP_FAILED)
 	{
-	  Debug(0, "error %d in mmap(%s): %s\n", errno, ucd_file->filename, strerror(errno));
+	  Debug(0, "error in mmap(%s)\n", ucd_file->filename);
 	  ucd_file->image = NULL;
 	  return NULL;
 	}

--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -128,7 +128,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local,
   if (!shdr ||
       (shdr->sh_offset + shdr->sh_size > ei.size))
     {
-      munmap(ei.image, ei.size);
+      mi_munmap(ei.image, ei.size);
       return 1;
     }
 
@@ -146,7 +146,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local,
 	  if (!*buf)
 	    {
 	      Debug (2, "failed to allocate zlib .debug_frame buffer, skipping\n");
-	      munmap(ei.image, ei.size);
+	      mi_munmap(ei.image, ei.size);
 	      return 1;
 	    }
 
@@ -156,8 +156,8 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local,
 	  if (ret != Z_OK)
 	    {
 	      Debug (2, "failed to decompress zlib .debug_frame, skipping\n");
-	      munmap(*buf, *bufsize);
-	      munmap(ei.image, ei.size);
+	      mi_munmap(*buf, *bufsize);
+	      mi_munmap(ei.image, ei.size);
 	      return 1;
 	    }
 
@@ -169,7 +169,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local,
 	{
 	  Debug (2, "unknown compression type %d, skipping\n",
 		 chdr->ch_type);
-          munmap(ei.image, ei.size);
+          mi_munmap(ei.image, ei.size);
 	  return 1;
         }
     }
@@ -182,7 +182,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local,
       if (!*buf)
         {
           Debug (2, "failed to allocate .debug_frame buffer, skipping\n");
-          munmap(ei.image, ei.size);
+          mi_munmap(ei.image, ei.size);
           return 1;
         }
 
@@ -207,7 +207,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local,
         break;
       }
 
-  munmap(ei.image, ei.size);
+  mi_munmap(ei.image, ei.size);
   return 0;
 }
 
@@ -549,7 +549,7 @@ dwarf_find_eh_frame_section(struct dl_phdr_info *info)
          eh_frame);
 
 out:
-  munmap (ei.image, ei.size);
+  mi_munmap (ei.image, ei.size);
 
   return eh_frame;
 }

--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -571,14 +571,14 @@ dwarf_flush_rs_cache (struct dwarf_rs_cache *cache)
     cache->log_size = DWARF_DEFAULT_LOG_UNW_CACHE_SIZE;
   } else {
     if (cache->hash && cache->hash != cache->default_hash)
-      munmap(cache->hash, DWARF_UNW_HASH_SIZE(cache->prev_log_size)
-                           * sizeof (cache->hash[0]));
+      mi_munmap(cache->hash, DWARF_UNW_HASH_SIZE(cache->prev_log_size)
+                              * sizeof (cache->hash[0]));
     if (cache->buckets && cache->buckets != cache->default_buckets)
-      munmap(cache->buckets, DWARF_UNW_CACHE_SIZE(cache->prev_log_size)
-	                      * sizeof (cache->buckets[0]));
+      mi_munmap(cache->buckets, DWARF_UNW_CACHE_SIZE(cache->prev_log_size)
+                              * sizeof (cache->buckets[0]));
     if (cache->links && cache->links != cache->default_links)
-      munmap(cache->links, DWARF_UNW_CACHE_SIZE(cache->prev_log_size)
-	                      * sizeof (cache->links[0]));
+      mi_munmap(cache->links, DWARF_UNW_CACHE_SIZE(cache->prev_log_size)
+                              * sizeof (cache->links[0]));
     GET_MEMORY(cache->hash, DWARF_UNW_HASH_SIZE(cache->log_size)
                              * sizeof (cache->hash[0]));
     GET_MEMORY(cache->buckets, DWARF_UNW_CACHE_SIZE(cache->log_size)

--- a/src/elfxx.c
+++ b/src/elfxx.c
@@ -239,10 +239,9 @@ elf_w (extract_minidebuginfo) (struct elf_image *ei, struct elf_image *mdi)
     }
 
   mdi->size = uncompressed_len;
-  mdi->image = mmap (NULL, uncompressed_len, PROT_READ|PROT_WRITE,
-                     MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+  GET_MEMORY (mdi->image, uncompressed_len);
 
-  if (mdi->image == MAP_FAILED)
+  if (!mdi->image)
     return 0;
 
   size_t in_pos = 0, out_pos = 0;

--- a/src/elfxx.c
+++ b/src/elfxx.c
@@ -253,7 +253,7 @@ elf_w (extract_minidebuginfo) (struct elf_image *ei, struct elf_image *mdi)
   if (lret != LZMA_OK)
     {
       Debug (1, "LZMA decompression failed: %d\n", lret);
-      munmap (mdi->image, mdi->size);
+      mi_munmap (mdi->image, mdi->size);
       return 0;
     }
 
@@ -299,7 +299,7 @@ elf_w (get_proc_name_in_image) (unw_addr_space_t as, struct elf_image *ei,
           ret = ret_mdi;
         }
 
-      munmap (mdi.image, mdi.size);
+      mi_munmap (mdi.image, mdi.size);
     }
 
   if (min_dist >= ei->size)
@@ -328,7 +328,7 @@ elf_w (get_proc_name) (unw_addr_space_t as, pid_t pid, unw_word_t ip,
 
   ret = elf_w (get_proc_name_in_image) (as, &ei, segbase, ip, buf, buf_len, offp);
 
-  munmap (ei.image, ei.size);
+  mi_munmap (ei.image, ei.size);
   ei.image = NULL;
 
   return ret;
@@ -474,7 +474,7 @@ elf_w (load_debuglink) (const char* file, struct elf_image *ei, int is_local)
         }
       else
         {
-          munmap (prev_image, prev_size);
+          mi_munmap (prev_image, prev_size);
         }
 
       return ret;

--- a/src/elfxx.h
+++ b/src/elfxx.h
@@ -92,7 +92,7 @@ elf_map_image (struct elf_image *ei, const char *path)
 
   if (!elf_w (valid_object) (ei))
   {
-    munmap(ei->image, ei->size);
+    mi_munmap(ei->image, ei->size);
     return -1;
   }
 

--- a/src/elfxx.h
+++ b/src/elfxx.h
@@ -85,7 +85,7 @@ elf_map_image (struct elf_image *ei, const char *path)
     }
 
   ei->size = stat.st_size;
-  ei->image = mmap (NULL, ei->size, PROT_READ, MAP_PRIVATE, fd, 0);
+  ei->image = mi_mmap (NULL, ei->size, PROT_READ, MAP_PRIVATE, fd, 0);
   close (fd);
   if (ei->image == MAP_FAILED)
     return -1;

--- a/src/mi/flush_cache.c
+++ b/src/mi/flush_cache.c
@@ -37,10 +37,10 @@ unw_flush_cache (unw_addr_space_t as, unw_word_t lo, unw_word_t hi)
       struct unw_debug_frame_list *n = w->next;
 
       if (w->index)
-        munmap (w->index, w->index_size);
+        mi_munmap (w->index, w->index_size);
 
-      munmap (w->debug_frame, w->debug_frame_size);
-      munmap (w, sizeof (*w));
+      mi_munmap (w->debug_frame, w->debug_frame_size);
+      mi_munmap (w, sizeof (*w));
       w = n;
     }
   as->debug_frames = NULL;

--- a/src/os-freebsd.c
+++ b/src/os-freebsd.c
@@ -46,7 +46,7 @@ get_mem(size_t sz)
 static void
 free_mem(void *ptr, size_t sz)
 {
-  munmap(ptr, sz);
+  mi_munmap(ptr, sz);
 }
 
 static int

--- a/src/os-freebsd.c
+++ b/src/os-freebsd.c
@@ -37,7 +37,7 @@ get_mem(size_t sz)
 {
   void *res;
 
-  res = mmap(NULL, sz, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+  res = mi_mmap(NULL, sz, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
   if (res == MAP_FAILED)
     return (NULL);
   return (res);

--- a/src/os-linux.h
+++ b/src/os-linux.h
@@ -77,9 +77,8 @@ maps_init (struct map_iterator *mi, pid_t pid)
     {
       /* Try to allocate a page-sized buffer.  */
       mi->buf_size = getpagesize ();
-      cp = mmap (NULL, mi->buf_size, PROT_READ | PROT_WRITE,
-                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-      if (cp == MAP_FAILED)
+      GET_MEMORY (cp, mi->buf_size);
+      if (!cp)
         {
           close(mi->fd);
           mi->fd = -1;

--- a/src/os-linux.h
+++ b/src/os-linux.h
@@ -306,7 +306,7 @@ maps_close (struct map_iterator *mi)
   mi->fd = -1;
   if (mi->buf)
     {
-      munmap (mi->buf_end - mi->buf_size, mi->buf_size);
+      mi_munmap (mi->buf_end - mi->buf_size, mi->buf_size);
       mi->buf = mi->buf_end = NULL;
     }
 }

--- a/src/x86_64/Gtrace.c
+++ b/src/x86_64/Gtrace.c
@@ -69,7 +69,7 @@ trace_cache_free (void *arg)
   }
   tls_cache_destroyed = 1;
   tls_cache = NULL;
-  munmap (cache->frames, (1u << cache->log_size) * sizeof(unw_tdep_frame_t));
+  mi_munmap (cache->frames, (1u << cache->log_size) * sizeof(unw_tdep_frame_t));
   mempool_free (&trace_cache_pool, cache);
   Debug(5, "freed cache %p\n", cache);
 }
@@ -151,7 +151,7 @@ trace_cache_expand (unw_trace_cache_t *cache)
   }
 
   Debug(5, "expanded cache from 2^%lu to 2^%lu buckets\n", cache->log_size, new_log_size);
-  munmap(cache->frames, old_size * sizeof(unw_tdep_frame_t));
+  mi_munmap(cache->frames, old_size * sizeof(unw_tdep_frame_t));
   cache->frames = new_frames;
   cache->log_size = new_log_size;
   cache->used = 0;


### PR DESCRIPTION
These functions are assumed to be direct wrappers to the syscalls, but in the past (see Open MPI) and also now (see UCX) runtimes do intercept these functions and do AS-unsafe stuff inside there runtimes. Hence provide internal syscall wrappers for these functions to improve AS-safety.