### PR TITLE
Initial spike of implementing UNW_INFO_FORMAT_DYNAMIC for dwarf targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ tests/[GL]ia64-test-stack
 tests/ia64-test-dyn1
 tests/ia64-test-sig
 tests/[GL]x64-test-dwarf-expressions
+tests/x64-test-dyn1
 tests/x64-unwind-badjmp-signal-frame
 tests/*.log
 tests/*.trs

--- a/include/dwarf.h
+++ b/include/dwarf.h
@@ -232,6 +232,10 @@ typedef enum
     DWARF_WHERE_EXPR,           /* register saved */
     DWARF_WHERE_VAL_EXPR,       /* register has computed value */
     DWARF_WHERE_CFA,            /* register is set to the computed cfa value */
+    DWARF_WHERE_DYN_OFFSET,     /* register has the value in the previous frame, plus an offset */
+    DWARF_WHERE_DYN_FP_REL,     /* register is spilled to this fp-relative offset */
+    DWARF_WHERE_DYN_SP_REL,     /* register is spilled to this sp-relative offset */
+    DWARF_WHERE_DYN_SAVE_SP,    /* used to implement UNW_DYN_SAVE_SP */
   }
 dwarf_where_t;
 

--- a/include/libunwind-dynamic.h
+++ b/include/libunwind-dynamic.h
@@ -67,7 +67,13 @@ typedef enum
     UNW_DYN_POP_FRAMES,         /* drop one or more stack frames */
     UNW_DYN_LABEL_STATE,        /* name the current state */
     UNW_DYN_COPY_STATE,         /* set the region's entry-state */
-    UNW_DYN_ALIAS               /* get unwind info from an alias */
+    UNW_DYN_ALIAS,              /* get unwind info from an alias */
+    UNW_DYN_RESTORE_REG,        /* restores a register to the value it had in the previous frame */
+    UNW_DYN_SAVE_SP,            /* the value of SP in the previous frame is found as BP + displacement,
+                                   where displacement is the accumulated value from previous UNW_DYN_ADD
+                                   directives on SP. This displacement is needed on x86_64, because the
+                                   value of %rsp saved in %rbp is _not_ exactly the value from the
+                                   previous frame, but rather slightly lower. */
   }
 unw_dyn_operation_t;
 
@@ -205,6 +211,12 @@ extern void _U_dyn_cancel (unw_dyn_info_t *);
 
 #define _U_dyn_op_alias(op, qp, when, addr)                             \
         (*(op) = _U_dyn_op (UNW_DYN_ALIAS, (qp), (when), 0, (addr)))
+
+#define _U_dyn_op_restore_reg(op, qp, when, reg)                        \
+        (*(op) = _U_dyn_op (UNW_DYN_RESTORE_REG, (qp), (when), (reg), 0))
+
+#define _U_dyn_op_save_sp(op, qp, when)                                 \
+        (*(op) = _U_dyn_op (UNW_DYN_SAVE_SP, (qp), (when), 0, 0))
 
 #define _U_dyn_op_stop(op)                                              \
         (*(op) = _U_dyn_op (UNW_DYN_STOP, _U_QP_TRUE, -1, 0, 0))

