### PR TITLE
Fix uc_addr() for FreeBSD/Aarch64.

### DIFF
--- a/include/libunwind-aarch64.h
+++ b/include/libunwind-aarch64.h
@@ -229,9 +229,6 @@ typedef struct
 #else
 /* On AArch64, we can directly use ucontext_t as the unwind context.  */
 typedef ucontext_t unw_tdep_context_t;
-#if defined(__FreeBSD__)
-typedef ucontext_t unw_fpsimd_context_t;
-#endif
 #endif
 
 

--- a/src/aarch64/Ginit.c
+++ b/src/aarch64/Ginit.c
@@ -66,7 +66,7 @@ uc_addr (unw_context_t *uc, int reg)
   else if (reg == UNW_AARCH64_PC)
     return &uc->uc_mcontext.mc_gpregs.gp_elr;
   else if (reg >= UNW_AARCH64_V0 && reg <= UNW_AARCH64_V31)
-    return &GET_FPCTX(uc)->uc_mcontext.mc_fpregs.fp_q[reg - UNW_AARCH64_V0];
+    return &uc->uc_mcontext.mc_fpregs.fp_q[reg  - UNW_AARCH64_V0];
   else
     return NULL;
 #elif defined(__QNX__)

--- a/src/aarch64/unwind_i.h
+++ b/src/aarch64/unwind_i.h
@@ -59,9 +59,7 @@ extern int aarch64_local_resume (unw_addr_space_t as, unw_cursor_t *cursor,
   } while (0)
 #endif
 
-#if defined(__FreeBSD__)
-#define GET_FPCTX(uc) ((unw_tdep_context_t *)(&uc->uc_mcontext.mc_spare))
-#else
+#if defined(__linux__)
 #define GET_FPCTX(uc) ((unw_fpsimd_context_t *)(&uc->uc_mcontext.__reserved))
 #endif
 


### PR DESCRIPTION
On FreeBSD the Neon registers are preserved in the mc_fpregs of the machine context structure.