### PR TITLE
Configure -lpthread always for FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -215,9 +215,9 @@ AM_COND_IF([CONFIG_TESTS], [
   AC_SEARCH_LIBS([dlopen], [dl],
                  [AS_IF([test "$ac_cv_search_dlopen" != "none required"],
                         [AC_SUBST([DLLIB], ["$ac_cv_search_dlopen"])])])
-  AC_SEARCH_LIBS([pthread_key_create], [pthread],
-                 [AS_IF([test "$ac_cv_search_pthread_key_create" != "none required"],
-                        [AC_SUBST([PTHREADS_LIB], ["$ac_cv_search_pthread_key_create"])])])
+  AC_SEARCH_LIBS([pthread_create], [pthread],
+                 [AS_IF([test "$ac_cv_search_pthread_create" != "none required"],
+                        [AC_SUBST([PTHREADS_LIB],["$ac_cv_search_pthread_create"])])])
   AC_SEARCH_LIBS([backtrace], [execinfo],
                  [AS_IF([test "$ac_cv_search_backtrace" != "none required"],
                         [AC_SUBST([BACKTRACELIB],["$ac_cv_search_backtrace"])])])


### PR DESCRIPTION
FreeBSD libc includes weak symbols for pthreads functions, so the AC_SEARCH_LIBS autoconf test fails and "make check" fails. The solution is to check for `pthread_create()` instead, which is not a weak symbol in the FreeBSD libc.

`make check`  after this change no longer has link errors when run on x86_64 FreeBSD 13.1
```
make  check-TESTS
PASS: test-proc-info
PASS: test-static-link
PASS: test-strerror
PASS: Gtest-bt
PASS: Ltest-bt
PASS: Gtest-exc
PASS: Ltest-exc
PASS: Gtest-init
PASS: Ltest-init
FAIL: Gtest-concurrent
FAIL: Ltest-concurrent
PASS: Gtest-resume-sig
PASS: Ltest-resume-sig
PASS: Gtest-resume-sig-rt
PASS: Ltest-resume-sig-rt
PASS: Gtest-trace
PASS: Ltest-trace
FAIL: Ltest-mem-validate
PASS: test-async-sig
PASS: test-flush-cache
PASS: test-init-remote
PASS: test-mem
PASS: test-reg-state
PASS: Ltest-varargs
PASS: Ltest-nomalloc
PASS: Ltest-nocalloc
PASS: Lrs-race
PASS: Ltest-init-local-signal
PASS: test-ptrace
PASS: test-setjmp
PASS: Gx64-test-dwarf-expressions
PASS: Lx64-test-dwarf-expressions
PASS: x64-unwind-badjmp-signal-frame
PASS: run-check-namespace
PASS: run-ptrace-mapper
PASS: run-ptrace-misc
============================================================================
Testsuite summary for libunwind 1.8-pre
============================================================================
# TOTAL: 36
# PASS:  33
# SKIP:  0
# XFAIL: 0
# FAIL:  3
# XPASS: 0
# ERROR: 0
============================================================================
See tests/test-suite.log
Please report to https://github.com/libunwind/libunwind
============================================================================
```