--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -492,8 +492,135 @@ fetch_proc_info (struct dwarf_cursor *c, unw_word_t ip)
 static int
 parse_dynamic (struct dwarf_cursor *c, unw_word_t ip, dwarf_state_record_t *sr)
 {
-  Debug (1, "Not yet implemented\n");
-  return -UNW_ENOINFO;
+
+  /* Default all register rules to "same as previous" */
+  sr->rs_current.ret_addr_column = UNW_TDEP_IP;
+  for (int i = 0; i < DWARF_NUM_PRESERVED_REGS + 2; ++i)
+    set_reg (sr, i, DWARF_WHERE_SAME, 0);
+  // set_reg (sr, TDEP_DWARF_SP, DWARF_WHERE_CFA, 0);
+
+  unw_dyn_info_t *dyn = c->pi.unwind_info;
+  unw_sword_t sp_offset = 0;
+  unw_word_t cur_ip;
+  unw_dyn_region_info_t *region;
+  size_t op_index = 0;
+  size_t region_number;
+
+  /* Initialize the op interpreting loop */
+  cur_ip = dyn->start_ip;
+  region = dyn->u.pi.regions;
+  region_number = 0;
+  op_index = 0;
+  Debug (6, "Initialized cur_ip to 0x%lx\n", cur_ip);
+
+  while (1)
+    {
+      if (!region)
+        {
+          /* the unwind info goes no further */
+          Debug (2, "Success: reached end of UNW_INFO_FORMAT_DYNAMIC info\n");
+          return 0;
+        }
+
+      if (op_index >= region->op_count)
+        {
+          /* This is an error - this means the region didn't end with UNW_DYN_STOP */
+          Debug (2, "Fail: UNW_INFO_FORMAT_DYNAMIC region (no. %ld) did not end with UNW_DYN_STOP\n",
+                 region_number);
+          return -UNW_EINVAL;
+        }
+
+      unw_dyn_op_t *op = &region->op[op_index];
+      /* Handle a stop "instruction" specially */
+      if (op->tag == UNW_DYN_STOP)
+        {
+            Debug (6, "Hit UNW_DYN_STOP; moving to next region\n");
+            region = region->next;
+            region_number++;
+            op_index = 0;
+            continue;
+        }
+      /* Advance ip to this op */
+      if (region->insn_count > 0)
+        {
+          /* Normal case - use op's when to work out what it refers to. */
+          cur_ip = dyn->start_ip + op->when;
+        }
+      else if (region->insn_count < 0)
+        {
+          /* Count from end of procedure if insn_count is negative */
+          cur_ip = dyn->end_ip - op->when - 1;
+        }
+      /*  else region->insn_count == 0 - means the region is empty, and so we must execute
+          it without advancing */
+
+      int region_is_empty = region->insn_count == 0;
+      if (cur_ip >= ip && !region_is_empty)
+        {
+          /* We've hit the target IP - note though that as a special case,
+             we will execute ops _at_ the target IP, if the region is empty; this is
+             because "Empty regions by definition contain no actual instructions and
+             as such the directives are not tied to a particular instruction". This
+             lets one use an empty region to describe the state of the stack before
+             _any_ instructions in the procedure are executed. */
+          Debug (2, "Success: hit target IP in UNW_INFO_FORMAT_DYNAMIC info; frame state ready\n");
+          return 0;
+        }
+
+      /* Otherwise we must execute this op */
+      Debug (6, "op %d cur_ip 0x%lx target ip 0x%lx\n", op->tag, cur_ip, ip);
+      switch (op->tag)
+        {
+          case UNW_DYN_STOP:
+            /* handled above */
+            unreachable();
+          case UNW_DYN_SAVE_REG:
+            sr->rs_current.reg.where[op->reg] = DWARF_WHERE_REG;
+            sr->rs_current.reg.val[op->reg] = op->val;
+            break;
+          case UNW_DYN_RESTORE_REG:
+            sr->rs_current.reg.where[op->reg] = DWARF_WHERE_SAME;
+            sr->rs_current.reg.val[op->reg] = 0;
+            break;
+          case UNW_DYN_ADD:
+            if (op->reg != UNW_TDEP_SP)
+              {
+                Debug (2, "tried to UNW_DYN_ADD unsupported reg %d", op->reg);
+                return -UNW_EINVAL;
+              }
+            Debug (6, "sp-add %ld\n", op->val);
+            sp_offset += op->val;
+            sr->rs_current.reg.where[op->reg] = DWARF_WHERE_DYN_OFFSET;
+            sr->rs_current.reg.val[op->reg] = sp_offset;
+            /* Need to also update any existing sp-relative spills with this extra
+                offset */
+            for (int i = 0; i < DWARF_NUM_PRESERVED_REGS; i++)
+              {
+                if (sr->rs_current.reg.where[i] == DWARF_WHERE_DYN_SP_REL)
+                  {
+                    Debug (6, "Updating sp-rel spill of reg %d by %ld\n", i, op->val);
+                    sr->rs_current.reg.val[i] -= op->val;
+                  }
+              }
+            break;
+          case UNW_DYN_SPILL_SP_REL:
+            sr->rs_current.reg.where[op->reg] = DWARF_WHERE_DYN_SP_REL;
+            sr->rs_current.reg.val[op->reg] = op->val;
+            break;
+          case UNW_DYN_SPILL_FP_REL:
+            sr->rs_current.reg.where[op->reg] = DWARF_WHERE_DYN_FP_REL;
+            sr->rs_current.reg.val[op->reg] = op->val;
+            break;
+          case UNW_DYN_SAVE_SP:
+            sr->rs_current.reg.where[TDEP_DWARF_SP] = DWARF_WHERE_DYN_SAVE_SP;
+            sr->rs_current.reg.val[TDEP_DWARF_SP] = sp_offset;
+            break;
+          default:
+            Debug (2, "Unimplemented op %d\n", op->tag);
+            return -UNW_EINVAL;
+          }
+      op_index++;
+    }
 }
 
 static inline void
