### PR TITLE
Rework register load in aarch64_local_resume()

### DIFF
--- a/src/aarch64/Gresume.c
+++ b/src/aarch64/Gresume.c
@@ -29,7 +29,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #ifndef UNW_REMOTE_ONLY
 
-HIDDEN inline int
+HIDDEN int
 aarch64_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
 {
 #ifdef __linux__
@@ -40,59 +40,63 @@ aarch64_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
     {
       /* Since there are no signals involved here we restore EH and non scratch
          registers only.  */
-      unsigned long regs[24];
-      regs[0] = uc->uc_mcontext.regs[0];
-      regs[1] = uc->uc_mcontext.regs[1];
-      regs[2] = uc->uc_mcontext.regs[2];
-      regs[3] = uc->uc_mcontext.regs[3];
-      regs[4] = uc->uc_mcontext.regs[19];
-      regs[5] = uc->uc_mcontext.regs[20];
-      regs[6] = uc->uc_mcontext.regs[21];
-      regs[7] = uc->uc_mcontext.regs[22];
-      regs[8] = uc->uc_mcontext.regs[23];
-      regs[9] = uc->uc_mcontext.regs[24];
-      regs[10] = uc->uc_mcontext.regs[25];
-      regs[11] = uc->uc_mcontext.regs[26];
-      regs[12] = uc->uc_mcontext.regs[27];
-      regs[13] = uc->uc_mcontext.regs[28];
-      regs[14] = uc->uc_mcontext.regs[29]; /* FP */
-      regs[15] = uc->uc_mcontext.regs[30]; /* LR */
-      regs[16] = GET_FPCTX(uc)->vregs[8];
-      regs[17] = GET_FPCTX(uc)->vregs[9];
-      regs[18] = GET_FPCTX(uc)->vregs[10];
-      regs[19] = GET_FPCTX(uc)->vregs[11];
-      regs[20] = GET_FPCTX(uc)->vregs[12];
-      regs[21] = GET_FPCTX(uc)->vregs[13];
-      regs[22] = GET_FPCTX(uc)->vregs[14];
-      regs[23] = GET_FPCTX(uc)->vregs[15];
-      unsigned long sp = uc->uc_mcontext.sp;
-
-      struct regs_overlay {
-        char x[sizeof(regs)];
-      };
-
       __asm__ __volatile__ (
-        "mov x4, %0\n"
-        "mov x5, %1\n"
-        "ldp x0,  x1,  [x4]\n"
-        "ldp x2,  x3,  [x4,16]\n"
-        "ldp x19, x20, [x4,32]\n"
-        "ldp x21, x22, [x4,48]\n"
-        "ldp x23, x24, [x4,64]\n"
-        "ldp x25, x26, [x4,80]\n"
-        "ldp x27, x28, [x4,96]\n"
-        "ldp x29, x30, [x4,112]\n"
-        "ldp d8, d9,   [x4,128]\n"
-        "ldp d10, d11, [x4,144]\n"
-        "ldp d12, d13, [x4,160]\n"
-        "ldp d14, d15, [x4,176]\n"
-        "mov sp, x5\n"
-        "ret \n"
+        "ldr x0,  %[x0]\n\t"
+        "ldr x1,  %[x1]\n\t"
+        "ldr x2,  %[x2]\n\t"
+        "ldr x3,  %[x3]\n\t"
+        "ldr x19, %[x19]\n\t"
+        "ldr x20, %[x20]\n\t"
+        "ldr x21, %[x21]\n\t"
+        "ldr x22, %[x22]\n\t"
+        "ldr x23, %[x23]\n\t"
+        "ldr x24, %[x24]\n\t"
+        "ldr x25, %[x25]\n\t"
+        "ldr x26, %[x26]\n\t"
+        "ldr x27, %[x27]\n\t"
+        "ldr x28, %[x28]\n\t"
+        "ldr x29, %[x29]\n\t"
+        "ldr x30, %[x30]\n\t"
+        "ldr d8,  %[d8]\n\t"
+        "ldr d9,  %[d9]\n\t"
+        "ldr d10, %[d10]\n\t"
+        "ldr d11, %[d11]\n\t"
+        "ldr d12, %[d12]\n\t"
+        "ldr d13, %[d13]\n\t"
+        "ldr d14, %[d14]\n\t"
+        "ldr d15, %[d15]\n\t"
+        "ldr x5,  %[sp]\n\t"
+        "mov sp, x5\n\t"
+        "ret\n"
         :
-        : "r" (regs),
-          "r" (sp),
-          "m" (*(struct regs_overlay *)regs)
-      );
+        : [x0]  "m"(uc->uc_mcontext.regs[0]),
+		  [x1]  "m"(uc->uc_mcontext.regs[1]),
+		  [x2]  "m"(uc->uc_mcontext.regs[2]),
+		  [x3]  "m"(uc->uc_mcontext.regs[3]),
+		  [x19] "m"(uc->uc_mcontext.regs[19]),
+		  [x20] "m"(uc->uc_mcontext.regs[20]),
+		  [x21] "m"(uc->uc_mcontext.regs[21]),
+		  [x22] "m"(uc->uc_mcontext.regs[22]),
+		  [x23] "m"(uc->uc_mcontext.regs[23]),
+		  [x24] "m"(uc->uc_mcontext.regs[24]),
+		  [x25] "m"(uc->uc_mcontext.regs[25]),
+		  [x26] "m"(uc->uc_mcontext.regs[26]),
+		  [x27] "m"(uc->uc_mcontext.regs[27]),
+		  [x28] "m"(uc->uc_mcontext.regs[28]),
+		  [x29] "m"(uc->uc_mcontext.regs[29]), /* FP */
+		  [x30] "m"(uc->uc_mcontext.regs[30]), /* LR */
+		  [d8]  "m"(GET_FPCTX(uc)->vregs[8]),
+		  [d9]  "m"(GET_FPCTX(uc)->vregs[9]),
+		  [d10] "m"(GET_FPCTX(uc)->vregs[10]),
+		  [d11] "m"(GET_FPCTX(uc)->vregs[11]),
+		  [d12] "m"(GET_FPCTX(uc)->vregs[12]),
+		  [d13] "m"(GET_FPCTX(uc)->vregs[13]),
+		  [d14] "m"(GET_FPCTX(uc)->vregs[14]),
+		  [d15] "m"(GET_FPCTX(uc)->vregs[15]),
+          [sp]  "m"(uc->uc_mcontext.sp)
+		: "x0",   "x1",  "x2",  "x3", "x19", "x20", "x21", "x22", "x23", "x24",
+		  "x25", "x26", "x27", "x28", "x29", "x30"
+	  );
     }
   else
     {
@@ -160,19 +164,17 @@ establish_machine_state (struct cursor *c)
 
   Debug (8, "copying out cursor state\n");
 
-  for (reg = 0; reg <= UNW_AARCH64_V31; ++reg)
+  for (reg = 0; reg <= UNW_AARCH64_RA_SIGN_STATE; ++reg)
     {
       Debug (16, "copying %s %d\n", unw_regname (reg), reg);
-      if (unw_is_fpreg (reg))
-        {
-          if (tdep_access_fpreg (c, reg, &fpval, 0) >= 0)
-            as->acc.access_fpreg (as, reg, &fpval, 1, arg);
-        }
-      else
-        {
-          if (tdep_access_reg (c, reg, &val, 0) >= 0)
-            as->acc.access_reg (as, reg, &val, 1, arg);
-        }
+      if (tdep_access_reg (c, reg, &val, 0) >= 0)
+        as->acc.access_reg (as, reg, &val, 1, arg);
+    }
+  for (reg = UNW_AARCH64_V0; reg <= UNW_AARCH64_V31; ++reg)
+    {
+      Debug (16, "copying %s %d\n", unw_regname (reg), reg);
+      if (tdep_access_fpreg (c, reg, &fpval, 0) >= 0)
+        as->acc.access_fpreg (as, reg, &fpval, 1, arg);
     }
 }
 
@@ -191,8 +193,10 @@ unw_resume (unw_cursor_t *cursor)
       return -UNW_EINVAL;
     }
 
+Debug(1, "==smw> before establish_machine_state\n");
   establish_machine_state (c);
 
+Debug(1, "==smw> before acc.resume\n");
   return (*c->dwarf.as->acc.resume) (c->dwarf.as, (unw_cursor_t *) c,
                                      c->dwarf.as_arg);
 }


### PR DESCRIPTION
The GCC 12 optimizer saw fit to reorder certain register loads which caused the inline assmbler code to use the wrong values when setting up the resume context. Rewrote the inline assembly to load the registers directly from memory instead.

Fixes GH issue #501.