### PR TITLE
Fix array indexing bug in dwarf_search_unwind_table

### DIFF
--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -966,7 +966,7 @@ dwarf_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
   if (as == unw_local_addr_space)
     {
       e = lookup (table, table_len, ip - ip_base - di->load_offset);
-      if (e && &e[1] < &table[table_len / sizeof (unw_word_t)])
+      if (e && &e[1] < &table[table_len / sizeof (struct table_entry)])
 	last_ip = e[1].start_ip_offset + ip_base + di->load_offset;
       else
 	last_ip = di->end_ip;


### PR DESCRIPTION
The variable `table` is of type `struct table_entry *`, and `table_len` is in bytes, so the index one past the end is properly `table_len / sizeof (struct table_entry)`. The previous implementation would read unallocated memory. This issue was detected with ASAN, and ASAN verified the fix no longer reads unallocated memory.