@@ -883,11 +1010,9 @@ apply_reg_state (struct dwarf_cursor *c, struct dwarf_reg_state *rs)
         }
       cfa += rs->reg.val[DWARF_CFA_OFF_COLUMN];
     }
-  else
+  else if (rs->reg.where[DWARF_CFA_REG_COLUMN] == DWARF_WHERE_EXPR)
     {
       /* CFA is equal to EXPR: */
-
-      assert (rs->reg.where[DWARF_CFA_REG_COLUMN] == DWARF_WHERE_EXPR);
 
       addr = rs->reg.val[DWARF_CFA_REG_COLUMN];
       /* The dwarf standard doesn't specify an initial value to be pushed on */
@@ -904,6 +1029,7 @@ apply_reg_state (struct dwarf_cursor *c, struct dwarf_reg_state *rs)
   dwarf_loc_t new_loc[DWARF_NUM_PRESERVED_REGS];
   memcpy(new_loc, c->loc, sizeof(new_loc));
 
+  unw_word_t reg_value;
   for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
     {
       switch ((dwarf_where_t) rs->reg.where[i])
@@ -951,7 +1077,32 @@ apply_reg_state (struct dwarf_cursor *c, struct dwarf_reg_state *rs)
             return ret;
           new_loc[i] = DWARF_VAL_LOC (c, DWARF_GET_LOC (new_loc[i]));
           break;
-        }
+
+        /* Special "where"'s which are for UNW_INFO_FORMAT_DYNAMIC */
+        case DWARF_WHERE_DYN_OFFSET:
+          if ((ret = dwarf_get(c, c->loc[i], &reg_value)) < 0)
+            return ret;
+          new_loc[i] = DWARF_VAL_LOC (c, reg_value - rs->reg.val[i]);
+          break;
+
+        case DWARF_WHERE_DYN_SP_REL:
+          if ((ret = dwarf_get(c, c->loc[UNW_TDEP_SP], &reg_value)) < 0)
+            return ret;
+          new_loc[i] = DWARF_MEM_LOC (c, reg_value + rs->reg.val[i]);
+          break;
+
+        case DWARF_WHERE_DYN_FP_REL:
+          if ((ret = dwarf_get(c, c->loc[UNW_TDEP_BP], &reg_value)) < 0)
+            return ret;
+          new_loc[i] = DWARF_MEM_LOC (c, reg_value + rs->reg.val[i]);
+          break;
+
+        case DWARF_WHERE_DYN_SAVE_SP:
+          if ((ret = dwarf_get(c, c->loc[UNW_TDEP_BP], &reg_value)) < 0)
+            return ret;
+          new_loc[i] = DWARF_VAL_LOC (c, reg_value - rs->reg.val[i]);
+          break;
+      }
     }
 
   memcpy(c->loc, new_loc, sizeof(new_loc));

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -42,7 +42,7 @@ if USE_ALTIVEC
 endif #USE_ALTIVEC
 else  #!ARCH_PPC64
 if ARCH_X86_64
- check_PROGRAMS_arch +=	Gx64-test-dwarf-expressions Lx64-test-dwarf-expressions x64-unwind-badjmp-signal-frame
+ check_PROGRAMS_arch +=	Gx64-test-dwarf-expressions Lx64-test-dwarf-expressions x64-unwind-badjmp-signal-frame x64-test-dyn1
 endif #ARCH X86_64
 endif #!ARCH_PPC64
 endif #!ARCH_IA64
