### PR TITLE
Add direct dependent libraries to remotes

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,6 +49,7 @@ libunwind_ptrace_la_SOURCES =						  \
 	ptrace/_UPT_find_proc_info.c ptrace/_UPT_get_dyn_info_list_addr.c \
 	ptrace/_UPT_put_unwind_info.c ptrace/_UPT_get_proc_name.c	  \
 	ptrace/_UPT_reg_offset.c ptrace/_UPT_resume.c
+libunwind_ptrace_la_LIBADD = libunwind-$(arch).la $(LIBLZMA)
 noinst_HEADERS += ptrace/_UPT_internal.h
 
 ### libunwind-coredump:
@@ -70,7 +71,7 @@ libunwind_coredump_la_SOURCES = \
 	coredump/_UPT_resume.c
 libunwind_coredump_la_LDFLAGS = $(COMMON_SO_LDFLAGS) \
 				-version-info $(COREDUMP_SO_VERSION)
-libunwind_coredump_la_LIBADD = $(LIBLZMA) $(LIBZ)
+libunwind_coredump_la_LIBADD = libunwind-$(arch).la $(LIBLZMA) $(LIBZ)
 noinst_HEADERS += coredump/_UCD_internal.h \
                   coredump/_UCD_lib.h \
                   coredump/ucd_file_table.h


### PR DESCRIPTION
The ptrace and coredump remote libraries were underlinked -- they did not have DT_NEEDED entries for their direct depdendencies. This is bad practice and is only alleviated by developers guessing what needs to be linked where and when when using these libraries.

This change adds those dependencies for the 7.1 branch.