### PR TITLE
Fix build warnings for aarch64-linux targets

### DIFF
--- a/include/tdep-aarch64/libunwind_i.h
+++ b/include/tdep-aarch64/libunwind_i.h
@@ -105,10 +105,10 @@ struct cursor
     unw_word_t sigcontext_sp;
     unw_word_t sigcontext_pc;
     int validate;
-    ucontext_t *uc;
+    unw_context_t *uc;
   };
 
-static inline ucontext_t *
+static inline unw_context_t *
 dwarf_get_uc(const struct dwarf_cursor *cursor)
 {
   const struct cursor *c = (struct cursor *) cursor->as_arg;
@@ -319,7 +319,7 @@ extern void tdep_init_mem_validate (void);
 extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
                                      unw_dyn_info_t *di, unw_proc_info_t *pi,
                                      int need_unwind_info, void *arg);
-extern void *tdep_uc_addr (unw_tdep_context_t *uc, int reg);
+extern void *tdep_uc_addr (unw_context_t *uc, int reg);
 extern int tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
                                unsigned long *segbase, unsigned long *mapoff,
                                char *path, size_t pathlen);
@@ -331,6 +331,6 @@ extern int tdep_access_fpreg (struct cursor *c, unw_regnum_t reg,
 extern int tdep_trace (unw_cursor_t *cursor, void **addresses, int *n);
 extern void tdep_stash_frame (struct dwarf_cursor *c,
                               struct dwarf_reg_state *rs);
-extern int tdep_getcontext_trace (unw_tdep_context_t *);
+extern int tdep_getcontext_trace (unw_context_t *);
 
 #endif /* AARCH64_LIBUNWIND_I_H */

--- a/src/aarch64/Ginit.c
+++ b/src/aarch64/Ginit.c
@@ -44,7 +44,7 @@ static struct unw_addr_space local_addr_space;
 unw_addr_space_t unw_local_addr_space = &local_addr_space;
 
 static inline void *
-uc_addr (unw_tdep_context_t *uc, int reg)
+uc_addr (unw_context_t *uc, int reg)
 {
   if (reg == UNW_AARCH64_VG)
     {
@@ -85,7 +85,7 @@ uc_addr (unw_tdep_context_t *uc, int reg)
 # ifdef UNW_LOCAL_ONLY
 
 HIDDEN void *
-tdep_uc_addr (unw_tdep_context_t *uc, int reg)
+tdep_uc_addr (unw_context_t *uc, int reg)
 {
   return uc_addr (uc, reg);
 }
@@ -119,7 +119,7 @@ static int mem_validate_pipe[2] = {-1, -1};
 static inline void
 do_pipe2 (int pipefd[2])
 {
-  pipe2 (pipefd, O_CLOEXEC | O_NONBLOCK);
+  (void) !pipe2 (pipefd, O_CLOEXEC | O_NONBLOCK);
 }
 #else
 static inline void
@@ -370,7 +370,7 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
             void *arg)
 {
   unw_word_t *addr;
-  unw_tdep_context_t *uc = ((struct cursor *)arg)->uc;
+  unw_context_t *uc = ((struct cursor *)arg)->uc;
 
   if (unw_is_fpreg (reg))
     goto badreg;
@@ -399,7 +399,7 @@ static int
 access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
               int write, void *arg)
 {
-  unw_tdep_context_t *uc = ((struct cursor *)arg)->uc;
+  unw_context_t *uc = ((struct cursor *)arg)->uc;
   unw_fpreg_t *addr;
 
   if (!unw_is_fpreg (reg))

--- a/src/aarch64/Ginit_local.c
+++ b/src/aarch64/Ginit_local.c
@@ -61,7 +61,7 @@ unw_init_local (unw_cursor_t *cursor, unw_context_t *uc)
 }
 
 int
-unw_init_local2 (unw_cursor_t *cursor, unw_tdep_context_t *uc, int flag)
+unw_init_local2 (unw_cursor_t *cursor, unw_context_t *uc, int flag)
 {
   if (!flag)
     {

--- a/src/aarch64/Gresume.c
+++ b/src/aarch64/Gresume.c
@@ -34,7 +34,7 @@ aarch64_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
 {
 #ifdef __linux__
   struct cursor *c = (struct cursor *) cursor;
-  unw_tdep_context_t *uc = c->uc;
+  unw_context_t *uc = c->uc;
 
   if (c->sigcontext_format == AARCH64_SCF_NONE)
     {

--- a/src/dwarf/Gget_proc_info_in_range.c
+++ b/src/dwarf/Gget_proc_info_in_range.c
@@ -53,11 +53,10 @@ unw_get_proc_info_in_range (unw_word_t start_ip, unw_word_t end_ip,
     if (eh_frame_table != 0) {
         unw_accessors_t *a = unw_get_accessors_int (as);
 
-        unw_word_t hdr;
-        if ((*a->access_mem)(as, eh_frame_table, &hdr, 0, arg) < 0) {
+        struct dwarf_eh_frame_hdr* exhdr = NULL;
+        if ((*a->access_mem)(as, eh_frame_table, (unw_word_t*)&exhdr, 0, arg) < 0) {
             return -UNW_EINVAL;
         }
-        struct dwarf_eh_frame_hdr* exhdr = (struct dwarf_eh_frame_hdr*)&hdr;
 
         if (exhdr->version != DW_EH_VERSION) {
             Debug (1, "Unexpected version %d\n", exhdr->version);

--- a/tests/Gtest-bt.c
+++ b/tests/Gtest-bt.c
@@ -141,6 +141,7 @@ bar (long v)
 {
   extern long f (long);
   int arr[v];
+  arr[0] = 0;
 
   /* This is a vain attempt to use up lots of registers to force
      the frame-chain info to be saved on the memory stack on ia64.

--- a/tests/Gtest-trace.c
+++ b/tests/Gtest-trace.c
@@ -208,6 +208,7 @@ bar (long v)
 {
   extern long f (long);
   int arr[v];
+  arr[0] = 0;
 
   /* This is a vain attempt to use up lots of registers to force
      the frame-chain info to be saved on the memory stack on ia64.

--- a/tests/test-setjmp.c
+++ b/tests/test-setjmp.c
@@ -1,6 +1,6 @@
 /* libunwind - a platform-independent unwind library
    Copyright (C) 2003 Hewlett-Packard Co
-	Contributed by David Mosberger-Tang <davidm@hpl.hp.com>
+    Contributed by David Mosberger-Tang <davidm@hpl.hp.com>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -39,7 +39,7 @@ static jmp_buf jbuf;
 static sigjmp_buf sigjbuf;
 static sigset_t sigset4;
 
-void
+NORETURN void
 raise_longjmp (jmp_buf jbuf, int i, int n)
 {
   while (i < n)
@@ -58,32 +58,32 @@ test_setjmp (void)
   for (i = 0; i < 10; ++i)
     {
       if ((ret = setjmp (jbuf)))
-	{
-	  if (verbose)
-	    printf ("%s: secondary setjmp () return, ret=%d\n",
-		    __FUNCTION__, ret);
-	  if (ret != i + 1)
-	    {
-	      fprintf (stderr, "%s: setjmp() returned %d, expected %d\n",
-		       __FUNCTION__, ret, i + 1);
-	      ++nerrors;
-	    }
-	  continue;
-	}
+        {
+          if (verbose)
+            printf ("%s: secondary setjmp () return, ret=%d\n",
+                    __FUNCTION__, ret);
+          if (ret != i + 1)
+            {
+              fprintf (stderr, "%s: setjmp() returned %d, expected %d\n",
+                       __FUNCTION__, ret, i + 1);
+              ++nerrors;
+            }
+          continue;
+        }
       if (verbose)
-	printf ("%s.%d: done with setjmp(); calling children\n",
-		__FUNCTION__, i + 1);
+        printf ("%s.%d: done with setjmp(); calling children\n",
+                __FUNCTION__, i + 1);
 
       raise_longjmp (jbuf, 0, i + 1);
 
       fprintf (stderr, "%s: raise_longjmp() returned unexpectedly\n",
-	       __FUNCTION__);
+               __FUNCTION__);
       ++nerrors;
     }
 }
 
 
-void
+NORETURN void
 raise_siglongjmp (sigjmp_buf jbuf, int i, int n)
 {
   while (i < n)
@@ -102,26 +102,26 @@ test_sigsetjmp (void)
   for (i = 0; i < 10; ++i)
     {
       if ((ret = sigsetjmp (jbuf, 1)))
-	{
-	  if (verbose)
-	    printf ("%s: secondary sigsetjmp () return, ret=%d\n",
-		    __FUNCTION__, ret);
-	  if (ret != i + 1)
-	    {
-	      fprintf (stderr, "%s: sigsetjmp() returned %d, expected %d\n",
-		       __FUNCTION__, ret, i + 1);
-	      ++nerrors;
-	    }
-	  continue;
-	}
+    {
       if (verbose)
-	printf ("%s.%d: done with sigsetjmp(); calling children\n",
-		__FUNCTION__, i + 1);
+        printf ("%s: secondary sigsetjmp () return, ret=%d\n",
+    	    __FUNCTION__, ret);
+      if (ret != i + 1)
+        {
+          fprintf (stderr, "%s: sigsetjmp() returned %d, expected %d\n",
+    	       __FUNCTION__, ret, i + 1);
+          ++nerrors;
+        }
+      continue;
+    }
+      if (verbose)
+    printf ("%s.%d: done with sigsetjmp(); calling children\n",
+    	__FUNCTION__, i + 1);
 
       raise_siglongjmp (jbuf, 0, i + 1);
 
       fprintf (stderr, "%s: raise_siglongjmp() returned unexpectedly\n",
-	       __FUNCTION__);
+           __FUNCTION__);
       ++nerrors;
     }
 }
@@ -143,7 +143,7 @@ sighandler (int signal)
 int
 main (int argc, char **argv UNUSED)
 {
-  volatile sigset_t sigset1, sigset2, sigset3;
+  sigset_t sigset1, sigset2, sigset3;
   volatile struct sigaction act;
 
   if (argc > 1)
@@ -172,13 +172,13 @@ main (int argc, char **argv UNUSED)
       sigemptyset ((sigset_t *) &sigset3);
       sigprocmask (SIG_BLOCK, NULL, (sigset_t *) &sigset3);
       if (memcmp ((sigset_t *) &sigset3, (sigset_t *) &sigset2,
-		  sizeof (sigset_t)) != 0)
-	{
-	  fprintf (stderr, "FAILURE: _longjmp() manipulated signal mask!\n");
-	  ++nerrors;
-	}
+    	  sizeof (sigset_t)) != 0)
+    {
+      fprintf (stderr, "FAILURE: _longjmp() manipulated signal mask!\n");
+      ++nerrors;
+    }
       else if (verbose)
-	printf ("OK: _longjmp() seems not to change signal mask\n");
+    printf ("OK: _longjmp() seems not to change signal mask\n");
     }
   else
     {
@@ -193,14 +193,14 @@ main (int argc, char **argv UNUSED)
       sigemptyset ((sigset_t *) &sigset3);
       sigprocmask (SIG_BLOCK, NULL, (sigset_t *) &sigset3);
       if (memcmp ((sigset_t *) &sigset3, (sigset_t *) &sigset1,
-		  sizeof (sigset_t)) != 0)
-	{
-	  fprintf (stderr,
-		   "FAILURE: siglongjmp() didn't restore signal mask!\n");
-	  ++nerrors;
-	}
+    	  sizeof (sigset_t)) != 0)
+    {
+      fprintf (stderr,
+    	   "FAILURE: siglongjmp() didn't restore signal mask!\n");
+      ++nerrors;
+    }
       else if (verbose)
-	printf ("OK: siglongjmp() restores signal mask when asked to\n");
+    printf ("OK: siglongjmp() restores signal mask when asked to\n");
     }
   else
     {
@@ -215,14 +215,14 @@ main (int argc, char **argv UNUSED)
       sigemptyset ((sigset_t *) &sigset3);
       sigprocmask (SIG_BLOCK, NULL, (sigset_t *) &sigset3);
       if (memcmp ((sigset_t *) &sigset3, (sigset_t *) &sigset2,
-		  sizeof (sigset_t)) != 0)
-	{
-	  fprintf (stderr,
-		   "FAILURE: siglongjmp() changed signal mask!\n");
-	  ++nerrors;
-	}
+    	  sizeof (sigset_t)) != 0)
+    {
+      fprintf (stderr,
+    	   "FAILURE: siglongjmp() changed signal mask!\n");
+      ++nerrors;
+    }
       else if (verbose)
-	printf ("OK: siglongjmp() leaves signal mask alone when asked to\n");
+    printf ("OK: siglongjmp() leaves signal mask alone when asked to\n");
     }
   else
     {
@@ -237,14 +237,14 @@ main (int argc, char **argv UNUSED)
       sigemptyset ((sigset_t *) &sigset3);
       sigprocmask (SIG_BLOCK, NULL, (sigset_t *) &sigset3);
       if (memcmp ((sigset_t *) &sigset3, (sigset_t *) &sigset1,
-		  sizeof (sigset_t)) != 0)
-	{
-	  fprintf (stderr,
-		   "FAILURE: siglongjmp() didn't restore signal mask!\n");
-	  ++nerrors;
-	}
+    	  sizeof (sigset_t)) != 0)
+    {
+      fprintf (stderr,
+    	   "FAILURE: siglongjmp() didn't restore signal mask!\n");
+      ++nerrors;
+    }
       else if (verbose)
-	printf ("OK: siglongjmp() restores signal mask when asked to\n");
+    printf ("OK: siglongjmp() restores signal mask when asked to\n");
     }
   else
     {
@@ -261,14 +261,14 @@ main (int argc, char **argv UNUSED)
       sigemptyset ((sigset_t *) &sigset3);
       sigprocmask (SIG_BLOCK, NULL, (sigset_t *) &sigset3);
       if (memcmp ((sigset_t *) &sigset3, (sigset_t *) &sigset4,
-		  sizeof (sigset_t)) != 0)
-	{
-	  fprintf (stderr,
-		   "FAILURE: siglongjmp() changed signal mask!\n");
-	  ++nerrors;
-	}
+    	  sizeof (sigset_t)) != 0)
+    {
+      fprintf (stderr,
+    	   "FAILURE: siglongjmp() changed signal mask!\n");
+      ++nerrors;
+    }
       else if (verbose)
-	printf ("OK: siglongjmp() leaves signal mask alone when asked to\n");
+    printf ("OK: siglongjmp() leaves signal mask alone when asked to\n");
     }
   else
     {


### PR DESCRIPTION
This required using unw_context_t consistently, and removing the volatile qualifier for sigset_t values in test-setjmp (it doesn't do what I think the author though it did).

Closes #429 