### PR TITLE
Reduce compile-time warnings.

### DIFF
--- a/tests/x64-test-dwarf-expressions.S
+++ b/tests/x64-test-dwarf-expressions.S
@@ -76,3 +76,6 @@ DW_CFA_expression_inner:
   ret
   .cfi_endproc
 .size DW_CFA_expression_inner,.-DW_CFA_expression_inner
+
+      /* We do not need executable stack.  */
+      .section        .note.GNU-stack,"",@progbits


### PR DESCRIPTION
Add .note.GNU-stack to x64-test-dwarf-expressions to satisfy linker.