### PR TITLE
Improve check to see if libgcc_s is needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,7 @@ AM_PROG_AS
 AM_PROG_CC_C_O
 
 dnl Checks for libraries.
+AC_CHECK_LIB(gcc_s, _Unwind_Resume)
 AC_CHECK_LIB(uca, __uc_get_grs)
 OLD_LIBS=${LIBS}
 AC_SEARCH_LIBS(dlopen, dl)
@@ -380,10 +381,6 @@ if test x$qcc_compiler = xyes; then
     LDFLAGS_NOSTARTFILES="-XCClinker -Wc,-nostartfiles"
 else
     LDFLAGS_NOSTARTFILES="-XCClinker -nostartfiles"
-fi
-
-if test x$GCC = xyes -a x$intel_compiler != xyes -a x$qcc_compiler != xyes -a x$android != xyes; then
-  LIBCRTS="-lgcc_s"
 fi
 
 OLD_CFLAGS="${CFLAGS}"


### PR DESCRIPTION
Until now configure would check for any number of compilers (and even operating systems) to indirectly derive if libgcc_s is required or not. This not only becomes ever more cumbersome as additional compiler and OS combinations become available, it is also unreliable.

There are compilers (e.g. clang) that can be configured to use either the GNU runtime or the LLVM runtime. Therefore, detecting clang does not reveal whether libgcc_s is needed or not. (Not that configure was ever checking for clang.) The answer regarding libgcc_s depends on how the toolchain was configured when it comes to clang.

The new approach (test-linking a binary against libgcc_s and determining if that was successful) takes care of this situation. It is also much simpler and it will handle new toolchain / OS combinations transparently should the need ever arise.