### PR TITLE
tests/mapper: avoid calling printf between SIGUSR1 and SIGUSR2

### DIFF
--- a/tests/mapper.c
+++ b/tests/mapper.c
@@ -43,6 +43,15 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 # define MAP_NORESERVE 0
 #endif
 
+void __attribute__((noinline)) push_some_stacks(int n)
+{
+  if (n >= 1)
+  {
+    push_some_stacks(n - 1);
+    push_some_stacks(n - 1);
+  }
+}
+
 int
 main (void)
 {
@@ -71,7 +80,7 @@ main (void)
 
   printf ("Turning on single-stepping...\n");
   kill (getpid (), SIGUSR1);	/* tell test-ptrace to start single-stepping */
-  printf ("Va bene?\n");
+  push_some_stacks (4);
   kill (getpid (), SIGUSR2);	/* tell test-ptrace to stop single-stepping */
   printf ("Turned single-stepping off...\n");
   return 0;


### PR DESCRIPTION
fix https://github.com/libunwind/libunwind/issues/557 test-ptrace-mapper testcase fail.

glibc printf() needs using atomic instruction to acquire the stdout lock.
Under ARMv8.0 ISA, atomic instruction is realized using LL-SC routine, which will keep retrying if other cpu accesses the target memory during the atomic instruction.
In mapper testcase, parent process uses ptrace to single step mapper program, thus if calling printf between SIGUSR1 and SIGUSR2, printf will be single-step executed, and the atomic instruction will be stuck in deadloop.