### PR TITLE
Introduce a new OS specific unw_step() function on x86_64.

### DIFF
--- a/src/x86_64/Gos-freebsd.c
+++ b/src/x86_64/Gos-freebsd.c
@@ -38,7 +38,7 @@ unw_is_signal_frame (unw_cursor_t *cursor)
 {
   /* XXXKIB */
   struct cursor *c = (struct cursor *) cursor;
-  unw_word_t w0, w1, w2, b0, ip;
+  unw_word_t w0, w1, w2, ip;
   unw_addr_space_t as;
   unw_accessors_t *a;
   void *arg;
@@ -69,22 +69,9 @@ eb fd                   jmp     0b
       w2 == 0x0000000000fdebf4)
    {
      c->sigcontext_format = X86_64_SCF_FREEBSD_SIGFRAME;
-     return (c->sigcontext_format);
+     return (1);
    }
-  /* Check if RIP points at standard syscall sequence.
-49 89 ca        mov    %rcx,%r10
-0f 05           syscall
-  */
-  if ((ret = (*a->access_mem) (as, ip - 5, &b0, 0, arg)) < 0)
-    return (0);
-  Debug (12, "b0 0x%lx\n", b0);
-  if ((b0 & 0xffffffffffffff) == 0x050fca89490000 ||
-      (b0 & 0xffffffffff) == 0x050fca8949)
-   {
-    c->sigcontext_format = X86_64_SCF_FREEBSD_SYSCALL;
-    return (c->sigcontext_format);
-   }
-  return (X86_64_SCF_NONE);
+  return (0);
 }
 
 HIDDEN int
@@ -130,26 +117,6 @@ x86_64_handle_signal_frame (unw_cursor_t *cursor)
     c->dwarf.loc[RIP] = DWARF_LOC (ucontext + UC_MCONTEXT_GREGS_RIP, 0);
 
     return 0;
-   }
-  else if (c->sigcontext_format == X86_64_SCF_FREEBSD_SYSCALL)
-   {
-    c->dwarf.loc[RCX] = c->dwarf.loc[R10];
-    /*  rsp_loc = DWARF_LOC(c->dwarf.cfa - 8, 0);       */
-    /*  rbp_loc = c->dwarf.loc[RBP];                    */
-    c->dwarf.loc[RSP] = DWARF_VAL_LOC (c, c->dwarf.cfa + 8);
-    c->dwarf.loc[RIP] = DWARF_LOC (c->dwarf.cfa, 0);
-    ret = dwarf_get (&c->dwarf, c->dwarf.loc[RIP], &c->dwarf.ip);
-    Debug (1, "Frame Chain [RIP=0x%Lx] = 0x%Lx\n",
-           (unsigned long long) DWARF_GET_LOC (c->dwarf.loc[RIP]),
-           (unsigned long long) c->dwarf.ip);
-    if (ret < 0)
-     {
-       Debug (2, "returning %d\n", ret);
-       return ret;
-     }
-    c->dwarf.cfa += 8;
-    c->dwarf.use_prev_instr = 1;
-    return 1;
    }
   else
     return -UNW_EBADFRAME;
@@ -220,3 +187,50 @@ x86_64_sigreturn (unw_cursor_t *cursor)
   abort();
 }
 #endif
+
+HIDDEN int
+x86_64_os_step(struct cursor *c)
+{
+  unw_word_t b0, ip;
+  unw_addr_space_t as;
+  unw_accessors_t *a;
+  void *arg;
+  int ret;
+
+  as = c->dwarf.as;
+  a = unw_get_accessors_int (as);
+  arg = c->dwarf.as_arg;
+  ip = c->dwarf.ip;
+
+  /*
+   * Check if RIP points at standard syscall sequence.
+   * 49 89 ca        mov    %rcx,%r10
+   * 0f 05           syscall
+   */
+  if ((ret = (*a->access_mem) (as, ip - 5, &b0, 0, arg)) < 0)
+    return (0);
+  Debug (12, "b0 0x%lx\n", b0);
+  if ((b0 & 0xffffffffffffff) == 0x050fca89490000 ||
+      (b0 & 0xffffffffff) == 0x050fca8949)
+   {
+    c->sigcontext_format = X86_64_SCF_FREEBSD_SYSCALL;
+    c->dwarf.loc[RCX] = c->dwarf.loc[R10];
+    /*  rsp_loc = DWARF_LOC(c->dwarf.cfa - 8, 0);       */
+    /*  rbp_loc = c->dwarf.loc[RBP];                    */
+    c->dwarf.loc[RSP] = DWARF_VAL_LOC (c, c->dwarf.cfa + 8);
+    c->dwarf.loc[RIP] = DWARF_LOC (c->dwarf.cfa, 0);
+    ret = dwarf_get (&c->dwarf, c->dwarf.loc[RIP], &c->dwarf.ip);
+    Debug (1, "Frame Chain [RIP=0x%Lx] = 0x%Lx\n",
+           (unsigned long long) DWARF_GET_LOC (c->dwarf.loc[RIP]),
+           (unsigned long long) c->dwarf.ip);
+    if (ret < 0)
+     {
+       Debug (2, "returning %d\n", ret);
+       return ret;
+     }
+    c->dwarf.cfa += 8;
+    c->dwarf.use_prev_instr = 1;
+    return 1;
+   }
+  return (0);
+}

--- a/src/x86_64/Gos-linux.c
+++ b/src/x86_64/Gos-linux.c
@@ -25,6 +25,10 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
+#ifdef HAVE_ASM_VSYSCALL_H
+#include <asm/vsyscall.h>
+#endif
+
 #include "libunwind_i.h"
 #include "unwind_i.h"
 #include "ucontext_i.h"
