### PR TITLE
Fix x64-unwind-badjmp-signal-frame test for FreeBSD.

### DIFF
--- a/tests/x64-unwind-badjmp-signal-frame.c
+++ b/tests/x64-unwind-badjmp-signal-frame.c
@@ -57,6 +57,9 @@ void handle_sigsegv(int signal, siginfo_t *info, void *ucontext)
   int found_signal_frame = 0;
   int i = 0;
   char *names[] = {
+#if defined __FreeBSD__
+    "",
+#endif
     "",
     "main",
   };


### PR DESCRIPTION
On FreeBSD unw_get_proc_name() routine does not return the name of the signal frame procedure, skip it too.