### PR TITLE
Add support for build-id

### DIFF
--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -120,7 +120,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local,
   ei.image = NULL;
   *load_offset = 0;
 
-  ret = elf_w (load_debuglink) (file, &ei, is_local);
+  ret = elf_w (load_debuglib) (file, &ei, is_local);
   if (ret != 0)
     return ret;
 

--- a/src/elfxx.h
+++ b/src/elfxx.h
@@ -54,7 +54,7 @@ extern int elf_w (get_proc_name_in_image) (unw_addr_space_t as,
                                            char *buf, size_t buf_len, unw_word_t *offp);
 
 extern Elf_W (Shdr)* elf_w (find_section) (struct elf_image *ei, const char* secname);
-extern int elf_w (load_debuglink) (const char* file, struct elf_image *ei, int is_local);
+extern int elf_w (load_debuglib) (const char* file, struct elf_image *ei, int is_local);
 
 static inline int
 elf_w (valid_object) (struct elf_image *ei)


### PR DESCRIPTION
Add build-id support. This has had limited testing. It seems to work for me on x86-64 (under debian buster).