### PR TITLE
Add a step limit to Ltest-init-local-signal.c

### DIFF
--- a/tests/Ltest-init-local-signal.c
+++ b/tests/Ltest-init-local-signal.c
@@ -9,6 +9,8 @@
 #include <stdio.h>
 #include <assert.h>
 
+static const int max_steps = 10;
+
 int stepper(unw_cursor_t* c) {
   int steps = 0;
   int ret = 1;
@@ -19,6 +21,7 @@ int stepper(unw_cursor_t* c) {
       break;
     }
     steps++;
+    if (steps > max_steps) break;
   }
   return steps;
 }


### PR DESCRIPTION
This test seemed to be hanging on an infinite loop on arm targets.

Adding a limit on the number of times the `stepper()` function loops should fix that. 10 seems like a reasonable limit since the expected number of steps is between 2 and 6 for most targets.

Closes #515 