@@ -155,3 +159,33 @@ x86_64_sigreturn (unw_cursor_t *cursor)
 }
 
 #endif
+
+static int
+is_vsyscall (struct dwarf_cursor *c UNUSED)
+{
+#if defined(VSYSCALL_START) && defined(VSYSCALL_END)
+  return c->ip >= VSYSCALL_START && c->ip < VSYSCALL_END;
+#elif defined(VSYSCALL_ADDR)
+  /* Linux 3.16 removes `VSYSCALL_START` and `VSYSCALL_END`.  Assume
+     a single page is mapped for vsyscalls.  */
+  return c->ip >= VSYSCALL_ADDR && c->ip < VSYSCALL_ADDR + unw_page_size;
+#else
+  return 0;
+#endif
+}
+
+HIDDEN int
+x86_64_os_step(struct cursor *c)
+{
+  if (is_vsyscall (&c->dwarf))
+    {
+      Debug (2, "in vsyscall region\n");
+      c->frame_info.cfa_reg_offset = 8;
+      c->frame_info.cfa_reg_rsp = -1;
+      c->frame_info.frame_type = UNW_X86_64_FRAME_GUESSED;
+      c->dwarf.loc[RIP] = DWARF_LOC (c->dwarf.cfa, 0);
+      c->dwarf.cfa += 8;
+      return (1);
+    }
+  return (0);
+}

--- a/src/x86_64/Gos-qnx.c
+++ b/src/x86_64/Gos-qnx.c
@@ -184,3 +184,8 @@ x86_64_sigreturn (unw_cursor_t *cursor)
 
 #endif
 
+HIDDEN int
+x86_64_os_step(struct cursor *c)
+{
+  return (0);
+}

--- a/src/x86_64/Gos-solaris.c
+++ b/src/x86_64/Gos-solaris.c
@@ -135,3 +135,9 @@ x86_64_sigreturn (unw_cursor_t *cursor)
 }
 
 #endif
+
+HIDDEN int
+x86_64_os_step(struct cursor *c)
+{
+  return (0);
+}

--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -25,10 +25,6 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
-#ifdef HAVE_ASM_VSYSCALL_H
-#include <asm/vsyscall.h>
-#endif
-
 #include "libunwind_i.h"
 #include "unwind_i.h"
 #include <signal.h>
@@ -55,20 +51,6 @@ is_plt_entry (struct dwarf_cursor *c)
 
   Debug (14, "ip=0x%lx => 0x%016lx 0x%016lx, ret = %d\n", c->ip, w0, w1, ret);
   return ret;
-}
-
-static int
-is_vsyscall (struct dwarf_cursor *c UNUSED)
-{
-#if defined(VSYSCALL_START) && defined(VSYSCALL_END)
-  return c->ip >= VSYSCALL_START && c->ip < VSYSCALL_END;
-#elif defined(VSYSCALL_ADDR)
-  /* Linux 3.16 removes `VSYSCALL_START` and `VSYSCALL_END`.  Assume
-     a single page is mapped for vsyscalls.  */
-  return c->ip >= VSYSCALL_ADDR && c->ip < VSYSCALL_ADDR + unw_page_size;
-#else
-  return 0;
-#endif
 }
 
 int
@@ -140,7 +122,15 @@ unw_step (unw_cursor_t *cursor)
 
       Debug (13, "dwarf_step() failed (ret=%d), trying frame-chain\n", ret);
 
-      if (unw_is_signal_frame (cursor) > 0)
+      if ((ret = x86_64_os_step (c)) != 0)
+        {
+          if (ret < 0)
+            {
+              Debug (2, "returning 0\n");
+              return 0;
+            }
+        }
+      else if (unw_is_signal_frame (cursor) > 0)
         {
           ret = x86_64_handle_signal_frame(cursor);
           if (ret < 0)
@@ -156,15 +146,6 @@ unw_step (unw_cursor_t *cursor)
           c->frame_info.cfa_reg_offset = 8;
           c->frame_info.cfa_reg_rsp = -1;
           c->frame_info.frame_type = UNW_X86_64_FRAME_STANDARD;
-          c->dwarf.loc[RIP] = DWARF_LOC (c->dwarf.cfa, 0);
-          c->dwarf.cfa += 8;
-        }
-      else if (is_vsyscall (&c->dwarf))
-        {
-          Debug (2, "in vsyscall region\n");
-          c->frame_info.cfa_reg_offset = 8;
-          c->frame_info.cfa_reg_rsp = -1;
-          c->frame_info.frame_type = UNW_X86_64_FRAME_GUESSED;
           c->dwarf.loc[RIP] = DWARF_LOC (c->dwarf.cfa, 0);
           c->dwarf.cfa += 8;
         }

--- a/src/x86_64/unwind_i.h
+++ b/src/x86_64/unwind_i.h
@@ -89,5 +89,7 @@ extern void *x86_64_r_uc_addr (ucontext_t *uc, int reg);
 extern NORETURN void x86_64_sigreturn (unw_cursor_t *cursor);
 #define x86_64_handle_signal_frame UNW_OBJ(handle_signal_frame)
 extern int x86_64_handle_signal_frame(unw_cursor_t *cursor);
+#define x86_64_os_step UNW_OBJ(os_step)
+extern HIDDEN int x86_64_os_step(struct cursor *c);
 
 #endif /* unwind_i_h */


### PR DESCRIPTION
And move out OS specific code to unw_step().
For Linux its a vsyscall handling, for Solaris is no-op for now, and for FreeBSD its a handling of syscall calling sequence. Thats fixes FreeBSD unw_is_signal_frame() which is incorrectly returns true for syscall frame.