### PR TITLE
Fix test-ptrace on x86-linux target

### DIFF
--- a/include/libunwind_i.h
+++ b/include/libunwind_i.h
@@ -221,18 +221,20 @@ do {                                            \
 static ALWAYS_INLINE void *
 mi_mmap (void *addr, size_t len, int prot, int flags, int fd, off_t offset)
 {
-#ifdef SYS_mmap
-#if defined(__FreeBSD__) // prefer over syscall on *BSD
+#if defined(SYS_mmap) && !defined(__i386__)
+  /* Where supported, bypass libc and invoke the syscall directly. */
+# if defined(__FreeBSD__) // prefer over syscall on *BSD
   long int ret = __syscall (SYS_mmap, addr, len, prot, flags, fd, offset);
-#else
+# else
   long int ret = syscall (SYS_mmap, addr, len, prot, flags, fd, offset);
-#endif
+# endif
   // @todo this is very likely Linux specific
   if ((unsigned long int)ret > -4096UL)
     return MAP_FAILED;
   else
     return (void *)ret;
 #else
+  /* Where direct syscalls are not supported, forward to the libc call. */
   return mmap (addr, len, prot, flags, fd, offset);
 #endif
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -75,6 +75,9 @@ if BUILD_PTRACE
  check_SCRIPTS_cdep += run-ptrace-mapper run-ptrace-misc
  check_PROGRAMS_cdep += test-ptrace
  noinst_PROGRAMS_cdep += mapper test-ptrace-misc
+if ARCH_X86
+ XFAIL_TESTS += test-ptrace
+endif
 endif
 
 if BUILD_SETJMP


### PR DESCRIPTION
The unit test test-ptrace was failing on x86 targets. This was for 3 unrelated reasons.

1. `mi_mmap()` was bypassing the libc `mmap()` call and invoking `syscall()` instead. Unfortunately on x86 Linux the direct syscall is not supported because of the way parameters are passed to syscalls. Fall back to the libc `mmap()` for x86-linux.

2. The `ptrace(PTRACE_GETREGSET)` call just returns an error no x86-linux. Fall back to using `ptrace(PTRACE_GETREGS)` instead. That only works if the parameters are passed in the correct order (they were reversed). This might break on Solaris.

3. The CI test run as multilibbed tests (running 32-bit binaries on a 64-bit OS). The test itself runs a 64-bit binary (`ls`) and the elfxx.c code built into libunwind can not handle multilibbed use although it's supposed to be the fundamental architecture of the library. That's a different issue though, so in the mean time XFAIL the test in CI. When the test is run manually using a 32-bit x86 binary it passes.
```
$ tests/test-ptrace tests/.libs/test-strerror && printf "PASSED\n" || printf "FAILED\n"
PASSED
```