@@ -184,6 +184,7 @@ Ltest_cxx_exceptions_SOURCES = Ltest-cxx-exceptions.cxx
 
 Ltest_init_local_signal_SOURCES = Ltest-init-local-signal.c Ltest-init-local-signal-lib.c
 
+x64_test_dyn1_SOURCES = x64-test-dyn1.c
 x64_unwind_badjmp_signal_frame_SOURCES = x64-unwind-badjmp-signal-frame.c
 Gtest_dyn1_SOURCES = Gtest-dyn1.c flush-cache.S flush-cache.h
 Ltest_dyn1_SOURCES = Ltest-dyn1.c flush-cache.S flush-cache.h
@@ -231,6 +232,7 @@ Ltest_init_local_signal_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 
 Gtest_bt_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 Gtest_concurrent_LDADD = $(LIBUNWIND) $(LIBUNWIND_local) -lpthread
+x64_test_dyn1_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 x64_unwind_badjmp_signal_frame_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 Gtest_dyn1_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 Gtest_exc_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)

--- a/tests/x64-test-dyn1.c
+++ b/tests/x64-test-dyn1.c
@@ -1,0 +1,234 @@
+#include "flush-cache.h"
+
+#include <assert.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <string.h>
+#include <unistd.h>
+#include <setjmp.h>
+
+#include <libunwind.h>
+
+static char asmfunc_1_bytes[] = {
+  /*  0 */ 0x55,                                       /* push %rbp */
+  /*  1 */ 0x48, 0x89, 0xe5,                           /* mov %rsp, %rbp */
+  /*  4 */ 0x48, 0x83, 0xec, 0x10,                     /* sub $0x10, %rsp */
+  /*  8 */ 0x48, 0xc7, 0xc0, 0x2a, 0x00, 0x00, 0x00,   /* mov $42, %rax */
+  /* 15 */ 0x48, 0x89, 0xec,                           /* mov %rbp, %rsp */
+  /* 18 */ 0x5d,                                       /* pop %rbp */
+  /* 19 */ 0xc3,                                       /* ret */
+};
+static int asmfunc_1_insn_offsets[] = {
+  0, 1, 4, 8, 15, 18, 19
+};
+
+static sigjmp_buf return_env;
+static char *exec_mapping;
+
+struct captured_frame_info {
+  char procname[256];
+  unw_word_t offset;
+};
+
+static struct captured_frame_info captured_frames[5];
+
+static void trap_handler(int signal, siginfo_t *siginfo, void *context)
+{
+  int r;  
+  unw_cursor_t c;
+  unw_context_t uc;
+
+  r = unw_getcontext(&uc);
+  assert(r == 0);
+  r = unw_init_local(&c, &uc);
+  assert(r == 0);
+
+  /* Step five times - we expect to see:
+       * trap_handler
+       * the __sigaction thunk
+       * asmfunc_1
+       * run_asmfunc1_traps
+       * main
+  */
+
+  for (int i = 0; i < 5; i++)
+    {
+      unw_word_t ip, sp;
+      assert(unw_get_reg(&c, UNW_X86_64_RIP, &ip) == 0);
+      assert(unw_get_reg(&c, UNW_X86_64_RSP, &sp) == 0);
+      printf("(unwound ip 0x%lx sp 0x%lx)\n", ip, sp);
+
+      r = unw_get_proc_name(&c, captured_frames[i].procname,
+                            sizeof(captured_frames[i].procname),
+                            &captured_frames[i].offset);
+      assert(r == 0);
+      if (i < 4)
+        assert(unw_step(&c) > 0);
+    }
+  siglongjmp(return_env, 1);
+}
+
+__attribute__ ((noinline))
+static void run_asmfunc_1_traps(void)
+{
+  /* make sure this function can't get optimized away */
+  asm("");
+
+  int insn_count = sizeof(asmfunc_1_insn_offsets)/sizeof(asmfunc_1_insn_offsets[0]);
+  for (int i = 0; i < insn_count; i++)
+    {
+      /* copy the function into the executable memory */
+      memcpy(exec_mapping, asmfunc_1_bytes, sizeof(asmfunc_1_bytes));
+      /* overwrite the instruction with one that will fault. I'd like to use 0xcc (INT 3),
+        which generates a SIGTRAP, but that actually inteferes with debugging the test in
+        gdb, which is kind of annoying. Instead, use 0xf4 (HLT), which will generate a
+        SIGSEGV when called outside of kernel mode. */
+      exec_mapping[asmfunc_1_insn_offsets[i]] = 0xf4;
+      flush_cache(exec_mapping, sizeof(asmfunc_1_bytes));
+      unw_flush_cache(unw_local_addr_space, 0, 0);
+
+      int r = sigsetjmp(return_env, 1);
+      if (r == 0)
+        {
+          /* runs the first time here */
+          ((void (*)(void))exec_mapping)();
+        }
+      /* control falls here after the trap handler runs */
+
+      for (int j = 0; j < 5; j++)
+        {
+          printf("frame %d: %s+0x%lx\n", j, captured_frames[j].procname, captured_frames[j].offset);
+        }
+      
+      printf("asserting round %d (offset %d)\n", i, asmfunc_1_insn_offsets[i]);
+      assert(strcmp(captured_frames[0].procname, "trap_handler") == 0);
+      /* don't asserting on __sigaction return thunk */
+      assert(strcmp(captured_frames[2].procname, "asmfunc_1") == 0);
+      assert(captured_frames[2].offset == asmfunc_1_insn_offsets[i]);
+      assert(strcmp(captured_frames[3].procname, "run_asmfunc_1_traps") == 0);
+    }
+
+    asm("");
+}
+
+static unw_dyn_info_t asmfunc_1_proc_info_sp;
+void configure_asmfunc_1_proc_info_sp(void)
+{
+  asmfunc_1_proc_info_sp.start_ip = (uintptr_t)exec_mapping;
+  asmfunc_1_proc_info_sp.end_ip = ((uintptr_t)exec_mapping) + sizeof(asmfunc_1_bytes);
+  asmfunc_1_proc_info_sp.format = UNW_INFO_FORMAT_DYNAMIC;
+  asmfunc_1_proc_info_sp.u.pi.name_ptr = (uintptr_t)"asmfunc_1";
+
+  size_t pre_region_sz = _U_dyn_region_info_size(3);
+  unw_dyn_region_info_t *pre_region = malloc(pre_region_sz);
+  memset(pre_region, 0, pre_region_sz);
+
+  _U_dyn_op_add(&pre_region->op[0], _U_QP_TRUE, 0, UNW_X86_64_RSP, -0x08);
+  _U_dyn_op_spill_sp_rel(&pre_region->op[1], _U_QP_TRUE, 0, UNW_X86_64_RIP, 0);
+  _U_dyn_op_stop(&pre_region->op[2]);
+  pre_region->insn_count = 0;
+  pre_region->op_count = 3;
+
+  size_t body_region_sz = _U_dyn_region_info_size(7);
+  unw_dyn_region_info_t *body_region = malloc(body_region_sz);
+  memset(body_region, 0, body_region_sz);
+
+  _U_dyn_op_add(&body_region->op[0], _U_QP_TRUE, 0, UNW_X86_64_RSP, -0x08);
+  _U_dyn_op_spill_sp_rel(&body_region->op[1], _U_QP_TRUE, 0, UNW_X86_64_RBP, 0);
+  _U_dyn_op_add(&body_region->op[2], _U_QP_TRUE, 4, UNW_X86_64_RSP, -0x10);
+  _U_dyn_op_add(&body_region->op[3], _U_QP_TRUE, 15, UNW_X86_64_RSP, 0x10);
+  _U_dyn_op_add(&body_region->op[4], _U_QP_TRUE, 18, UNW_X86_64_RSP, 0x08);
+  _U_dyn_op_restore_reg(&body_region->op[5], _U_QP_TRUE, 18, UNW_X86_64_RBP);
+  _U_dyn_op_stop(&body_region->op[6]);
+  body_region->insn_count = sizeof(asmfunc_1_bytes);
+  body_region->op_count = 7;
+  
+  pre_region->next = body_region;
+  asmfunc_1_proc_info_sp.u.pi.regions = pre_region;
+}
+
+static unw_dyn_info_t asmfunc_1_proc_info_fp;
+void configure_asmfunc_1_proc_info_fp(void)
+{
+  asmfunc_1_proc_info_fp.start_ip = (uintptr_t)exec_mapping;
+  asmfunc_1_proc_info_fp.end_ip = ((uintptr_t)exec_mapping) + sizeof(asmfunc_1_bytes);
+  asmfunc_1_proc_info_fp.format = UNW_INFO_FORMAT_DYNAMIC;
+  asmfunc_1_proc_info_fp.u.pi.name_ptr = (uintptr_t)"asmfunc_1";
+
+
+  size_t pre_region_sz = _U_dyn_region_info_size(3);
+  unw_dyn_region_info_t *pre_region = malloc(pre_region_sz);
+  memset(pre_region, 0, pre_region_sz);
+
+  _U_dyn_op_add(&pre_region->op[0], _U_QP_TRUE, 0, UNW_X86_64_RSP, -0x08);
+  _U_dyn_op_spill_sp_rel(&pre_region->op[1], _U_QP_TRUE, 0, UNW_X86_64_RIP, 0);
+  _U_dyn_op_stop(&pre_region->op[2]);
+  pre_region->insn_count = 0;
+  pre_region->op_count = 3;
+
+  size_t body_region_sz = _U_dyn_region_info_size(10);
+  unw_dyn_region_info_t *body_region = malloc(body_region_sz);
+  memset(body_region, 0, body_region_sz);
+
+  /* Although the title of this test is "fp relative", we can only refer to the saved
+     value of RBP by the stack pointer after the first instruction - we haven't set up
+     the frame pointer yet. We'll overwrite this for subsequent instructions. */
+  _U_dyn_op_add(&body_region->op[0], _U_QP_TRUE, 0, UNW_X86_64_RSP, -0x08);
+  _U_dyn_op_spill_sp_rel(&body_region->op[1], _U_QP_TRUE, 0, UNW_X86_64_RBP, 0);
+  /* _now_, at the second instructoin, we can make it fp-relative */
+  _U_dyn_op_save_sp(&body_region->op[2], _U_QP_TRUE, 1);
+  /* previous %rbp is at [%rbp] */
+  _U_dyn_op_spill_fp_rel(&body_region->op[3], _U_QP_TRUE, 1, UNW_X86_64_RBP, 0);
+  /* previous ip is at [%rbp+8] */
+  _U_dyn_op_spill_fp_rel(&body_region->op[4], _U_QP_TRUE, 1, UNW_X86_64_RIP, 8);
+  /* epilogue */
+  _U_dyn_op_restore_reg(&body_region->op[5], _U_QP_TRUE, 18, UNW_X86_64_RBP);
+  /* %rip & %rbp can't be fp-relative anymore */
+  _U_dyn_op_restore_reg(&body_region->op[6], _U_QP_TRUE, 18, UNW_X86_64_RSP);
+  _U_dyn_op_add(&body_region->op[7], _U_QP_TRUE, 18, UNW_X86_64_RSP, -0x08);
+  _U_dyn_op_spill_sp_rel(&body_region->op[8], _U_QP_TRUE, 18, UNW_X86_64_RIP, 0);
+  _U_dyn_op_stop(&body_region->op[9]);
+  body_region->insn_count = sizeof(asmfunc_1_bytes);
+  body_region->op_count = 10;
+  
+  pre_region->next = body_region;
+  asmfunc_1_proc_info_fp.u.pi.regions = pre_region;
+}
+
+int main(int argc, char *argv[])
+{
+  int r;
+  exec_mapping = mmap(NULL, getpagesize(), PROT_READ | PROT_WRITE | PROT_EXEC,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  assert(exec_mapping != MAP_FAILED);
+
+
+  struct sigaction sa = {0};
+  sa.sa_sigaction = trap_handler;
+  sa.sa_flags = SA_SIGINFO;
+  r = sigaction(SIGSEGV, &sa, NULL);
+  assert(!r);
+
+  /* There are two different sets of debuginfo we can use for asmfunc_1;
+     one uses sp-relative offsets, one uses fp-relative offsets. */
+  configure_asmfunc_1_proc_info_sp();
+  configure_asmfunc_1_proc_info_fp();
+
+
+  unw_set_caching_policy(unw_local_addr_space, UNW_CACHE_NONE);
+  _U_dyn_register(&asmfunc_1_proc_info_sp);
+  printf("running sp-relative local tests\n");
+  run_asmfunc_1_traps();
+  _U_dyn_cancel(&asmfunc_1_proc_info_sp);
+
+  _U_dyn_register(&asmfunc_1_proc_info_fp);
+  printf("running fp-relative local tests\n");
+  run_asmfunc_1_traps();
+  _U_dyn_cancel(&asmfunc_1_proc_info_fp);
+  
+
+  printf("exiting normally\n");
+  exit(0);
+}


### PR DESCRIPTION
This is a patch to start a discussion about UNW_INFO_FORMAT_DYNAMIC.

Currently, the documentation in libunwind-dynamic(3) says that this format is "the preferred dynamic unwind-info format" and that "it is generally the one used by full-blown runtime code generators". However, it seems that it's only actually implemented on Itanium, which rather substantially limits its usefulness!

This format is interesting for me because I want to try using it in a JIT compiler under the following constraints:
  * Code is generated in small chunks incrementally; thus, registering & unregistering unwind info needs to be fast.
  * Most blocks will use one of a few standard stack layouts. The ability to share unw_dyn_info_region_t instances between procedures is therefore attractive.
  * Code can be garbage-collected and inserted into freed pages; the IP of generated code is not eternally increasing. This makes the requirement that DWARF unwind tables be sorted in IP order problematic, because inserting code into the middle of the table requires much copying.
  * The project does not wish to take a dependency on a library for serializing DWARF info; the structs for UNW_INFO_FORMAT_DYNAMIC however can easily be assembled in the code generator code with nothing else but libunwind.
  * The JIT compiler does not emit very complex stack manipulations, so the full complexity of DWARF is not needed.

I have attempted to implement this format for x86_64 by filling in the "Not implemented yet" method `parse_dynamic`. This works inside the existing dwarf unwinder by walking through the UNW_INFO_FORMAT_DYNAMIC data and converting it to the existing register rule structure.

This seems to "work" - there's a test, which asserts generates both sp-relative and fp-relative unwind info for a procedure, and it seems to be able to successfully unwind from all points in the procedure.

Discussion points:

  * I implemented a few new DWARF_WHERE_ rules inside `apply_reg_state` to implement some of the behaviour. Strictly speaking, this is unnescessary; all of these rules could be replaced by use of DWARF_WHERE_EXPR, however I couldn't see any existing code to generate dwarf expressions, and it didn't seem like a good idea to serialise an expression just to immediately deserialise it again, so I did it this way.

  * I don't think the existing set of ops documented in libunwind-dynamic(3) is sufficient to express normal x86_64 stacks. In particular, I had to implement a couple of extra ops. :: UNW_DYN_RESTORE_REG is needed because x86_64 does not have a single-instruction way to tear down a stack frame (which is what I assume UNW_DYN_POP_FRAMES does on Itanium). So, `pop %rbp` needs this. :: UNW_DYN_SAVE_SP is needed because calling a function on x86_64 pushes the return address onto the stack, and the old %rbp is also pushed onto the stack, _before_ `mov %rsp, %rbp` happens; thus, the value of %rsp being saved into %rbp is _NOT_ "%rsp from the previous frame", but rather "%rsp from the previous frame + two words". So, I implemented these.

  * It wasn't clear what the behaviour of mixing UNW_DYN_ADD and UNW_DYN_SPILL_SP_REL should be; should the existing sp-relative spills be updated if the stack pointer is decremented? I decided that "yes" was the most useful answer, and that seemed to be what I deduced should happen from this old message: https://www.hpl.hp.com/hosted/linux/mail-archives/libunwind/2004-March/000217.html

  * It felt kind of wrong to implement this in src/dwarf, since it has ~nothing to do with dwarf. However, that's where the "implement me" stub was. Is this the right decision, or should the arch-specific code explicitly call e.g. `dynamic_step` _and_ `dwarf_step`?

  * I have no Itanium hardware, so I have absolutely no way to know how the existing implementation behaves other than squinting at code and guessing. I don't suppose there's an emulator or such the project uses to keep this working? I couldn't find anything.

  * Because this is currently only supported on Itanium, I have to assume the current set of users for it is ~zero. With that being the case, is implementing the existing interface something that we should do here, or should something else be designed specifically to meet the needs of CPU archs and JIT compilers from this millenium?

Anyway - interested in thoughts and feedback. Thanks for reading!