### PR TITLE
Eliminate x86_64 build warnings

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -40,9 +40,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 # if (__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ > 2)
 #  define ALWAYS_INLINE inline __attribute__((always_inline))
 #  define HIDDEN        __attribute__((visibility ("hidden")))
+#  define FALLTHROUGH   __attribute__((fallthrough))
 # else
 #  define ALWAYS_INLINE
 #  define HIDDEN
+#  define FALLTHROUGH
 # endif
 # define WEAK           __attribute__((weak))
 # if (__GNUC__ >= 3)
@@ -60,6 +62,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 # define NORETURN
 # define ALIAS(name)
 # define HIDDEN
+# define FALLTHROUGH
 # define WEAK
 # define likely(x)      (x)
 # define unlikely(x)    (x)

--- a/include/dwarf_i.h
+++ b/include/dwarf_i.h
@@ -43,8 +43,8 @@ typedef union __attribute__ ((packed))
 dwarf_misaligned_value_t;
 
 static inline int
-dwarf_reads8 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
-              int8_t *val, void *arg)
+dwarf_reads8 (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED, unw_word_t *addr,
+              int8_t *val, void *arg UNUSED)
 {
   dwarf_misaligned_value_t *mvp = (void *) (uintptr_t) *addr;
 
@@ -54,8 +54,8 @@ dwarf_reads8 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
 }
 
 static inline int
-dwarf_reads16 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
-               int16_t *val, void *arg)
+dwarf_reads16 (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED, unw_word_t *addr,
+               int16_t *val, void *arg UNUSED)
 {
   dwarf_misaligned_value_t *mvp = (void *) (uintptr_t) *addr;
 
@@ -65,8 +65,8 @@ dwarf_reads16 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
 }
 
 static inline int
-dwarf_reads32 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
-               int32_t *val, void *arg)
+dwarf_reads32 (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED, unw_word_t *addr,
+               int32_t *val, void *arg UNUSED)
 {
   dwarf_misaligned_value_t *mvp = (void *) (uintptr_t) *addr;
 
@@ -76,8 +76,8 @@ dwarf_reads32 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
 }
 
 static inline int
-dwarf_reads64 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
-               int64_t *val, void *arg)
+dwarf_reads64 (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED, unw_word_t *addr,
+               int64_t *val, void *arg UNUSED)
 {
   dwarf_misaligned_value_t *mvp = (void *) (uintptr_t) *addr;
 
@@ -87,8 +87,8 @@ dwarf_reads64 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
 }
 
 static inline int
-dwarf_readu8 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
-              uint8_t *val, void *arg)
+dwarf_readu8 (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED, unw_word_t *addr,
+              uint8_t *val, void *arg UNUSED)
 {
   dwarf_misaligned_value_t *mvp = (void *) (uintptr_t) *addr;
 
@@ -98,8 +98,8 @@ dwarf_readu8 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
 }
 
 static inline int
-dwarf_readu16 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
-               uint16_t *val, void *arg)
+dwarf_readu16 (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED, unw_word_t *addr,
+               uint16_t *val, void *arg UNUSED)
 {
   dwarf_misaligned_value_t *mvp = (void *) (uintptr_t) *addr;
 
@@ -109,8 +109,8 @@ dwarf_readu16 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
 }
 
 static inline int
-dwarf_readu32 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
-               uint32_t *val, void *arg)
+dwarf_readu32 (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED, unw_word_t *addr,
+               uint32_t *val, void *arg UNUSED)
 {
   dwarf_misaligned_value_t *mvp = (void *) (uintptr_t) *addr;
 
@@ -120,8 +120,8 @@ dwarf_readu32 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
 }
 
 static inline int
