### PR TITLE
Fallback to direct access instead of through /proc/[pid]/root/

### DIFF
--- a/src/os-linux.c
+++ b/src/os-linux.c
@@ -84,6 +84,9 @@ tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
   strcpy (full_path, root);
   strcat (full_path, mi.path);
 
+  if (stat(full_path, &st) || !S_ISREG(st.st_mode))
+    strcpy(full_path, mi.path);
+
   rc = elf_map_image (ei, full_path);
 
   if (!path)


### PR DESCRIPTION
In some namespace setups the binary might not even be present in the mnt_ns. This is the case if it's launched from an fd in a specially prepared empty mnt_ns via a execveat (sandboxing usecase).

Therefore it makes sense to fallback to the original path.