### PR TITLE
Reduce compile-time warnings on FreeBSD/x86_64

### DIFF
--- a/include/tdep-x86_64/libunwind_i.h
+++ b/include/tdep-x86_64/libunwind_i.h
@@ -291,9 +291,9 @@ extern void tdep_fetch_frame (struct dwarf_cursor *c, unw_word_t ip,
 extern int tdep_cache_frame (struct dwarf_cursor *c);
 extern void tdep_reuse_frame (struct dwarf_cursor *c,
                               int frame);
+#endif
 extern void tdep_stash_frame (struct dwarf_cursor *c,
                               struct dwarf_reg_state *rs);
-#endif
 
 extern int tdep_getcontext_trace (unw_tdep_context_t *);
 extern int tdep_trace (unw_cursor_t *cursor, void **addresses, int *n);

--- a/src/x86_64/Ginit.c
+++ b/src/x86_64/Ginit.c
@@ -164,7 +164,11 @@ static int msync_validate (unw_word_t addr, size_t len)
 #ifdef HAVE_MINCORE
 static int mincore_validate (unw_word_t addr, size_t len)
 {
+#ifdef __FreeBSD__
+  char mvec[2];
+#else
   unsigned char mvec[2]; /* Unaligned access may cross page boundary */
+#endif
 
   /* mincore could fail with EAGAIN but we conservatively return -1
      instead of looping. */
@@ -213,7 +217,11 @@ tdep_init_mem_validate (void)
   unsigned char present = 1;
   size_t len = unw_page_size;
   unw_word_t addr = unw_page_start((unw_word_t)&present);
+#ifdef __FreeBSD__
+  char mvec[2];
+#else
   unsigned char mvec[1];
+#endif
   int ret;
   while ((ret = mincore ((void*)addr, len, mvec)) == -1 &&
          errno == EAGAIN) {}

--- a/src/x86_64/Ginit.c
+++ b/src/x86_64/Ginit.c
@@ -215,7 +215,7 @@ tdep_init_mem_validate (void)
   unw_word_t addr = unw_page_start((unw_word_t)&present);
   unsigned char mvec[1];
   int ret;
-  while ((ret = mincore ((void*)addr, len, (unsigned char *)mvec)) == -1 &&
+  while ((ret = mincore ((void*)addr, len, mvec)) == -1 &&
          errno == EAGAIN) {}
   if (ret == 0)
     {


### PR DESCRIPTION
Unhide tdep_stash_frame from __linux__ due it’s os independent nature.