-dwarf_readu64 (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
-               uint64_t *val, void *arg)
+dwarf_readu64 (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED, unw_word_t *addr,
+               uint64_t *val, void *arg UNUSED)
 {
   dwarf_misaligned_value_t *mvp = (void *) (uintptr_t) *addr;
 

--- a/include/remote.h
+++ b/include/remote.h
@@ -8,8 +8,8 @@
 #ifdef UNW_LOCAL_ONLY
 
 static inline int
-fetch8 (unw_addr_space_t as, unw_accessors_t *a,
-        unw_word_t *addr, int8_t *valp, void *arg)
+fetch8 (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED,
+        unw_word_t *addr, int8_t *valp, void *arg UNUSED)
 {
   *valp = *(int8_t *) (uintptr_t) *addr;
   *addr += 1;
@@ -17,8 +17,8 @@ fetch8 (unw_addr_space_t as, unw_accessors_t *a,
 }
 
 static inline int
-fetch16 (unw_addr_space_t as, unw_accessors_t *a,
-         unw_word_t *addr, int16_t *valp, void *arg)
+fetch16 (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED,
+         unw_word_t *addr, int16_t *valp, void *arg UNUSED)
 {
   *valp = *(int16_t *) (uintptr_t) *addr;
   *addr += 2;
@@ -26,8 +26,8 @@ fetch16 (unw_addr_space_t as, unw_accessors_t *a,
 }
 
 static inline int
-fetch32 (unw_addr_space_t as, unw_accessors_t *a,
-         unw_word_t *addr, int32_t *valp, void *arg)
+fetch32 (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED,
+         unw_word_t *addr, int32_t *valp, void *arg UNUSED)
 {
   *valp = *(int32_t *) (uintptr_t) *addr;
   *addr += 4;
@@ -35,8 +35,8 @@ fetch32 (unw_addr_space_t as, unw_accessors_t *a,
 }
 
 static inline int
-fetchw (unw_addr_space_t as, unw_accessors_t *a,
-        unw_word_t *addr, unw_word_t *valp, void *arg)
+fetchw (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED,
+        unw_word_t *addr, unw_word_t *valp, void *arg UNUSED)
 {
   *valp = *(unw_word_t *) (uintptr_t) *addr;
   *addr += sizeof (unw_word_t);

--- a/include/tdep-x86_64/libunwind_i.h
+++ b/include/tdep-x86_64/libunwind_i.h
@@ -175,7 +175,7 @@ dwarf_is_null_loc(dwarf_loc_t l)
 #endif /* !UNW_LOCAL_ONLY */
 
 static inline int
-dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
+dwarf_getfp (struct dwarf_cursor *c UNUSED, dwarf_loc_t loc, unw_fpreg_t *val UNUSED)
 {
   if (DWARF_IS_NULL_LOC (loc))
     return -UNW_EBADREG;
@@ -184,7 +184,7 @@ dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
 }
 
 static inline int
-dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
+dwarf_putfp (struct dwarf_cursor *c UNUSED, dwarf_loc_t loc, unw_fpreg_t val UNUSED)
 {
   if (DWARF_IS_NULL_LOC (loc))
     return -UNW_EBADREG;

--- a/src/coredump/_UCD_access_mem.c
+++ b/src/coredump/_UCD_access_mem.c
@@ -26,7 +26,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "ucd_file_table.h"
 
 int
-_UCD_access_mem (unw_addr_space_t  as,
+_UCD_access_mem (unw_addr_space_t  as UNUSED,
                  unw_word_t        addr,
                  unw_word_t       *val,
                  int               write,

--- a/src/coredump/_UCD_access_reg_linux.c
+++ b/src/coredump/_UCD_access_reg_linux.c
@@ -27,9 +27,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "_UCD_internal.h"
 
 int
-_UCD_access_reg (unw_addr_space_t as,
-                                unw_regnum_t regnum, unw_word_t *valp,
-                                int write, void *arg)
+_UCD_access_reg (unw_addr_space_t  as UNUSED,
+                 unw_regnum_t      regnum,
+                 unw_word_t       *valp,
+                 int               write,
+                 void             *arg)
 {
   struct UCD_info *ui = arg;
 

--- a/src/coredump/_UCD_get_mapinfo_linux.c
+++ b/src/coredump/_UCD_get_mapinfo_linux.c
@@ -130,12 +130,12 @@ _handle_nt_file_note (uint8_t *desc, void *arg)
  * Note interpretation requires both name and type.
  */
 static int
-_handle_pt_note_segment (uint32_t  n_namesz,
-						 uint32_t  n_descsz,
-						 uint32_t  n_type,
-						 char     *name,
-						 uint8_t  *desc,
-						 void     *arg)
+_handle_pt_note_segment (uint32_t  n_namesz UNUSED,
+                         uint32_t  n_descsz UNUSED,
+                         uint32_t  n_type,
+                         char     *name,
+                         uint8_t  *desc,
+                         void     *arg)
 {
 #ifdef NT_FILE
   if (n_type == NT_FILE && strcmp (name, "CORE") == 0)

--- a/src/coredump/_UCD_get_threadinfo_prstatus.c
+++ b/src/coredump/_UCD_get_threadinfo_prstatus.c
@@ -38,7 +38,12 @@
  * NT_PRSTATUS note seen.
  */
 static int
-_count_thread_notes(uint32_t n_namesz, uint32_t n_descsz, uint32_t n_type, char *name, uint8_t *desc, void *arg)
+_count_thread_notes(uint32_t  n_namesz UNUSED,
+                    uint32_t  n_descsz UNUSED,
+                    uint32_t  n_type,
+                    char     *name UNUSED,
+                    uint8_t  *desc UNUSED,
+                    void     *arg)
 {
   size_t *thread_count = (size_t *)arg;
   if (n_type == NT_PRSTATUS)
@@ -57,7 +62,12 @@ _count_thread_notes(uint32_t n_namesz, uint32_t n_descsz, uint32_t n_type, char 
  * increments the count.
  */
 static int
-_save_thread_notes(uint32_t n_namesz, uint32_t n_descsz, uint32_t n_type, char *name, uint8_t *desc, void *arg)
+_save_thread_notes(uint32_t  n_namesz UNUSED,
+                   uint32_t  n_descsz UNUSED,
+                   uint32_t  n_type,
+                   char     *name UNUSED,
+                   uint8_t  *desc,
+                   void     *arg)
 {
   struct UCD_info *ui = (struct UCD_info *)arg;
   if (n_type == NT_PRSTATUS)

--- a/src/coredump/_UPT_access_fpreg.c
+++ b/src/coredump/_UPT_access_fpreg.c
@@ -25,8 +25,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "_UCD_internal.h"
 
 int
-_UCD_access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
-                   int write, void *arg)
+_UCD_access_fpreg (unw_addr_space_t  as UNUSED,
+                   unw_regnum_t      reg UNUSED,
+                   unw_fpreg_t      *val UNUSED,
+                   int               write,
+                   void             *arg)
 {
   struct UCD_info *ui UNUSED = arg;
 

--- a/src/coredump/_UPT_get_dyn_info_list_addr.c
+++ b/src/coredump/_UPT_get_dyn_info_list_addr.c
@@ -79,8 +79,10 @@ get_list_addr (unw_addr_space_t as, unw_word_t *dil_addr, void *arg,
        DWARF2 unwind info.  */
 
 static inline int
-get_list_addr (unw_addr_space_t as, unw_word_t *dil_addr, void *arg,
-               int *countp)
+get_list_addr (unw_addr_space_t  as UNUSED,
+               unw_word_t       *dil_addr UNUSED,
+               void             *arg UNUSED,
+               int              *countp)
 {
 # warning Implement get_list_addr(), please.
   *countp = 0;

--- a/src/coredump/_UPT_put_unwind_info.c
+++ b/src/coredump/_UPT_put_unwind_info.c
@@ -27,7 +27,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "_UCD_internal.h"
 
 void
-_UCD_put_unwind_info (unw_addr_space_t as, unw_proc_info_t *pi, void *arg)
+_UCD_put_unwind_info (unw_addr_space_t  as UNUSED,
+					  unw_proc_info_t  *pi,
+                      void             *arg UNUSED)
 {
   if (!pi->unwind_info)
     return;

--- a/src/coredump/_UPT_resume.c
+++ b/src/coredump/_UPT_resume.c
@@ -27,7 +27,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "_UCD_internal.h"
 
 int
-_UCD_resume (unw_addr_space_t as, unw_cursor_t *c, void *arg)
+_UCD_resume (unw_addr_space_t  as UNUSED,
+             unw_cursor_t     *c UNUSED,
+             void             *arg UNUSED)
 {
   print_error (__func__);
   print_error (" not implemented\n");

--- a/src/dwarf/Gexpr.c
+++ b/src/dwarf/Gexpr.c
@@ -110,7 +110,7 @@ static const uint8_t operands[256] =
   };
 
 static inline unw_sword_t
-sword (unw_addr_space_t as, unw_word_t val)
+sword (unw_addr_space_t as UNUSED, unw_word_t val)
 {
   switch (dwarf_addr_size (as))
     {

--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -1037,7 +1037,7 @@ dwarf_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
 }
 
 HIDDEN void
-dwarf_put_unwind_info (unw_addr_space_t as, unw_proc_info_t *pi, void *arg)
+dwarf_put_unwind_info (unw_addr_space_t as UNUSED, unw_proc_info_t *pi UNUSED, void *arg UNUSED)
 {
   return;       /* always a nop */
 }

--- a/src/dwarf/Gfind_unwind_table.c
+++ b/src/dwarf/Gfind_unwind_table.c
@@ -36,9 +36,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #define to_unw_word(p) ((unw_word_t) (uintptr_t) (p))
 
 int
-dwarf_find_unwind_table (struct elf_dyn_info *edi, unw_addr_space_t as,
-                         const char *path, unw_word_t segbase, unw_word_t mapoff,
-                         unw_word_t ip)
+dwarf_find_unwind_table (struct elf_dyn_info *edi,
+						 unw_addr_space_t     as UNUSED,
+                         const char          *path UNUSED,
+                         unw_word_t           segbase,
+                         unw_word_t           mapoff,
+                         unw_word_t           ip UNUSED)
 {
   Elf_W(Phdr) *phdr, *ptxt = NULL, *peh_hdr = NULL, *pdyn = NULL;
   unw_word_t addr, eh_frame_start, fde_count, loadoff, load_base;

--- a/src/dwarf/Gget_proc_info_in_range.c
+++ b/src/dwarf/Gget_proc_info_in_range.c
@@ -24,12 +24,17 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "dwarf_i.h"
 
 int
-unw_get_proc_info_in_range (unw_word_t start_ip, unw_word_t end_ip,
-                            unw_word_t eh_frame_table, unw_word_t eh_frame_table_len,
-                            unw_word_t exidx_frame_table, unw_word_t exidx_frame_table_len,
-                            unw_addr_space_t as, unw_word_t ip,
-                            unw_proc_info_t *pi, int need_unwind_info,
-                            void *arg)
+unw_get_proc_info_in_range (unw_word_t        start_ip,
+							unw_word_t        end_ip,
+                            unw_word_t        eh_frame_table,
+                            unw_word_t        eh_frame_table_len UNUSED,
+                            unw_word_t        exidx_frame_table UNUSED,
+                            unw_word_t        exidx_frame_table_len UNUSED,
+                            unw_addr_space_t  as,
+                            unw_word_t        ip,
+                            unw_proc_info_t  *pi,
+                            int               need_unwind_info,
+                            void             *arg)
 {
     int ret = 0;
 

--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -490,7 +490,9 @@ fetch_proc_info (struct dwarf_cursor *c, unw_word_t ip)
 }
 
 static int
-parse_dynamic (struct dwarf_cursor *c, unw_word_t ip, dwarf_state_record_t *sr)
+parse_dynamic (struct dwarf_cursor  *c UNUSED,
+			   unw_word_t            ip UNUSED,
+               dwarf_state_record_t *sr UNUSED)
 {
   Debug (1, "Not yet implemented\n");
   return -UNW_ENOINFO;
@@ -1097,9 +1099,9 @@ dwarf_make_proc_info (struct dwarf_cursor *c)
 }
 
 static int
-dwarf_reg_states_dynamic_iterate(struct dwarf_cursor *c,
-				 unw_reg_states_callback cb,
-				 void *token)
+dwarf_reg_states_dynamic_iterate(struct dwarf_cursor     *c UNUSED,
+                                 unw_reg_states_callback  cb UNUSED,
+                                 void                    *token UNUSED)
 {
   Debug (1, "Not yet implemented\n");
   return -UNW_ENOINFO;

--- a/src/elfxx.c
+++ b/src/elfxx.c
@@ -85,7 +85,7 @@ elf_w (string_table) (struct elf_image *ei, int section)
 }
 
 static int
-elf_w (lookup_symbol) (unw_addr_space_t as,
+elf_w (lookup_symbol) (unw_addr_space_t as UNUSED,
                        unw_word_t ip, struct elf_image *ei,
                        Elf_W (Addr) load_offset,
                        char *buf, size_t buf_len, Elf_W (Addr) *min_dist)
@@ -328,7 +328,7 @@ elf_w (extract_minidebuginfo) (struct elf_image *ei, struct elf_image *mdi)
 }
 #else
 static int
-elf_w (extract_minidebuginfo) (struct elf_image *ei, struct elf_image *mdi)
+elf_w (extract_minidebuginfo) (struct elf_image *ei UNUSED, struct elf_image *mdi UNUSED)
 {
   return 0;
 }

--- a/src/mi/Gdestroy_addr_space.c
+++ b/src/mi/Gdestroy_addr_space.c
@@ -26,7 +26,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "libunwind_i.h"
 
 void
-unw_destroy_addr_space (unw_addr_space_t as)
+unw_destroy_addr_space (unw_addr_space_t as UNUSED)
 {
 #ifndef UNW_LOCAL_ONLY
 # if UNW_DEBUG

--- a/src/mi/Gdyn-remote.c
+++ b/src/mi/Gdyn-remote.c
@@ -286,8 +286,9 @@ unwi_dyn_remote_find_proc_info (unw_addr_space_t as, unw_word_t ip,
 }
 
 HIDDEN void
-unwi_dyn_remote_put_unwind_info (unw_addr_space_t as, unw_proc_info_t *pi,
-                                 void *arg)
+unwi_dyn_remote_put_unwind_info (unw_addr_space_t  as UNUSED,
+                                 unw_proc_info_t  *pi,
+                                 void             *arg UNUSED)
 {
   if (!pi->unwind_info)
     return;

--- a/src/mi/Gfind_dynamic_proc_info.c
+++ b/src/mi/Gfind_dynamic_proc_info.c
@@ -63,8 +63,11 @@ local_find_proc_info (unw_addr_space_t as, unw_word_t ip, unw_proc_info_t *pi,
 #ifdef UNW_LOCAL_ONLY
 
 static inline int
-remote_find_proc_info (unw_addr_space_t as, unw_word_t ip, unw_proc_info_t *pi,
-                       int need_unwind_info, void *arg)
+remote_find_proc_info (unw_addr_space_t  as UNUSED,
+					   unw_word_t        ip UNUSED,
+					   unw_proc_info_t  *pi UNUSED,
+                       int               need_unwind_info UNUSED,
+                       void             *arg UNUSED)
 {
   return -UNW_ENOINFO;
 }

--- a/src/mi/flush_cache.c
+++ b/src/mi/flush_cache.c
@@ -27,7 +27,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <stdatomic.h>
 
 void
-unw_flush_cache (unw_addr_space_t as, unw_word_t lo, unw_word_t hi)
+unw_flush_cache (unw_addr_space_t as, unw_word_t lo UNUSED, unw_word_t hi UNUSED)
 {
 #if !UNW_TARGET_IA64
   struct unw_debug_frame_list *w = as->debug_frames;

--- a/src/ptrace/_UPT_access_fpreg.c
+++ b/src/ptrace/_UPT_access_fpreg.c
@@ -28,7 +28,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #if HAVE_DECL_PTRACE_POKEUSER || defined(HAVE_TTRACE)
 int
-_UPT_access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
+_UPT_access_fpreg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_fpreg_t *val,
                    int write, void *arg)
 {
   unw_word_t *wp = (unw_word_t *) val;

--- a/src/ptrace/_UPT_access_mem.c
+++ b/src/ptrace/_UPT_access_mem.c
@@ -28,7 +28,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #if HAVE_DECL_PTRACE_POKEDATA || defined(HAVE_TTRACE)
 int
-_UPT_access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val,
+_UPT_access_mem (unw_addr_space_t as UNUSED, unw_word_t addr, unw_word_t *val,
                  int write, void *arg)
 {
   struct UPT_info *ui = arg;

--- a/src/ptrace/_UPT_access_reg.c
+++ b/src/ptrace/_UPT_access_reg.c
@@ -37,7 +37,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #if HAVE_DECL_PTRACE_SETREGSET && (defined(__linux__) && !defined(UNW_TARGET_X86))
 #include <sys/uio.h>
 int
-_UPT_access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val,
+_UPT_access_reg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_word_t *val,
                  int write, void *arg)
 {
   struct UPT_info *ui = arg;
@@ -79,7 +79,7 @@ badreg:
 }
 #elif (HAVE_DECL_PTRACE_POKEUSER || defined(HAVE_TTRACE)) && (defined(__linux__) && !defined(UNW_TARGET_X86))
 int
-_UPT_access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val,
+_UPT_access_reg (UNUSED unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val,
                  int write, void *arg)
 {
   struct UPT_info *ui = arg;

--- a/src/ptrace/_UPT_get_dyn_info_list_addr.c
+++ b/src/ptrace/_UPT_get_dyn_info_list_addr.c
@@ -77,8 +77,10 @@ get_list_addr (unw_addr_space_t as, unw_word_t *dil_addr, void *arg,
        DWARF2 unwind info.  */
 
 static inline int
-get_list_addr (unw_addr_space_t as, unw_word_t *dil_addr, void *arg,
-               int *countp)
+get_list_addr (unw_addr_space_t  as UNUSED,
+               unw_word_t       *dil_addr UNUSED,
+               void             *arg UNUSED,
+               int              *countp)
 {
 # warning Implement get_list_addr(), please.
   *countp = 0;

--- a/src/ptrace/_UPT_put_unwind_info.c
+++ b/src/ptrace/_UPT_put_unwind_info.c
@@ -26,7 +26,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "_UPT_internal.h"
 
 void
-_UPT_put_unwind_info (unw_addr_space_t as, unw_proc_info_t *pi, void *arg)
+_UPT_put_unwind_info (unw_addr_space_t as UNUSED, unw_proc_info_t *pi, void *arg UNUSED)
 {
   if (!pi->unwind_info)
     return;

--- a/src/ptrace/_UPT_resume.c
+++ b/src/ptrace/_UPT_resume.c
@@ -26,7 +26,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "_UPT_internal.h"
 
 int
-_UPT_resume (unw_addr_space_t as, unw_cursor_t *c, void *arg)
+_UPT_resume (unw_addr_space_t as UNUSED, unw_cursor_t *c UNUSED, void *arg)
 {
   struct UPT_info *ui = arg;
 

--- a/src/setjmp/setjmp_i.h
+++ b/src/setjmp/setjmp_i.h
@@ -23,10 +23,10 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
-#if UNW_TARGET_IA64
-
 #include "libunwind_i.h"
-#include "tdep-ia64/rse.h"
+
+#if UNW_TARGET_IA64
+# include "tdep-ia64/rse.h"
 
 static inline int
 bsp_match (unw_cursor_t *c, unw_word_t *wp)
@@ -103,13 +103,13 @@ resume_restores_sigmask (unw_cursor_t *c, unw_word_t *wp)
 #else /* !UNW_TARGET_IA64 */
 
 static inline int
-bsp_match (unw_cursor_t *c, unw_word_t *wp)
+bsp_match (unw_cursor_t *c UNUSED, unw_word_t *wp UNUSED)
 {
   return 1;
 }
 
 static inline int
-resume_restores_sigmask (unw_cursor_t *c, unw_word_t *wp)
+resume_restores_sigmask (unw_cursor_t *c UNUSED, unw_word_t *wp  UNUSED)
 {
   /* We may want to do this analogously as for ia64... */
   return 0;

--- a/src/x86_64/Gcreate_addr_space.c
+++ b/src/x86_64/Gcreate_addr_space.c
@@ -35,7 +35,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #endif
 
 unw_addr_space_t
-unw_create_addr_space (unw_accessors_t *a, int byte_order)
+unw_create_addr_space (unw_accessors_t *a UNUSED, int byte_order UNUSED)
 {
 #ifdef UNW_LOCAL_ONLY
   return NULL;

--- a/src/x86_64/Ginit.c
+++ b/src/x86_64/Ginit.c
@@ -54,14 +54,14 @@ static struct unw_addr_space local_addr_space;
 unw_addr_space_t unw_local_addr_space = &local_addr_space;
 
 static void
-put_unwind_info (unw_addr_space_t as, unw_proc_info_t *proc_info, void *arg)
+put_unwind_info (unw_addr_space_t as UNUSED, unw_proc_info_t *proc_info UNUSED, void *arg UNUSED)
 {
   /* it's a no-op */
 }
 
 static int
-get_dyn_info_list_addr (unw_addr_space_t as, unw_word_t *dyn_info_list_addr,
-                        void *arg)
+get_dyn_info_list_addr (unw_addr_space_t as UNUSED, unw_word_t *dyn_info_list_addr,
+                        void *arg UNUSED)
 {
 #ifndef UNW_LOCAL_ONLY
 # pragma weak _U_dyn_info_list_addr
@@ -339,7 +339,7 @@ validate_mem (unw_word_t addr, size_t len)
 }
 
 static int
-access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
+access_mem (unw_addr_space_t as UNUSED, unw_word_t addr, unw_word_t *val, int write,
             void *arg)
 {
   if (unlikely (write))
@@ -362,7 +362,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
 }
 
 static int
-access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
+access_reg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_word_t *val, int write,
             void *arg)
 {
   unw_word_t *addr;
@@ -392,7 +392,7 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 }
 
 static int
-access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
+access_fpreg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_fpreg_t *val,
               int write, void *arg)
 {
   ucontext_t *uc = AS_ARG_GET_UC_PTR(arg);
@@ -427,7 +427,7 @@ access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
 static int
 get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
-                      void *arg)
+                      void *arg UNUSED)
 {
   return _Uelf64_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
 }

--- a/src/x86_64/Ginit_remote.c
+++ b/src/x86_64/Ginit_remote.c
@@ -30,7 +30,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "unwind_i.h"
 
 int
-unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
+unw_init_remote (unw_cursor_t *cursor UNUSED, unw_addr_space_t as UNUSED, void *as_arg UNUSED)
 {
 #ifdef UNW_LOCAL_ONLY
   return -UNW_EINVAL;

--- a/src/x86_64/Gos-linux.c
+++ b/src/x86_64/Gos-linux.c
@@ -32,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <sys/syscall.h>
 
 HIDDEN void
-tdep_fetch_frame (struct dwarf_cursor *dw, unw_word_t ip, int need_unwind_info)
+tdep_fetch_frame (struct dwarf_cursor *dw, unw_word_t ip UNUSED, int need_unwind_info UNUSED)
 {
   struct cursor *c = (struct cursor *) dw;
   assert(! need_unwind_info || dw->pi_valid);
@@ -85,7 +85,7 @@ unw_is_signal_frame (unw_cursor_t *cursor)
 }
 
 HIDDEN int
-x86_64_handle_signal_frame (unw_cursor_t *cursor)
+x86_64_handle_signal_frame (unw_cursor_t *cursor UNUSED)
 {
 #if UNW_DEBUG /* To silence compiler warnings */
   /* Should not get here because we now use kernel-provided dwarf

--- a/src/x86_64/Gregs.c
+++ b/src/x86_64/Gregs.c
@@ -131,8 +131,8 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
 }
 
 HIDDEN int
-tdep_access_fpreg (struct cursor *c, unw_regnum_t reg, unw_fpreg_t *valp,
-                   int write)
+tdep_access_fpreg (struct cursor *c UNUSED, unw_regnum_t reg UNUSED,
+                   unw_fpreg_t *valp UNUSED, int write UNUSED)
 {
       return -UNW_EBADREG;
 }

--- a/src/x86_64/Gresume.c
+++ b/src/x86_64/Gresume.c
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #ifndef UNW_REMOTE_ONLY
 
 HIDDEN inline int
-x86_64_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
+x86_64_local_resume (unw_addr_space_t as UNUSED, unw_cursor_t *cursor, void *arg UNUSED)
 {
   struct cursor *c = (struct cursor *) cursor;
   ucontext_t *uc = dwarf_get_uc(&c->dwarf);

--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -58,7 +58,7 @@ is_plt_entry (struct dwarf_cursor *c)
 }
 
 static int
-is_vsyscall (struct dwarf_cursor *c)
+is_vsyscall (struct dwarf_cursor *c UNUSED)
 {
 #if defined(VSYSCALL_START) && defined(VSYSCALL_END)
   return c->ip >= VSYSCALL_START && c->ip < VSYSCALL_END;
@@ -236,10 +236,14 @@ unw_step (unw_cursor_t *cursor)
                             rip_loc = DWARF_LOC (rsp, 0);
                           }
                         else
-                          Debug (2, "new_ip 0x%lx dwarf_get(&c->dwarf, DWARF_MEM_LOC(c->dwarf, new_ip), &not_used) != 0\n", new_ip);
+                          {
+                            Debug (2, "new_ip 0x%lx dwarf_get(&c->dwarf, DWARF_MEM_LOC(c->dwarf, new_ip), &not_used) != 0\n", new_ip);
+                          }
                       }
                     else
+                      {
                         Debug (2, "rsp 0x%lx dwarf_get(&c->dwarf, DWARF_MEM_LOC(c->dwarf, rsp), &new_ip) != 0\n", rsp);
+                      }
                   }
               /*
                * If the previous rip we found on the stack didn't look valid fall back

--- a/src/x86_64/Gtrace.c
+++ b/src/x86_64/Gtrace.c
@@ -477,6 +477,7 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       /* Fall thru to standard processing after forcing validation. */
       if (d->as == unw_local_addr_space)
         dwarf_set_validate(d, 1);
+      FALLTHROUGH;
 
     case UNW_X86_64_FRAME_STANDARD:
       /* Advance standard traceable frame. */

--- a/src/x86_64/is_fpreg.c
+++ b/src/x86_64/is_fpreg.c
@@ -28,7 +28,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "libunwind_i.h"
 
 int
-unw_is_fpreg (int regnum)
+unw_is_fpreg (int regnum UNUSED)
 {
 #if 0
   return ((regnum >= UNW_X86_ST0 && regnum <= UNW_X86_ST7)

--- a/tests/Gperf-trace.c
+++ b/tests/Gperf-trace.c
@@ -32,8 +32,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <sys/resource.h>
 #include <sys/time.h>
 
-#define panic(args...)							  \
-	do { fprintf (stderr, args); exit (-1); } while (0)
+#define panic(...)							  \
+	do { fprintf (stderr, __VA_ARGS__); exit (-1); } while (0)
 
 long dummy;
 

--- a/tests/Gtest-concurrent.c
+++ b/tests/Gtest-concurrent.c
@@ -39,8 +39,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #define NTHREADS	128
 
-#define panic(args...)						\
-	do { fprintf (stderr, args); ++nerrors; } while (0)
+#define panic(...)						\
+	do { fprintf (stderr, __VA_ARGS__); ++nerrors; } while (0)
 
 int verbose;
 int nerrors;

--- a/tests/Gtest-exc.c
+++ b/tests/Gtest-exc.c
@@ -40,8 +40,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 # include <ia64intrin.h>
 #endif
 
-#define panic(args...)				\
-	{ ++nerrors; fprintf (stderr, args); }
+#define panic(...)				\
+	{ ++nerrors; fprintf (stderr, __VA_ARGS__); }
 
 int nerrors = 0;
 int verbose = 0;
@@ -112,7 +112,7 @@ a (int n)
 
   if (verbose)
     printf ("a(n=%d): sp=%p bsp=0x%lx\n",
-	    n, &stack, (unsigned long) get_bsp ());
+            n, (void *)&stack, (unsigned long) get_bsp ());
 
   if (n > 0)
     a (n - 1);
@@ -122,7 +122,7 @@ a (int n)
   if (verbose)
     {
       printf ("exception handler: here we go (sp=%p, bsp=0x%lx)...\n",
-	      &stack, (unsigned long) get_bsp ());
+              (void *)&stack, (unsigned long) get_bsp ());
       /* This call works around a bug in gcc (up-to pre3.4) which
 	 causes invalid assembly code to be generated when
 	 __builtin_ia64_bsp() gets predicated.  */

--- a/tests/Gtest-resume-sig.c
+++ b/tests/Gtest-resume-sig.c
@@ -41,8 +41,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 # include <ia64intrin.h>
 #endif
 
-#define panic(args...)						\
-	do { fprintf (stderr, args); ++nerrors; } while (0)
+#define panic(...)						\
+	do { fprintf (stderr, __VA_ARGS__); ++nerrors; } while (0)
 
 int verbose;
 int nerrors;

--- a/tests/Gtest-trace.c
+++ b/tests/Gtest-trace.c
@@ -40,8 +40,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <unistd.h>
 #include <libunwind.h>
 
-#define panic(args...)				\
-	{ fprintf (stderr, args); exit (-1); }
+#define panic(...)				\
+	{ fprintf (stderr, __VA_ARGS__); exit (-1); }
 
 #define SIG_STACK_SIZE 0x100000
 
@@ -80,7 +80,7 @@ do_backtrace (void)
   if (ret < 0)
     {
       unw_get_reg (&cursor, UNW_REG_IP, &ip);
-      printf ("FAILURE: unw_step() returned %d for ip=%lx\n", ret, (long) ip);
+      printf ("FAILURE: unw_step() returned %d for ip=%#010lx\n", ret, (long) ip);
       ++num_errors;
     }
 
@@ -121,7 +121,7 @@ do_backtrace (void)
   if (n == m)
     for (i = 1; i < n; ++i)
       /* Allow one in difference in comparison, trace returns adjusted addresses. */
-      if (labs((unw_word_t) addresses[1][i] - (unw_word_t) addresses[2][i]) > 1)
+      if (labs (addresses[1][i] - addresses[2][i]) > 1)
 	{
           printf ("FAILURE: backtrace() and unw_backtrace() addresses differ at %d: %p vs. %p\n",
                   i, addresses[1][i], addresses[2][i]);
@@ -131,7 +131,7 @@ do_backtrace (void)
   if (n == depth+1)
     for (i = 1; i < depth; ++i)
       /* Allow one in difference in comparison, trace returns adjusted addresses. */
-      if (labs((unw_word_t) addresses[0][i] - (unw_word_t) addresses[1][i]) > 1)
+      if (labs (addresses[0][i] - addresses[1][i]) > 1)
 	{
           printf ("FAILURE: unw_step() loop and backtrace() addresses differ at %d: %p vs. %p\n",
                   i, addresses[0][i], addresses[1][i]);
@@ -163,7 +163,7 @@ do_backtrace_with_context(void *context)
   if (ret < 0)
     {
       unw_get_reg (&cursor, UNW_REG_IP, &ip);
-      printf ("FAILURE: unw_step() returned %d for ip=%lx\n", ret, (long) ip);
+      printf ("FAILURE: unw_step() returned %d for ip=%#010lx\n", ret, (long) ip);
       ++num_errors;
     }
 
@@ -189,7 +189,7 @@ do_backtrace_with_context(void *context)
   if (m == depth + 1)
     for (i = 0; i < depth; ++i)
       /* Allow one in difference in comparison, trace returns adjusted addresses. */
-      if (labs((unw_word_t) addresses[0][i] - (unw_word_t) addresses[1][i]) > 1)
+      if ( labs(addresses[0][i] - addresses[1][i]) > 1)
 	{
           printf ("FAILURE: unw_step() loop and unw_backtrace2() addresses differ at %d: %p vs. %p\n",
                   i, addresses[0][i], addresses[1][i]);
@@ -236,7 +236,7 @@ bar (long v)
 }
 
 void
-sighandler (int signal, void *siginfo UNUSED, void *context)
+sighandler (int signal, siginfo_t *siginfo UNUSED, void *context)
 {
   ucontext_t *uc UNUSED;
   int sp;
@@ -245,10 +245,10 @@ sighandler (int signal, void *siginfo UNUSED, void *context)
 
   if (verbose)
     {
-      printf ("sighandler: got signal %d, sp=%p", signal, &sp);
+      printf ("sighandler: got signal %d, sp=%p", signal, (void *)&sp);
 #if UNW_TARGET_IA64
 # if defined(__linux__)
-      printf (" @ %lx", uc->uc_mcontext.sc_ip);
+      printf (" @ %#010lx", uc->uc_mcontext.sc_ip);
 # else
       {
 	uint16_t reason;
@@ -256,26 +256,26 @@ sighandler (int signal, void *siginfo UNUSED, void *context)
 
 	__uc_get_reason (uc, &reason);
 	__uc_get_ip (uc, &ip);
-	printf (" @ %lx (reason=%d)", ip, reason);
+	printf (" @ %#010lx (reason=%d)", ip, reason);
       }
 # endif
 #elif UNW_TARGET_X86
 #if defined __linux__
-      printf (" @ %lx", (unsigned long) uc->uc_mcontext.gregs[REG_EIP]);
+      printf (" @ %#010lx", (unsigned long) uc->uc_mcontext.gregs[REG_EIP]);
 #elif defined __FreeBSD__
-      printf (" @ %lx", (unsigned long) uc->uc_mcontext.mc_eip);
+      printf (" @ %#010lx", (unsigned long) uc->uc_mcontext.mc_eip);
 #endif
 #elif UNW_TARGET_X86_64
 #if defined __linux__ || defined __sun
-      printf (" @ %lx", (unsigned long) uc->uc_mcontext.gregs[REG_RIP]);
+      printf (" @ %#010lx", (unsigned long) uc->uc_mcontext.gregs[REG_RIP]);
 #elif defined __FreeBSD__
-      printf (" @ %lx", (unsigned long) uc->uc_mcontext.mc_rip);
+      printf (" @ %#010lx", (unsigned long) uc->uc_mcontext.mc_rip);
 #endif
 #elif defined UNW_TARGET_ARM
 #if defined __linux__
-      printf (" @ %lx", (unsigned long) uc->uc_mcontext.arm_pc);
+      printf (" @ %#010lx", (unsigned long) uc->uc_mcontext.arm_pc);
 #elif defined __FreeBSD__
-      printf (" @ %lx", (unsigned long) uc->uc_mcontext.__gregs[_REG_PC]);
+      printf (" @ %#010lx", (unsigned long) uc->uc_mcontext.__gregs[_REG_PC]);
 #endif
 #endif
       printf ("\n");
@@ -300,7 +300,7 @@ main (int argc, char **argv UNUSED)
   bar (1);
 
   memset (&act, 0, sizeof (act));
-  act.sa_handler = (void (*)(int)) sighandler;
+  act.sa_sigaction = sighandler;
   act.sa_flags = SA_SIGINFO;
   if (sigaction (SIGTERM, &act, NULL) < 0)
     panic ("sigaction: %s\n", strerror (errno));
@@ -321,7 +321,7 @@ main (int argc, char **argv UNUSED)
     panic ("sigaltstack: %s\n", strerror (errno));
 
   memset (&act, 0, sizeof (act));
-  act.sa_handler = (void (*)(int)) sighandler;
+  act.sa_sigaction = sighandler;
   act.sa_flags = SA_ONSTACK | SA_SIGINFO;
   if (sigaction (SIGTERM, &act, NULL) < 0)
     panic ("sigaction: %s\n", strerror (errno));

--- a/tests/Gx64-test-dwarf-expressions.c
+++ b/tests/Gx64-test-dwarf-expressions.c
@@ -3,12 +3,13 @@
 #include <stdlib.h>
 
 #include <libunwind.h>
+#include "compiler.h"
 
 static int verbose;
 static int nerrors;
 
-#define panic(args...)							  \
-	do { printf (args); ++nerrors; } while (0)
+#define panic(...)							  \
+	do { printf (__VA_ARGS__); ++nerrors; } while (0)
 
 // Assembly routine which sets up the stack for the test then calls another one
 // which clobbers the stack, and which in turn calls recover_register below
@@ -46,7 +47,7 @@ extern int64_t recover_register(int64_t regnum, int64_t height)
 }
 
 int
-main (int argc, char **argv)
+main (int argc, char **argv UNUSED)
 {
   if (argc > 1)
     verbose = 1;

--- a/tests/Ltest-init-local-signal.c
+++ b/tests/Ltest-init-local-signal.c
@@ -1,4 +1,5 @@
 #include "libunwind.h"
+#include "compiler.h"
 #include <sys/types.h>
 #include <unistd.h>
 #include <string.h>
@@ -35,7 +36,7 @@ int stepper(unw_cursor_t* c) {
 /* Verify that we can step from both ucontext, and from getcontext()
  * roughly the same.  This tests that the IP from ucontext is used
  * correctly (see impl of unw_init_local2) */
-void handler(int num, siginfo_t* info, void* ucontext) {
+void handler(int num UNUSED, siginfo_t* info UNUSED, void* ucontext) {
   unw_cursor_t c;
   unw_context_t context;
   unw_getcontext(&context);

--- a/tests/Ltest-mem-validate.c
+++ b/tests/Ltest-mem-validate.c
@@ -38,8 +38,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#define panic(args...)				\
-	{ fprintf (stderr, args); exit (-1); }
+#define panic(...)				\
+	{ fprintf (stderr, __VA_ARGS__); exit (-1); }
 
 void * stack_start;
 
@@ -97,7 +97,7 @@ void NOINLINE consume_and_run (int depth)
   unw_context_t uc;
   char string[1024];
 
-  sprintf (string, "hello %p %p\n", &cursor, &uc);
+  sprintf (string, "hello %p %p\n", (void *)&cursor, (void *)&uc);
   if (depth == 0) {
     do_backtrace();
   } else {
@@ -106,7 +106,7 @@ void NOINLINE consume_and_run (int depth)
 }
 
 int
-main (int argc, char **argv UNUSED)
+main (int argc UNUSED, char **argv UNUSED)
 {
   int start;
   unw_context_t uc;

--- a/tests/test-async-sig.c
+++ b/tests/test-async-sig.c
@@ -60,8 +60,8 @@ int sigcount;
 int recurcount;
 #endif
 
-#define panic(args...)					\
-	{ ++nerrors; fprintf (stderr, args); return; }
+#define panic(...)					\
+	{ ++nerrors; fprintf (stderr, __VA_ARGS__); return; }
 
 static void
 do_backtrace (int may_print, int get_proc_name)

--- a/tests/test-init-remote.c
+++ b/tests/test-init-remote.c
@@ -39,8 +39,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <string.h>
 #include <libunwind.h>
 
-#define panic(args...)				\
-	{ fprintf (stderr, args); exit (-1); }
+#define panic(...)				\
+	{ fprintf (stderr, __VA_ARGS__); exit (-1); }
 
 int verbose;
 

--- a/tests/test-mem.c
+++ b/tests/test-mem.c
@@ -35,8 +35,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include <sys/resource.h>
 
-#define panic(args...)				\
-	{ fprintf (stderr, args); exit (-1); }
+#define panic(...)				\
+	{ fprintf (stderr, __VA_ARGS__); exit (-1); }
 
 int verbose;
 
@@ -80,7 +80,7 @@ consume_some_stack_space (void)
 
   memset (&cursor, 0, sizeof (cursor));
   memset (&uc, 0, sizeof (uc));
-  return sprintf (string, "hello %p %p\n", &cursor, &uc);
+  return sprintf (string, "hello %p %p\n", (void *)&cursor, (void *)&uc);
 }
 
 int

--- a/tests/test-proc-info.c
+++ b/tests/test-proc-info.c
@@ -40,8 +40,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 int errors;
 
-#define panic(args...)					\
-	{ ++errors; fprintf (stderr, args); return -1; }
+#define panic(...)					\
+	{ ++errors; fprintf (stderr, __VA_ARGS__); return -1; }
 
 static int
 find_proc_info (unw_addr_space_t as UNUSED,

--- a/tests/test-ptrace.c
+++ b/tests/test-ptrace.c
@@ -64,8 +64,8 @@ enum
   }
 trace_mode = SYSCALL;
 
-#define panic(args...)						\
-	do { fprintf (stderr, args); ++nerrors; } while (0)
+#define panic(...)						\
+	do { fprintf (stderr, __VA_ARGS__); ++nerrors; } while (0)
 
 static unw_addr_space_t as;
 static struct UPT_info *ui;

--- a/tests/test-reg-state.c
+++ b/tests/test-reg-state.c
@@ -36,8 +36,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <sys/mman.h>
 #include <sys/resource.h>
 
-#define panic(args...)				\
-	{ fprintf (stderr, args); exit (-1); }
+#define panic(...)				\
+	{ fprintf (stderr, __VA_ARGS__); exit (-1); }
 
 int verbose;
 
@@ -111,7 +111,7 @@ consume_some_stack_space (void)
 
   memset (&cursor, 0, sizeof (cursor));
   memset (&uc, 0, sizeof (uc));
-  return sprintf (string, "hello %p %p\n", &cursor, &uc);
+  return sprintf (string, "hello %p %p\n", (void *)&cursor, (void *)&uc);
 }
 
 int

--- a/tests/x64-unwind-badjmp-signal-frame.c
+++ b/tests/x64-unwind-badjmp-signal-frame.c
@@ -37,12 +37,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
+#include "compiler.h"
 
 /*
  * unwind in the signal handler checking the backtrace is correct
  * after a bad jump.
  */
-void handle_sigsegv(int signal, siginfo_t *info, void *ucontext)
+void handle_sigsegv(int signal UNUSED, siginfo_t *info UNUSED, void *ucontext UNUSED)
 {
   /*
    * 0 = success
@@ -105,7 +106,7 @@ void handle_sigsegv(int signal, siginfo_t *info, void *ucontext)
 
 void (*invalid_function)() = (void*)1;
 
-int main(int argc, char *argv[])
+int main(int argc UNUSED, char *argv[] UNUSED)
 {
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));


### PR DESCRIPTION
Eliminated all build warnings coming from `make check` with CFLAGS="-Wall -Wextra" (and some "-pedantic") for an x86_64 target (GCC 9 Ubuntu 16.04, GCC 10 Ubuntu 20.04).  Except for the "Implement get_list_addr(), please." beg.

This was mostly tagging various parameters as "maybe unused", but there were a few other changes like assigning to the correct member of sa_handler and casting things to the right type.

This will hopefully reduce the noise in builds. Fixes #529 