### PR TITLE
Bump to release 1.7.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,9 +2,9 @@ dnl Process this file with autoconf to produce a configure script.
 
 define(pkg_major, 1)
 define(pkg_minor, 7)
-define(pkg_extra, 0)
+define(pkg_extra, 1)
 define(pkg_maintainer, libunwind-devel@nongnu.org)
-define(mkvers, $1.$2$3)
+define(mkvers, $1.$2.$3)
 
 AC_INIT([libunwind],[mkvers(pkg_major, pkg_minor, pkg_extra)],[pkg_maintainer])
 AC_CONFIG_SRCDIR(src/mi/backtrace.c)


### PR DESCRIPTION
Fixes format of release number string for proper semantic versioning.

Closes #535