### PR TITLE
Cache synthetic eh_frame_hdr.

### DIFF
--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -517,6 +517,47 @@ dwarf_find_debug_frame (int found, unw_dyn_info_t *di_debug, unw_word_t ip,
 
 #ifndef UNW_REMOTE_ONLY
 
+typedef struct eh_frame_list_entry
+  {
+    struct eh_frame_list_entry *next;
+    Elf_W (Addr) eh_frame;
+    char filename[];
+  }
+eh_frame_list_entry_t;
+
+/* Prepend entry to singly linked list head.  */
+static void
+eh_frame_list_prepend (eh_frame_list_entry_t **head, eh_frame_list_entry_t *entry)
+{
+  entry->next = *head;
+  *head = entry;
+}
+
+/* Search singly linked list head for item with given filename.  */
+static eh_frame_list_entry_t*
+eh_frame_list_search (eh_frame_list_entry_t *head, const char *filename)
+{
+  eh_frame_list_entry_t *entry = head;
+  while (entry)
+    {
+      if (strcmp (entry->filename, filename) == 0)
+        {
+          Debug (6, "cache: found matching %s at 0x%lx\n",
+                 entry->filename,
+                 entry->eh_frame);
+          return entry;
+        }
+      Debug (6, "cache: %s at 0x%lx did not match\n",
+             entry->filename,
+             entry->eh_frame);
+      entry = entry->next;
+    }
+  Debug (6, "cache: %s not in cache\n", filename);
+  return NULL;
+}
+
+static eh_frame_list_entry_t *eh_frame_list;
+
 static Elf_W (Addr)
 dwarf_find_eh_frame_section(struct dl_phdr_info *info)
 {
@@ -526,11 +567,19 @@ dwarf_find_eh_frame_section(struct dl_phdr_info *info)
   Elf_W (Shdr)* shdr;
   const char *file = info->dlpi_name;
   char exepath[PATH_MAX];
+  eh_frame_list_entry_t *eh_frame_list_entry;
 
   if (strlen(file) == 0)
     {
       tdep_get_exe_image_path(exepath);
       file = exepath;
+    }
+
+  /* Check if cached synthetic eh_frame header exists for this file.  */
+  eh_frame_list_entry = eh_frame_list_search (eh_frame_list, file);
+  if (eh_frame_list_entry)
+    {
+      return eh_frame_list_entry->eh_frame;
     }
 
   Debug (1, "looking for .eh_frame section in %s\n",
@@ -545,8 +594,14 @@ dwarf_find_eh_frame_section(struct dl_phdr_info *info)
     goto out;
 
   eh_frame = shdr->sh_addr + info->dlpi_addr;
-  Debug (4, "found .eh_frame at address %lx\n",
+  Debug (4, "found .eh_frame at address 0x%lx\n",
          eh_frame);
+
+  /* Cache synthetic eh_frame header */
+  GET_MEMORY (eh_frame_list_entry, sizeof (eh_frame_list_entry_t) + strlen (file) + 1);
+  strcpy (eh_frame_list_entry->filename, file);
+  eh_frame_list_entry->eh_frame = eh_frame;
+  eh_frame_list_prepend (&eh_frame_list, eh_frame_list_entry);
 
 out:
   mi_munmap (ei.image, ei.size);


### PR DESCRIPTION
Cache value of eh_frame_hdr to avoid having to open and find it within the same file again. The values of eh_frame_hdr are stored in a singly-linked list along with their respective filenames.