### PR TITLE
Move man pages into section 3libunwind

### DIFF
--- a/doc/_U_dyn_cancel.man
+++ b/doc/_U_dyn_cancel.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 12:09:49 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "\\_U\\_DYN\\_CANCEL" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "\\_U\\_DYN\\_CANCEL" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 _U_dyn_cancel
 \-\- cancel unwind\-info for dynamically generated code 
@@ -30,7 +32,7 @@ _U_dyn_cancel(unw_dyn_info_t *di);
 .PP
 The _U_dyn_cancel()
 routine cancels the registration of the 
-unwind\-info for a dynamically generated procedure. Argument di
+unwind info for a dynamically generated procedure. Argument di
 is the pointer to the unw_dyn_info_t
 structure that 
 describes the procedure\&'s unwind\-info. 
@@ -45,15 +47,15 @@ or _U_dyn_cancel()).
 
 .PP
 _U_dyn_cancel()
-is thread\-safe but \fInot\fP
+is thread safe but \fInot\fP
 safe to use 
 from a signal handler. 
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind\-dynamic(3),
-_U_dyn_register(3)
+libunwind\-dynamic(3libunwind),
+_U_dyn_register(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/_U_dyn_cancel.tex
+++ b/doc/_U_dyn_cancel.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{\_U\_dyn\_cancel}{David Mosberger-Tang}{Programming Library}{\_U\_dyn\_cancel}\_U\_dyn\_cancel -- cancel unwind-info for dynamically generated code
+\begin{Name}{3libunwind}{\_U\_dyn\_cancel}{David Mosberger-Tang}{Programming Library}{\_U\_dyn\_cancel}\_U\_dyn\_cancel -- cancel unwind-info for dynamically generated code
 \end{Name}
 
 \section{Synopsis}
@@ -17,7 +17,7 @@
 \section{Description}
 
 The \Func{\_U\_dyn\_cancel}() routine cancels the registration of the
-unwind-info for a dynamically generated procedure.  Argument \Var{di}
+unwind info for a dynamically generated procedure.  Argument \Var{di}
 is the pointer to the \Type{unw\_dyn\_info\_t} structure that
 describes the procedure's unwind-info.
 
@@ -28,12 +28,13 @@ constant time (in the absence of contention from concurrent calls to
 
 \section{Thread and Signal Safety}
 
-\Func{\_U\_dyn\_cancel}() is thread-safe but \emph{not} safe to use
+\Func{\_U\_dyn\_cancel}() is thread safe but \emph{not} safe to use
 from a signal handler.
 
 \section{See Also}
 
-\SeeAlso{libunwind-dynamic(3)}, \SeeAlso{\_U\_dyn\_register(3)}
+\SeeAlso{libunwind-dynamic}(3libunwind),
+\SeeAlso{\_U\_dyn\_register}(3libunwind)
 
 \section{Author}
 

--- a/doc/_U_dyn_register.man
+++ b/doc/_U_dyn_register.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 12:09:49 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,10 +12,10 @@
 
 .fi
 ..
-.TH "\\_U\\_DYN\\_REGISTER" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "\\_U\\_DYN\\_REGISTER" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 _U_dyn_register
-\-\- register unwind\-info for dynamically generated code 
+\-\- register unwind info for dynamically generated code 
 .PP
 .SH SYNOPSIS
 
@@ -29,11 +31,11 @@ _U_dyn_register(unw_dyn_info_t *di);
 
 .PP
 The _U_dyn_register()
-routine registers unwind\-info for a 
-dynamically generated procedure. The procedure\&'s unwind\-info is 
+routine registers unwind info for a 
+dynamically generated procedure. The procedure\&'s unwind info is 
 described by a structure of type unw_dyn_info_t
 (see 
-libunwind\-dynamic(3)).
+libunwind\-dynamic(3libunwind)).
 A pointer to this structure is 
 passed in argument di\&.
 .PP
@@ -47,15 +49,15 @@ or _U_dyn_cancel()).
 
 .PP
 _U_dyn_register()
-is thread\-safe but \fInot\fP
+is thread safe but \fInot\fP
 safe to use 
 from a signal handler. 
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind\-dynamic(3),
-_U_dyn_cancel(3)
+libunwind\-dynamic(3libunwind),
+_U_dyn_cancel(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/_U_dyn_register.tex
+++ b/doc/_U_dyn_register.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{\_U\_dyn\_register}{David Mosberger-Tang}{Programming Library}{\_U\_dyn\_register}\_U\_dyn\_register -- register unwind-info for dynamically generated code
+\begin{Name}{3libunwind}{\_U\_dyn\_register}{David Mosberger-Tang}{Programming Library}{\_U\_dyn\_register}\_U\_dyn\_register -- register unwind info for dynamically generated code
 \end{Name}
 
 \section{Synopsis}
@@ -16,10 +16,10 @@
 
 \section{Description}
 
-The \Func{\_U\_dyn\_register}() routine registers unwind-info for a
-dynamically generated procedure.  The procedure's unwind-info is
+The \Func{\_U\_dyn\_register}() routine registers unwind info for a
+dynamically generated procedure.  The procedure's unwind info is
 described by a structure of type \Type{unw\_dyn\_info\_t} (see
-\SeeAlso{libunwind-dynamic(3)}).  A pointer to this structure is
+\SeeAlso{libunwind-dynamic}(3libunwind)).  A pointer to this structure is
 passed in argument \Var{di}.
 
 The \Func{\_U\_dyn\_register}() routine is guaranteed to execute in
@@ -29,12 +29,13 @@ constant time (in the absence of contention from concurrent calls to
 
 \section{Thread and Signal Safety}
 
-\Func{\_U\_dyn\_register}() is thread-safe but \emph{not} safe to use
+\Func{\_U\_dyn\_register}() is thread safe but \emph{not} safe to use
 from a signal handler.
 
 \section{See Also}
 
-\SeeAlso{libunwind-dynamic(3)}, \SeeAlso{\_U\_dyn\_cancel(3)}
+\SeeAlso{libunwind-dynamic}(3libunwind),
+\SeeAlso{\_U\_dyn\_cancel}(3libunwind)
 
 \section{Author}
 

--- a/doc/libunwind-coredump.man
+++ b/doc/libunwind-coredump.man
@@ -1,7 +1,7 @@
 .\" *********************************** start of \input{common.tex}
 .\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu May 18 11:05:16 2023
+.\" Manual page created with latex2man on Tue Aug 29 10:53:41 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -12,7 +12,7 @@
 
 .fi
 ..
-.TH "LIBUNWIND\-COREDUMP" "3" "18 May 2023" "Programming Library " "Programming Library "
+.TH "LIBUNWIND\-COREDUMP" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 libunwind\-coredump
 \-\- coredump() support in libunwind 
@@ -27,26 +27,21 @@ unw_accessors_t
 _UCD_accessors;
 .br
 .PP
-void *_UCD_create(char const *);
+struct UCD_info *_UCD_create(char const *);
 .br
-.PP
-void
-_UCD_destroy(struct UCD_info *);
+void _UCD_destroy(struct UCD_info *);
 .br
 .PP
 int
 _UCD_get_num_threads(struct UCD_info *);
 .br
-.PP
 void
 _UCD_select_thread(struct UCD_info *,
 int);
 .br
-.PP
 void
 _UCD_get_pid(struct UCD_info *);
 .br
-.PP
 void
 _UCD_get_cursig(struct UCD_info *);
 .br
@@ -58,19 +53,16 @@ unw_proc_info_t *,
 int,
 void *);
 .br
-.PP
 void
 _UCD_put_unwind_info(unw_addr_space_t,
 unw_proc_info_t *,
 void *);
 .br
-.PP
 int
 _UCD_get_dyn_info_list_addr(unw_addr_space_t,
 unw_word_t *,
 void *);
 .br
-.PP
 int
 _UCD_access_mem(unw_addr_space_t,
 unw_word_t,
@@ -78,7 +70,6 @@ unw_word_t *,
 int,
 void *);
 .br
-.PP
 int
 _UCD_access_reg(unw_addr_space_t,
 unw_regnum_t,
@@ -86,7 +77,6 @@ unw_word_t *,
 int,
 void *);
 .br
-.PP
 int
 _UCD_access_fpreg(unw_addr_space_t,
 unw_regnum_t,
@@ -94,7 +84,6 @@ unw_fpreg_t *,
 int,
 void *);
 .br
-.PP
 int
 _UCD_get_proc_name(unw_addr_space_t,
 unw_word_t,
@@ -103,7 +92,6 @@ size_t,
 unw_word_t *,
 void *);
 .br
-.PP
 int
 _UCD_resume(unw_addr_space_t,
 unw_cursor_t *,
@@ -114,7 +102,7 @@ void *);
 
 .PP
 It is possible to generate a snapshot of a process state at a specific moment in 
-time and save it in a spcially\-formatted file called a coredump. 
+time and save it in a specially\-formatted file called a coredump. 
 This often happens automatically when a process encounters an unrecoverable 
 error and the OS itself captures the state of the process when the error 
 occurred. 
@@ -123,13 +111,13 @@ provides a library that can be used as part of a lightweight
 tool to generate some useful information as to why the process abnormally 
 terminated (such as a stack trace of al threads of execution). 
 The routines and variables 
-implementing this facility use a name\-prefix of _UCD,
-which is 
+implementing this facility use a prefix of _UCD,
+which 
 stands for ``unwind\-via\-coredump\&''\&. 
 .PP
 An application that wants to use the coredump remote first needs 
 to create a new libunwind
-address\-space that represents the 
+address space that represents the 
 target process. This is done by calling 
 unw_create_addr_space().
 In many cases, the application 
@@ -155,7 +143,7 @@ they are never actually called.
 Next, the application needs to load the corefile for analysis and create an 
 (opaque) UCD_info structure by calling _UCD_create(),
 passing the name of the corefile. 
-The returned void\-pointer then needs to be 
+The returned opaque pointer then needs to be 
 passed as the ``argument\&'' pointer (third argument) to 
 unw_init_remote().
 .PP
@@ -168,21 +156,21 @@ _UCD_create().
 This ensures that all memory and other resources are freed up. 
 .PP
 .TP
-_UCD_get_num_threads() 
-Gets the number of threads in the corefile. 
+_UCD_get_num_threads()
+ Gets the number of threads in the corefile. 
 .PP
 .TP
-_UCD_get_pid() 
-Gets the process ID of the process associated with the corefile. 
+_UCD_get_pid()
+ Gets the process ID of the process associated with the corefile. 
 .PP
 .TP
-_UCD_get_cursig() 
-Gets the current signal begin received by the process associated with the 
+_UCD_get_cursig()
+ Gets the current signal begin received by the process associated with the 
 corefile (if any). 
 .PP
 .TP
-_UCD_select_thread() 
-Selects the current thread for unwinding. 
+_UCD_select_thread()
+ Selects the current thread for unwinding. 
 .PP
 .SH THREAD SAFETY
 
@@ -199,8 +187,7 @@ this facility is thread\-safe.
 
 .PP
 _UCD_create()
-may return a NULL
-pointer if it fails 
+may return a null pointer if it fails 
 to create the UCD_info
 for any reason. 
 .PP
@@ -219,6 +206,6 @@ functions defined by this library.
 .SH SEE ALSO
 
 .PP
-libunwind(3),
+libunwind(3libunwind)
 .PP
 .\" NOTE: This file is generated, DO NOT EDIT.

--- a/doc/libunwind-coredump.tex
+++ b/doc/libunwind-coredump.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{libunwind-coredump}{}{Programming Library}{coredump analysis support in libunwind}libunwind-coredump -- coredump() support in libunwind
+\begin{Name}{3libunwind}{libunwind-coredump}{}{Programming Library}{coredump analysis support in libunwind}libunwind-coredump -- coredump() support in libunwind
 \end{Name}
 
 \section{Synopsis}
@@ -15,51 +15,40 @@
 \noindent
 \Type{unw\_accessors\_t} \Var{\_UCD\_accessors};\\
 
-\Type{void~*}\Func{\_UCD\_create}(\Type{char const~*});\\
-
+\Type{struct~UCD\_info~*}\Func{\_UCD\_create}(\Type{char const~*});\\
 \noindent
-\Type{void} \Func{\_UCD\_destroy}(\Type{struct UCD\_info~*});\\
+\Type{void}~\Func{\_UCD\_destroy}(\Type{struct UCD\_info~*});\\
 
 \noindent
 \Type{int} \Func{\_UCD\_get\_num\_threads}(\Type{struct UCD\_info~*});\\
-
 \noindent
 \Type{void} \Func{\_UCD\_select\_thread}(\Type{struct UCD\_info~*}, \Type{int});\\
-
 \noindent
 \Type{void} \Func{\_UCD\_get\_pid}(\Type{struct UCD\_info~*});\\
-
 \noindent
 \Type{void} \Func{\_UCD\_get\_cursig}(\Type{struct UCD\_info~*});\\
 
 \noindent
 \Type{int} \Func{\_UCD\_find\_proc\_info}(\Type{unw\_addr\_space\_t}, \Type{unw\_word\_t}, \Type{unw\_proc\_info\_t~*}, \Type{int}, \Type{void~*});\\
-
 \noindent
 \Type{void} \Func{\_UCD\_put\_unwind\_info}(\Type{unw\_addr\_space\_t}, \Type{unw\_proc\_info\_t~*}, \Type{void~*});\\
-
 \noindent
 \Type{int} \Func{\_UCD\_get\_dyn\_info\_list\_addr}(\Type{unw\_addr\_space\_t}, \Type{unw\_word\_t~*}, \Type{void~*});\\
-
 \noindent
 \Type{int} \Func{\_UCD\_access\_mem}(\Type{unw\_addr\_space\_t}, \Type{unw\_word\_t}, \Type{unw\_word\_t~*}, \Type{int}, \Type{void~*});\\
-
 \noindent
 \Type{int} \Func{\_UCD\_access\_reg}(\Type{unw\_addr\_space\_t}, \Type{unw\_regnum\_t}, \Type{unw\_word\_t~*}, \Type{int}, \Type{void~*});\\
-
 \noindent
 \Type{int} \Func{\_UCD\_access\_fpreg}(\Type{unw\_addr\_space\_t}, \Type{unw\_regnum\_t}, \Type{unw\_fpreg\_t~*}, \Type{int}, \Type{void~*});\\
-
 \noindent
 \Type{int} \Func{\_UCD\_get\_proc\_name}(\Type{unw\_addr\_space\_t}, \Type{unw\_word\_t}, \Type{char~*}, \Type{size\_t}, \Type{unw\_word\_t~*}, \Type{void~*});\\
-
 \noindent
 \Type{int} \Func{\_UCD\_resume}(\Type{unw\_addr\_space\_t}, \Type{unw\_cursor\_t~*}, \Type{void~*});\\
 
 \section{Description}
 
 It is possible to generate a snapshot of a process state at a specific moment in
-time and save it in a spcially-formatted file called a coredump.
+time and save it in a specially-formatted file called a coredump.
 This often happens automatically when a process encounters an unrecoverable
 error and the OS itself captures the state of the process when the error
 occurred.
@@ -67,11 +56,11 @@ occurred.
 tool to generate some useful information as to why the process abnormally
 terminated (such as a stack trace of al threads of execution).
 The routines and variables
-implementing this facility use a name-prefix of \Func{\_UCD}, which is
+implementing this facility use a prefix of \Func{\_UCD}, which
 stands for ``unwind-via-coredump''.
 
 An application that wants to use the coredump remote first needs
-to create a new \Prog{libunwind} address-space that represents the
+to create a new \Prog{libunwind} address space that represents the
 target process.  This is done by calling
 \Func{unw\_create\_addr\_space}().  In many cases, the application
 will simply want to pass the address of \Var{\_UCD\_accessors} as the
@@ -90,7 +79,7 @@ they are never actually called.
 Next, the application needs to load the corefile for analysis and create an
 (opaque) UCD\_info structure by calling \Func{\_UCD_create}(),
 passing the name of the corefile.
-The returned void-pointer then needs to be
+The returned opaque pointer then needs to be
 passed as the ``argument'' pointer (third argument) to
 \Func{unw\_init\_remote}().
 
@@ -102,17 +91,17 @@ This ensures that all memory and other resources are freed up.
 
 \begin{description}[style=nextline]
 
-\item[\_UCD\_get\_num\_threads()]
+    \item[\Func{\_UCD\_get\_num\_threads}()]
     Gets the number of threads in the corefile.
 
-\item[\_UCD\_get\_pid()]
+\item[\Func{\_UCD\_get\_pid}()]
     Gets the process ID of the process associated with the corefile.
 
-\item[\_UCD\_get\_cursig()]
+\item[\Func{\_UCD\_get\_cursig}()]
     Gets the current signal begin received by the process associated with the
     corefile (if any).
 
-\item[\_UCD\_select\_thread()]
+\item[\Func{\_UCD\_select\_thread}()]
     Selects the current thread for unwinding.
 
 \end{description}
@@ -128,7 +117,7 @@ this facility is thread-safe.
 
 \section{Return Value}
 
-\Func{\_UCD\_create}() may return a \Const{NULL} pointer if it fails
+\Func{\_UCD\_create}() may return a null pointer if it fails
 to create the \Prog{UCD\_info} for any reason.
 
 \section{Files}
@@ -143,7 +132,7 @@ to create the \Prog{UCD\_info} for any reason.
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
+\SeeAlso{libunwind}(3libunwind)
 
 \LatexManEnd
 \end{document}

--- a/doc/libunwind-dynamic.man
+++ b/doc/libunwind-dynamic.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
+.\" Manual page created with latex2man on Tue Aug 29 12:09:48 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,479 +12,478 @@
 
 .fi
 ..
-.TH "LIBUNWIND\-DYNAMIC" "3" "29 August 2021" "Programming Library " "Programming Library "
+.TH "LIBUNWIND\-DYNAMIC" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 libunwind\-dynamic
-\-\- libunwind\-support for runtime\-generated code
+\-\- libunwind\-support for runtime\-generated code 
 .PP
 .SH INTRODUCTION
 
 .PP
 For libunwind
-to do its job, it needs to be able to reconstruct
+to do its job, it needs to be able to reconstruct 
 the \fIframe state\fP
-of each frame in a call\-chain. The frame state
-describes the subset of the machine\-state that consists of the
+of each frame in a call\-chain. The frame state 
+describes the subset of the machine\-state that consists of the 
 \fIframe registers\fP
-(typically the instruction\-pointer and the
-stack\-pointer) and all callee\-saved registers (preserved registers).
-The frame state describes each register either by providing its
-current value (for frame registers) or by providing the location at
-which the current value is stored (callee\-saved registers).
+(typically the instruction\-pointer and the 
+stack\-pointer) and all callee\-saved registers (preserved registers). 
+The frame state describes each register either by providing its 
+current value (for frame registers) or by providing the location at 
+which the current value is stored (callee\-saved registers). 
 .PP
-For statically generated code, the compiler normally takes care of
+For statically generated code, the compiler normally takes care of 
 emitting \fIunwind\-info\fP
-which provides the minimum amount of
-information needed to reconstruct the frame\-state for each instruction
-in a procedure. For dynamically generated code, the runtime code
-generator must use the dynamic unwind\-info interface provided by
+which provides the minimum amount of 
+information needed to reconstruct the frame\-state for each instruction 
+in a procedure. For dynamically generated code, the runtime code 
+generator must use the dynamic unwind\-info interface provided by 
 libunwind
-to supply the equivalent information. This manual
-page describes the format of this information in detail.
+to supply the equivalent information. This manual 
+page describes the format of this information in detail. 
 .PP
 For the purpose of this discussion, a \fIprocedure\fP
-is defined to
+is defined to 
 be an arbitrary piece of \fIcontiguous\fP
-code. Normally, each
-procedure directly corresponds to a function in the source\-language
-but this is not strictly required. For example, a runtime
-code\-generator could translate a given function into two separate
-(discontiguous) procedures: one for frequently\-executed (hot) code and
-one for rarely\-executed (cold) code. Similarly, simple
-source\-language functions (usually leaf functions) may get translated
-into code for which the default unwind\-conventions apply and for such
-code, it is not strictly necessary to register dynamic unwind\-info.
+code. Normally, each 
+procedure directly corresponds to a function in the source\-language 
+but this is not strictly required. For example, a runtime 
+code\-generator could translate a given function into two separate 
+(discontiguous) procedures: one for frequently\-executed (hot) code and 
+one for rarely\-executed (cold) code. Similarly, simple 
+source\-language functions (usually leaf functions) may get translated 
+into code for which the default unwind\-conventions apply and for such 
+code, it is not strictly necessary to register dynamic unwind\-info. 
 .PP
 A procedure logically consists of a sequence of \fIregions\fP\&.
-Regions are nested in the sense that the frame state at the end of one
-region is, by default, assumed to be the frame state for the next
-region. Each region is thought of as being divided into a
+Regions are nested in the sense that the frame state at the end of one 
+region is, by default, assumed to be the frame state for the next 
+region. Each region is thought of as being divided into a 
 \fIprologue\fP,
 a \fIbody\fP,
 and an \fIepilogue\fP\&.
-Each of them
-can be empty. If non\-empty, the prologue sets up the frame state for
-the body. For example, the prologue may need to allocate some space
-on the stack and save certain callee\-saved registers. The body
-performs the actual work of the procedure but does not change the
-frame state in any way. If non\-empty, the epilogue restores the
-previous frame state and as such it undoes or cancels the effect of
-the prologue. In fact, a single epilogue may undo the effect of the
-prologues of several (nested) regions.
+Each of them 
+can be empty. If non\-empty, the prologue sets up the frame state for 
+the body. For example, the prologue may need to allocate some space 
+on the stack and save certain callee\-saved registers. The body 
+performs the actual work of the procedure but does not change the 
+frame state in any way. If non\-empty, the epilogue restores the 
+previous frame state and as such it undoes or cancels the effect of 
+the prologue. In fact, a single epilogue may undo the effect of the 
+prologues of several (nested) regions. 
 .PP
-We should point out that even though the prologue, body, and epilogue
-are logically separate entities, optimizing code\-generators will
-generally interleave instructions from all three entities. For this
+We should point out that even though the prologue, body, and epilogue 
+are logically separate entities, optimizing code\-generators will 
+generally interleave instructions from all three entities. For this 
 reason, the dynamic unwind\-info interface of libunwind
-makes no
-distinction whatsoever between prologue and body. Similarly, the
-exact set of instructions that make up an epilogue is also irrelevant.
-The only point in the epilogue that needs to be described explicitly
-by the dynamic unwind\-info is the point at which the stack\-pointer
-gets restored. The reason this point needs to be described is that
-once the stack\-pointer is restored, all values saved in the
-deallocated portion of the stack frame become invalid and hence
+makes no 
+distinction whatsoever between prologue and body. Similarly, the 
+exact set of instructions that make up an epilogue is also irrelevant. 
+The only point in the epilogue that needs to be described explicitly 
+by the dynamic unwind\-info is the point at which the stack\-pointer 
+gets restored. The reason this point needs to be described is that 
+once the stack\-pointer is restored, all values saved in the 
+deallocated portion of the stack frame become invalid and hence 
 libunwind
-needs to know about it. The portion of the frame
-state not saved on the stack is assumed to remain valid through the end
-of the region. For this reason, there is usually no need to describe
-instructions which restore the contents of callee\-saved registers.
+needs to know about it. The portion of the frame 
+state not saved on the stack is assumed to remain valid through the end 
+of the region. For this reason, there is usually no need to describe 
+instructions which restore the contents of callee\-saved registers. 
 .PP
-Within a region, each instruction that affects the frame state in some
-fashion needs to be described with an operation descriptor. For this
-purpose, each instruction in the region is assigned a unique index.
-Exactly how this index is derived depends on the architecture. For
-example, on RISC and EPIC\-style architecture, instructions have a
-fixed size so it\&'s possible to simply number the instructions. In
-contrast, most CISC use variable\-length instruction encodings, so it
-is usually necessary to use a byte\-offset as the index. Given the
-instruction index, the operation descriptor specifies the effect of
-the instruction in an abstract manner. For example, it might express
+Within a region, each instruction that affects the frame state in some 
+fashion needs to be described with an operation descriptor. For this 
+purpose, each instruction in the region is assigned a unique index. 
+Exactly how this index is derived depends on the architecture. For 
+example, on RISC and EPIC\-style architecture, instructions have a 
+fixed size so it\&'s possible to simply number the instructions. In 
+contrast, most CISC use variable\-length instruction encodings, so it 
+is usually necessary to use a byte\-offset as the index. Given the 
+instruction index, the operation descriptor specifies the effect of 
+the instruction in an abstract manner. For example, it might express 
 that the instruction stores callee\-saved register r1
-at offset 16
-in the stack frame.
+at offset 16 
+in the stack frame. 
 .PP
 .SH PROCEDURES
 
 .PP
-A runtime code\-generator registers the dynamic unwind\-info of a
+A runtime code\-generator registers the dynamic unwind\-info of a 
 procedure by setting up a structure of type unw_dyn_info_t
 and calling _U_dyn_register(),
-passing the address of the
-structure as the sole argument. The members of the
+passing the address of the 
+structure as the sole argument. The members of the 
 unw_dyn_info_t
-structure are described below:
+structure are described below: 
 .TP
 void *next
  Private to libunwind\&.
-Must not be used
-by the application.
+Must not be used 
+by the application. 
 .TP
 void *prev
  Private to libunwind\&.
-Must not be used
-by the application.
+Must not be used 
+by the application. 
 .TP
 unw_word_t start_ip
- The start\-address of the
-instructions of the procedure (remember: procedure are defined to be
-contiguous pieces of code, so a single code\-range is sufficient).
+ The start\-address of the 
+instructions of the procedure (remember: procedure are defined to be 
+contiguous pieces of code, so a single code\-range is sufficient). 
 .TP
 unw_word_t end_ip
- The end\-address of the
-instructions of the procedure (non\-inclusive, that is,
+ The end\-address of the 
+instructions of the procedure (non\-inclusive, that is, 
 end_ip\-start_ip
-is the size of the procedure in
-bytes).
+is the size of the procedure in 
+bytes). 
 .TP
 unw_word_t gp
- The global\-pointer value in use
-for this procedure. The exact meaning of the global\-pointer is
-architecture\-specific and on some architecture, it is not used at
-all.
+ The global\-pointer value in use 
+for this procedure. The exact meaning of the global\-pointer is 
+architecture\-specific and on some architecture, it is not used at 
+all. 
 .TP
 int32_t format
- The format of the unwind\-info.
+ The format of the unwind\-info. 
 This member can be one of UNW_INFO_FORMAT_DYNAMIC,
 UNW_INFO_FORMAT_TABLE,
-or
+or 
 UNW_INFO_FORMAT_REMOTE_TABLE\&.
 .TP
 union u
- This union contains one sub\-member
-structure for every possible unwind\-info format:
+ This union contains one sub\-member 
+structure for every possible unwind\-info format: 
 .RS
 .TP
 unw_dyn_proc_info_t pi
- This member is used
+ This member is used 
 for format UNW_INFO_FORMAT_DYNAMIC\&.
 .TP
 unw_dyn_table_info_t ti
- This member is used
+ This member is used 
 for format UNW_INFO_FORMAT_TABLE\&.
 .TP
 unw_dyn_remote_table_info_t rti
- This member
+ This member 
 is used for format UNW_INFO_FORMAT_REMOTE_TABLE\&.
 .RE
 .RS
 .PP
-The format of these sub\-members is described in detail below.
+The format of these sub\-members is described in detail below. 
 .RE
 .PP
 .SS PROC\-INFO FORMAT
 .PP
-This is the preferred dynamic unwind\-info format and it is generally
-the one used by full\-blown runtime code\-generators. In this format,
-the details of a procedure are described by a structure of type
+This is the preferred dynamic unwind\-info format and it is generally 
+the one used by full\-blown runtime code generators. In this format, 
+the details of a procedure are described by a structure of type 
 unw_dyn_proc_info_t\&.
-This structure contains the following
-members:
+This structure contains the following 
+members: 
 .PP
-.RE
 .TP
 unw_word_t name_ptr
- The address of a
-(human\-readable) name of the procedure or 0 if no such name is
-available. If non\-zero, the string stored at this address must be
-ASCII NUL terminated. For source languages that use name\-mangling
-(such as C++ or Java) the string stored at this address should be
+ The address of a 
+(human\-readable) name of the procedure or 0 if no such name is 
+available. If non\-zero, the string stored at this address must be 
+ASCII NUL terminated. For source languages that use name mangling 
+(such as C++ or Java) the string stored at this address should be 
 the \fIdemangled\fP
-version of the name.
+version of the name. 
 .PP
 .TP
 unw_word_t handler
- The address of the
-personality\-routine for this procedure. Personality\-routines are
-used in conjunction with exception handling. See the C++ ABI draft
-(http://www.codesourcery.com/cxx\-abi/) for an overview and a
-description of the personality routine. If the procedure has no
+ The address of the 
+personality routine for this procedure. Personality routines are 
+used in conjunction with exception handling. See the C++ ABI draft 
+(http://www.codesourcery.com/cxx\-abi/) for an overview and a 
+description of the personality routine. If the procedure has no 
 personality routine, handler
-must be set to 0.
+must be set to 0. 
 .PP
 .TP
 uint32_t flags
- A bitmask of flags. At the
-moment, no flags have been defined and this member must be
-set to 0.
+ A bitmask of flags. At the 
+moment, no flags have been defined and this member must be 
+set to 0. 
 .PP
 .TP
 unw_dyn_region_info_t *regions
- A NULL\-terminated
-linked list of region\-descriptors. See section ``Region
-descriptors\&'' below for more details.
+ A NULL\-terminated 
+linked list of region descriptors. See section ``Region 
+descriptors\&'' below for more details. 
 .PP
 .SS TABLE\-INFO FORMAT
 .PP
-This format is generally used when the dynamically generated code was
-derived from static code and the unwind\-info for the dynamic and the
-static versions are identical. For example, this format can be useful
-when loading statically\-generated code into an address\-space in a
-non\-standard fashion (i.e., through some means other than
+This format is generally used when the dynamically generated code was 
+derived from static code and the unwind\-info for the dynamic and the 
+static versions are identical. For example, this format can be useful 
+when loading statically\-generated code into an address\-space in a 
+non\-standard fashion (i.e., through some means other than 
 dlopen()).
-In this format, the details of a group of procedures
+In this format, the details of a group of procedures 
 is described by a structure of type unw_dyn_table_info\&.
-This structure contains the following members:
+This structure contains the following members: 
 .PP
 .TP
 unw_word_t name_ptr
- The address of a
-(human\-readable) name of the procedure or 0 if no such name is
-available. If non\-zero, the string stored at this address must be
-ASCII NUL terminated. For source languages that use name\-mangling
-(such as C++ or Java) the string stored at this address should be
+ The address of a 
+(human\-readable) name of the procedure or 0 if no such name is 
+available. If non\-zero, the string stored at this address must be 
+ASCII NUL terminated. For source languages that use name\-mangling 
+(such as C++ or Java) the string stored at this address should be 
 the \fIdemangled\fP
-version of the name.
+version of the name. 
 .PP
 .TP
 unw_word_t segbase
- The segment\-base value
-that needs to be added to the segment\-relative values stored in the
-unwind\-info. The exact meaning of this value is
-architecture\-specific.
+ The segment\-base value 
+that needs to be added to the segment\-relative values stored in the 
+unwind\-info. The exact meaning of this value is 
+architecture\-specific. 
 .PP
 .TP
 unw_word_t table_len
- The length of the
+ The length of the 
 unwind\-info (table_data)
-counted in units of words
+counted in units of words 
 (unw_word_t).
 .PP
 .TP
 unw_word_t table_data
- A pointer to the actual
-data encoding the unwind\-info. The exact format is
-architecture\-specific (see architecture\-specific sections below).
+ A pointer to the actual 
+data encoding the unwind info. The exact format is 
+architecture\-specific (see architecture\-specific sections below). 
 .PP
 .SS REMOTE TABLE\-INFO FORMAT
 .PP
-The remote table\-info format has the same basic purpose as the regular
+The remote table\-info format has the same basic purpose as the regular 
 table\-info format. The only difference is that when libunwind
-uses the unwind\-info, it will keep the table data in the target
-address\-space (which may be remote). Consequently, the type of the
+uses the unwind\-info, it will keep the table data in the target 
+address\-space (which may be remote). Consequently, the type of the 
 table_data
 member is unw_word_t
-rather than a pointer.
+rather than a pointer. 
 This implies that libunwind
-will have to access the table\-data
+will have to access the table\-data 
 via the address\-space\&'s access_mem()
-call\-back, rather than
-through a direct memory reference.
+call\-back, rather than 
+through a direct memory reference. 
 .PP
-From the point of view of a runtime\-code generator, the remote
-table\-info format offers no advantage and it is expected that such
-generators will describe their procedures either with the proc\-info
-format or the normal table\-info format. The main reason that the
-remote table\-info format exists is to enable the
+From the point of view of a runtime code generator, the remote 
+table\-info format offers no advantage and it is expected that such 
+generators will describe their procedures either with the proc\-info 
+format or the normal table\-info format. The main reason that the 
+remote table\-info format exists is to enable the 
 address\-space\-specific find_proc_info()
-callback (see
-unw_create_addr_space(3))
-to return unwind tables whose
-data remains in remote memory. This can speed up unwinding (e.g., for
-a debugger) because it reduces the amount of data that needs to be
-loaded from remote memory.
+callback (see 
+unw_create_addr_space(3libunwind))
+to return unwind tables whose 
+data remains in remote memory. This can speed up unwinding (e.g., for 
+a debugger) because it reduces the amount of data that needs to be 
+loaded from remote memory. 
 .PP
 .SH REGIONS DESCRIPTORS
 
 .PP
-A region descriptor is a variable length structure that describes how
-each instruction in the region affects the frame state. Of course,
-most instructions in a region usually do not change the frame state and
-for those, nothing needs to be recorded in the region descriptor. A
-region descriptor is a structure of type
+A region descriptor is a variable length structure that describes how 
+each instruction in the region affects the frame state. Of course, 
+most instructions in a region usually do not change the frame state and 
+for those, nothing needs to be recorded in the region descriptor. A 
+region descriptor is a structure of type 
 unw_dyn_region_info_t
-and has the following members:
+and has the following members: 
 .TP
 unw_dyn_region_info_t *next
- A pointer to the
+ A pointer to the 
 next region. If this is the last region, next
 is NULL\&.
 .TP
 int32_t insn_count
- The length of the region in
-instructions. Each instruction is assumed to have a fixed size (see
-architecture\-specific sections for details). The value of
+ The length of the region in 
+instructions. Each instruction is assumed to have a fixed size (see 
+architecture\-specific sections for details). The value of 
 insn_count
-may be negative in the last region of a procedure
+may be negative in the last region of a procedure 
 (i.e., it may be negative only if next
 is NULL).
-A
+A 
 negative value indicates that the region covers the last \fIN\fP
 instructions of the procedure, where \fIN\fP
-is the absolute value
+is the absolute value 
 of insn_count\&.
 .TP
 uint32_t op_count
- The (allocated) length of
+ The (allocated) length of 
 the op_count
-array.
+array. 
 .TP
 unw_dyn_op_t op
- An array of dynamic unwind
-directives. See Section ``Dynamic unwind directives\&'' for a
-description of the directives.
+ An array of dynamic unwind 
+directives. See Section ``Dynamic unwind directives\&'' for a 
+description of the directives. 
 .PP
 A region descriptor with an insn_count
-of zero is an
+of zero is an 
 \fIempty region\fP
-and such regions are perfectly legal. In fact,
-empty regions can be useful to establish a particular frame state
-before the start of another region.
+and such regions are perfectly legal. In fact, 
+empty regions can be useful to establish a particular frame state 
+before the start of another region. 
 .PP
-A single region list can be shared across multiple procedures provided
-those procedures share a common prologue and epilogue (their bodies
-may differ, of course). Normally, such procedures consist of a canned
-prologue, the body, and a canned epilogue. This could be described by
-two regions: one covering the prologue and one covering the epilogue.
-Since the body length is variable, the latter region would need to
+A single region list can be shared across multiple procedures provided 
+those procedures share a common prologue and epilogue (their bodies 
+may differ, of course). Normally, such procedures consist of a canned 
+prologue, the body, and a canned epilogue. This could be described by 
+two regions: one covering the prologue and one covering the epilogue. 
+Since the body length is variable, the latter region would need to 
 specify a negative value in insn_count
-such that
+such that 
 libunwind
-knows that the region covers the end of the procedure
+knows that the region covers the end of the procedure 
 (up to the address specified by end_ip).
 .PP
-The region descriptor is a variable length structure to make it
-possible to allocate all the necessary memory with a single
-memory\-allocation request. To facilitate the allocation of a region
+The region descriptor is a variable length structure to make it 
+possible to allocate all the necessary memory with a single 
+memory\-allocation request. To facilitate the allocation of a region 
 descriptors libunwind
-provides a helper routine with the
-following synopsis:
+provides a helper routine with the 
+following synopsis: 
 .PP
 size_t
 _U_dyn_region_size(int
 op_count);
 .PP
-This routine returns the number of bytes needed to hold a region
+This routine returns the number of bytes needed to hold a region 
 descriptor with space for op_count
-unwind directives. Note
+unwind directives. Note 
 that the length of the op
-array does not have to match exactly
-with the number of directives in a region. Instead, it is sufficient
+array does not have to match exactly 
+with the number of directives in a region. Instead, it is sufficient 
 if the op
-array contains at least as many entries as there are
-directives, since the end of the directives can always be indicated
+array contains at least as many entries as there are 
+directives, since the end of the directives can always be indicated 
 with the UNW_DYN_STOP
-directive.
+directive. 
 .PP
 .SH DYNAMIC UNWIND DIRECTIVES
 
 .PP
-A dynamic unwind directive describes how the frame state changes
-at a particular point within a region. The description is in
+A dynamic unwind directive describes how the frame state changes 
+at a particular point within a region. The description is in 
 the form of a structure of type unw_dyn_op_t\&.
-This
-structure has the following members:
+This 
+structure has the following members: 
 .TP
 int8_t tag
- The operation tag. Must be one
+ The operation tag. Must be one 
 of the unw_dyn_operation_t
-values described below.
+values described below. 
 .TP
 int8_t qp
- The qualifying predicate that controls
-whether or not this directive is active. This is useful for
-predicated architectures such as IA\-64 or ARM, where the contents of
-another (callee\-saved) register determines whether or not an
-instruction is executed (takes effect). If the directive is always
-active, this member should be set to the manifest constant
+ The qualifying predicate that controls 
+whether or not this directive is active. This is useful for 
+predicated architectures such as IA\-64 or ARM, where the contents of 
+another (callee\-saved) register determines whether or not an 
+instruction is executed (takes effect). If the directive is always 
+active, this member should be set to the manifest constant 
 _U_QP_TRUE
-(this constant is defined for all
-architectures, predicated or not).
+(this constant is defined for all 
+architectures, predicated or not). 
 .TP
 int16_t reg
- The number of the register affected
-by the instruction.
+ The number of the register affected 
+by the instruction. 
 .TP
 int32_t when
- The region\-relative number of
-the instruction to which this directive applies. For example,
-a value of 0 means that the effect described by this directive
-has taken place once the first instruction in the region has
-executed.
+ The region\-relative number of 
+the instruction to which this directive applies. For example, 
+a value of 0 means that the effect described by this directive 
+has taken place once the first instruction in the region has 
+executed. 
 .TP
 unw_word_t val
- The value to be applied by the
-operation tag. The exact meaning of this value varies by tag. See
-Section ``Operation tags\&'' below.
+ The value to be applied by the 
+operation tag. The exact meaning of this value varies by tag. See 
+Section ``Operation tags\&'' below. 
 .PP
-It is perfectly legitimate to specify multiple dynamic unwind
+It is perfectly legitimate to specify multiple dynamic unwind 
 directives with the same when
-value, if a particular instruction
-has a complex effect on the frame state.
+value, if a particular instruction 
+has a complex effect on the frame state. 
 .PP
-Empty regions by definition contain no actual instructions and as such
-the directives are not tied to a particular instruction. By
+Empty regions by definition contain no actual instructions and as such 
+the directives are not tied to a particular instruction. By 
 convention, the when
-member should be set to 0, however.
+member should be set to 0, however. 
 .PP
-There is no need for the dynamic unwind directives to appear
+There is no need for the dynamic unwind directives to appear 
 in order of increasing when
-values. If the directives happen to
-be sorted in that order, it may result in slightly faster execution,
-but a runtime code\-generator should not go to extra lengths just to
-ensure that the directives are sorted.
+values. If the directives happen to 
+be sorted in that order, it may result in slightly faster execution, 
+but a runtime code\-generator should not go to extra lengths just to 
+ensure that the directives are sorted. 
 .PP
 IMPLEMENTATION NOTE: should libunwind
-implementations for
-certain architectures prefer the list of unwind directives to be
-sorted, it is recommended that such implementations first check
-whether the list happens to be sorted already and, if not, sort the
-directives explicitly before the first use. With this approach, the
-overhead of explicit sorting is only paid when there is a real benefit
-and if the runtime code\-generator happens to generate sorted lists
-naturally, the performance penalty is limited to a simple O(N) check.
+implementations for 
+certain architectures prefer the list of unwind directives to be 
+sorted, it is recommended that such implementations first check 
+whether the list happens to be sorted already and, if not, sort the 
+directives explicitly before the first use. With this approach, the 
+overhead of explicit sorting is only paid when there is a real benefit 
+and if the runtime code\-generator happens to generate sorted lists 
+naturally, the performance penalty is limited to a simple O(N) check. 
 .PP
 .SS OPERATIONS TAGS
 .PP
-The possible operation tags are defined by enumeration type
+The possible operation tags are defined by enumeration type 
 unw_dyn_operation_t
-which defines the following
-values:
+which defines the following 
+values: 
 .PP
 .TP
 UNW_DYN_STOP
- Marks the end of the dynamic unwind
+ Marks the end of the dynamic unwind 
 directive list. All remaining entries in the op
-array of the
-region\-descriptor are ignored. This tag is guaranteed to have a
-value of 0.
+array of the 
+region\-descriptor are ignored. This tag is guaranteed to have a 
+value of 0. 
 .PP
 .TP
 UNW_DYN_SAVE_REG
- Marks an instruction which saves
+ Marks an instruction which saves 
 register reg
 to register val\&.
 .PP
 .TP
 UNW_DYN_SPILL_FP_REL
- Marks an instruction which
+ Marks an instruction which 
 spills register reg
-to a frame\-pointer\-relative location. The
-frame\-pointer\-relative offset is given by the value stored in member
+to a frame\-pointer\-relative location. The 
+frame\-pointer\-relative offset is given by the value stored in member 
 val\&.
-See the architecture\-specific sections for a description
-of the stack frame layout.
+See the architecture\-specific sections for a description 
+of the stack frame layout. 
 .PP
 .TP
 UNW_DYN_SPILL_SP_REL
- Marks an instruction which
+ Marks an instruction which 
 spills register reg
-to a stack\-pointer\-relative location. The
-stack\-pointer\-relative offset is given by the value stored in member
+to a stack\-pointer\-relative location. The 
+stack\-pointer\-relative offset is given by the value stored in member 
 val\&.
-See the architecture\-specific sections for a description
-of the stack frame layout.
+See the architecture\-specific sections for a description 
+of the stack frame layout. 
 .PP
 .TP
 UNW_DYN_ADD
- Marks an instruction which adds
+ Marks an instruction which adds 
 the constant value val
 to register reg\&.
-To add subtract
-a constant value, store the two\&'s\-complement of the value in
+To add subtract 
+a constant value, store the two\&'s\-complement of the value in 
 val\&.
-The set of registers that can be specified for this tag
-is described in the architecture\-specific sections below.
+The set of registers that can be specified for this tag 
+is described in the architecture\-specific sections below. 
 .PP
 .TP
 UNW_DYN_POP_FRAMES
@@ -496,36 +497,36 @@ UNW_DYN_COPY_STATE
 .TP
 UNW_DYN_ALIAS
  .PP
-unw_dyn_op_t
+unw_dyn_op_t 
 .PP
-_U_dyn_op_save_reg();
-_U_dyn_op_spill_fp_rel();
-_U_dyn_op_spill_sp_rel();
-_U_dyn_op_add();
-_U_dyn_op_pop_frames();
-_U_dyn_op_label_state();
-_U_dyn_op_copy_state();
-_U_dyn_op_alias();
-_U_dyn_op_stop();
+_U_dyn_op_save_reg(); 
+_U_dyn_op_spill_fp_rel(); 
+_U_dyn_op_spill_sp_rel(); 
+_U_dyn_op_add(); 
+_U_dyn_op_pop_frames(); 
+_U_dyn_op_label_state(); 
+_U_dyn_op_copy_state(); 
+_U_dyn_op_alias(); 
+_U_dyn_op_stop(); 
 .PP
 .SH IA\-64 SPECIFICS
 
 .PP
-\- meaning of segbase member in table\-info/table\-remote\-info format
-\- format of table_data in table\-info/table\-remote\-info format
-\- instruction size: each bundle is counted as 3 instructions, regardless
-of template (MLX)
-\- describe stack\-frame layout, especially with regards to sp\-relative
-and fp\-relative addressing
-\- UNW_DYN_ADD can only add to ``sp\&'' (always a negative value); use
-POP_FRAMES otherwise
+\- meaning of segbase member in table\-info/table\-remote\-info format 
+\- format of table_data in table\-info/table\-remote\-info format 
+\- instruction size: each bundle is counted as 3 instructions, regardless 
+of template (MLX) 
+\- describe stack\-frame layout, especially with regards to sp\-relative 
+and fp\-relative addressing 
+\- UNW_DYN_ADD can only add to ``sp\&'' (always a negative value); use 
+POP_FRAMES otherwise 
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-_U_dyn_register(3),
-_U_dyn_cancel(3)
+libunwind(3libunwind),
+_U_dyn_register(3libunwind),
+_U_dyn_cancel(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/libunwind-dynamic.tex
+++ b/doc/libunwind-dynamic.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{libunwind-dynamic}{David Mosberger-Tang}{Programming Library}{Introduction to dynamic unwind-info}libunwind-dynamic -- libunwind-support for runtime-generated code
+\begin{Name}{3libunwind}{libunwind-dynamic}{David Mosberger-Tang}{Programming Library}{Introduction to dynamic unwind-info}libunwind-dynamic -- libunwind-support for runtime-generated code
 \end{Name}
 
 \section{Introduction}
@@ -124,7 +124,7 @@ structure as the sole argument.  The members of the
 \subsection{Proc-info format}
 
 This is the preferred dynamic unwind-info format and it is generally
-the one used by full-blown runtime code-generators.  In this format,
+the one used by full-blown runtime code generators.  In this format,
 the details of a procedure are described by a structure of type
 \Type{unw\_dyn\_proc\_info\_t}.  This structure contains the following
 members:
@@ -133,12 +133,12 @@ members:
 \item[\Type{unw\_word\_t} \Var{name\_ptr}] The address of a
   (human-readable) name of the procedure or 0 if no such name is
   available.  If non-zero, the string stored at this address must be
-  ASCII NUL terminated.  For source languages that use name-mangling
+  ASCII NUL terminated.  For source languages that use name mangling
   (such as C++ or Java) the string stored at this address should be
   the \emph{demangled} version of the name.
 
 \item[\Type{unw\_word\_t} \Var{handler}] The address of the
-  personality-routine for this procedure.  Personality-routines are
+  personality routine for this procedure.  Personality routines are
   used in conjunction with exception handling.  See the C++ ABI draft
   (http://www.codesourcery.com/cxx-abi/) for an overview and a
   description of the personality routine.  If the procedure has no
@@ -149,7 +149,7 @@ members:
   set to 0.
 
 \item[\Type{unw\_dyn\_region\_info\_t~*}\Var{regions}] A NULL-terminated
-  linked list of region-descriptors.  See section ``Region
+  linked list of region descriptors.  See section ``Region
   descriptors'' below for more details.
 
 \end{description}
@@ -183,7 +183,7 @@ This structure contains the following members:
   (\Type{unw\_word\_t}).
 
 \item[\Type{unw\_word\_t} \Var{table\_data}] A pointer to the actual
-  data encoding the unwind-info.  The exact format is
+  data encoding the unwind info.  The exact format is
   architecture-specific (see architecture-specific sections below).
 
 \end{description}
@@ -199,13 +199,13 @@ This implies that \Prog{libunwind} will have to access the table-data
 via the address-space's \Func{access\_mem}() call-back, rather than
 through a direct memory reference.
 
-From the point of view of a runtime-code generator, the remote
+From the point of view of a runtime code generator, the remote
 table-info format offers no advantage and it is expected that such
 generators will describe their procedures either with the proc-info
 format or the normal table-info format.  The main reason that the
 remote table-info format exists is to enable the
 address-space-specific \Func{find\_proc\_info}() callback (see
-\SeeAlso{unw\_create\_addr\_space}(3)) to return unwind tables whose
+\SeeAlso{unw\_create\_addr\_space}(3libunwind)) to return unwind tables whose
 data remains in remote memory.  This can speed up unwinding (e.g., for
 a debugger) because it reduces the amount of data that needs to be
 loaded from remote memory.
@@ -386,9 +386,9 @@ unw\_dyn\_op\_t
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{\_U\_dyn\_register(3)},
-\SeeAlso{\_U\_dyn\_cancel(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{\_U\_dyn\_register}(3libunwind),
+\SeeAlso{\_U\_dyn\_cancel}(3libunwind)
 
 \section{Author}
 

--- a/doc/libunwind-ia64.man
+++ b/doc/libunwind-ia64.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:44 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 12:09:48 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "LIBUNWIND\-IA64" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "LIBUNWIND\-IA64" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 libunwind\-ia64
 \-\- IA\-64\-specific support in libunwind 
@@ -301,7 +303,7 @@ portable code should not rely on this equivalence.
 .SH SEE ALSO
 
 .PP
-libunwind(3)
+libunwind(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/libunwind-ia64.tex
+++ b/doc/libunwind-ia64.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{libunwind-ia64}{David Mosberger-Tang}{Programming Library}{IA-64-specific support in libunwind}libunwind-ia64 -- IA-64-specific support in libunwind
+\begin{Name}{3libunwind}{libunwind-ia64}{David Mosberger-Tang}{Programming Library}{IA-64-specific support in libunwind}libunwind-ia64 -- IA-64-specific support in libunwind
 \end{Name}
 
 
@@ -203,7 +203,7 @@ example.  However, since this is an IA-64-specific extension to
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)}
+\SeeAlso{libunwind}(3libunwind)
 
 \section{Author}
 

--- a/doc/libunwind-nto.man
+++ b/doc/libunwind-nto.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Mar  9 08:56:23 EST 2023
+.\" Manual page created with latex2man on Tue Aug 29 10:53:41 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,11 +12,10 @@
 
 .fi
 ..
-.TH "LIBUNWIND\-NTO" "3" "09 March 2023" "Programming Library " "Programming Library "
+.TH "LIBUNWIND\-NTO" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 libunwind\-nto
 \-\- QNX Neutrino support in libunwind 
-.PP
 .SH SYNOPSIS
 
 .PP
@@ -28,8 +29,7 @@ unw_nto_accessors;
 void *unw_nto_create(pid_t,
 pthread_t);
 .br
-void
-unw_nto_destroy(void *);
+void unw_nto_destroy(void *);
 .br
 .PP
 int
@@ -88,34 +88,62 @@ void *);
 
 .PP
 The QNX operating system makes it possible for a process to 
-gain access to the machine\-state and virtual memory of \fIanother\fP
-process. 
-With the right set of call\-back routines, 
-it is therefore possible to hook up libunwind
+gain access to the machine state and virtual memory of \fIanother\fP
+process, or a different thread within the same process. 
+gain access to the machine state and virtual memory of \fIanother\fP
+it is possible to hook up libunwind
 to another process. 
 While it\&'s not very difficult to do so directly, 
 libunwind
 further facilitates this task by providing 
 ready\-to\-use callbacks for this purpose. 
 The routines and variables 
-implementing this facility use a name\-prefix of unw_nto,
+implementing this facility use a name prefix of unw_nto,
 which is stands for ``unwind\-via\-nto\&''\&. 
 .PP
-An application that wants to use the unw_nto\-facility
-first needs 
-to create a new libunwind
-address\-space that represents the 
-target process. This is done by calling 
+An application that wants to use the libunwind
+NTO remote needs 
+to take the following steps. 
+.PP
+.TP
+1.
+Create a new libunwind address\-space that represents the target
+process and thread. This is done by calling 
 unw_create_addr_space().
-In many cases, the application 
-will simply want to pass the address of unw_nto_accessors
+In many cases, the application will 
+simply want to pass the address of unw_nto_accessors
 as the 
 first argument to this routine. Doing so will ensure that 
 libunwind
 will be able to properly unwind the target process. 
-However, in special circumstances, an application may prefer to use 
-only portions of the unw_nto\-facility.
-For this reason, the 
+.PP
+.TP
+2.
+Create an NTO info structure by calling unw_nto_create(),
+passing the pid and tid of the target process thread as the arguments. 
+This will stop the target thread. The process ID (pid) of the target 
+process must be known, and only a single thread can be unwound at a time 
+so the thread ID (tid) must also be specified. 
+.PP
+.TP
+3.
+The opaque pointer returned then needs to be passed as the 
+``argument\&'' pointer (third argument) to unw_init_remote().
+.PP
+When the application is done using libunwind
+on the target process, 
+unw_nto_destroy()
+needs to be called, passing it the opaque pointer 
+that was returned by the call to unw_nto_create().
+This ensures that 
+all memory and other resources are freed up. 
+.PP
+The unw_nto_resume()
+is not supported on the NTO remote. 
+.PP
+In special circumstances, an application may prefer to use 
+only portions of the libunwind
+NTO remote. For this reason, the 
 individual callback routines (unw_nto_find_proc_info(),
 unw_nto_put_unwind_info(),
 etc.) are also available for direct 
@@ -127,52 +155,23 @@ initialization. Also, when using unw_nto_accessors,
 the callback routines will be linked into the application, even if 
 they are never actually called. 
 .PP
-The process\-ID (pid) of the target process must be known, 
-and only a single thread can be unwound at a time so the thread\-id (tid) 
-must also be specified. 
-A unw_nto\-info\-structure
-can be created 
-by calling unw_nto_create(),
-passing the pid and tid of the target 
-process thread as the arguments. 
-This will stop the target thread. 
-The returned void\-pointer then needs to be 
-passed as the ``argument\&'' pointer (third argument) to 
-unw_init_remote().
-.PP
-The unw_nto_resume()
-routine can be used to resume execution of 
-the target process after unwinding. 
-.PP
-When the application is done using libunwind
-on the target 
-process, unw_nto_destroy()
-needs to be called, passing it the 
-void\-pointer that was returned by the corresponding call to 
-unw_nto_create().
-This ensures that all memory and other 
-resources are freed up. 
-.PP
 .SH THREAD SAFETY
 
 .PP
-The unw_nto\-facility
-assumes that a single unw_nto\-info
+The libunwind
+NTO remote assumes that a single unw_nto\-info
 structure is never shared between threads of the unwinding program. 
 Because of this, 
 no explicit locking is used. 
-As long as only one thread uses a unw_nto\-info
-structure at any given time, 
+As long as only one thread uses an NTO info structure at any given time, 
 this facility is thread\-safe. 
 .PP
 .SH RETURN VALUE
 
 .PP
 unw_nto_create()
-may return a NULL
-pointer if it fails 
-to create the unw_nto\-info\-structure
-for any reason. 
+may return a NULL if it fails 
+to create the NTO info structure for any reason. 
 .PP
 .SH FILES
 
@@ -186,9 +185,72 @@ interface defined by this library.
  Linker\-switches to add when building a program that uses the 
 functions defined by this library. 
 .PP
+.SH EXAMPLE
+
+.Vb
+    #include <libunwind\-nto.h>
+    #include <stdio.h>
+    #include <stdlib.h>
+
+    int
+    main (int argc, char **argv)
+    {
+      if (argc != 2) {
+        fprintf (stderr, "usage: %s PID\\n", argv[0]);
+        exit (EXIT_FAILURE);
+      }
+
+      char *endptr;
+      pid_t target_pid = strtoul (argv[1], &endptr, 10);
+      if (target_pid == 0 && argv[1] == endptr) {
+        fprintf (stderr, "usage: %s PID\\n", argv[0]);
+        exit (EXIT_FAILURE);
+      }
+
+      unw_addr_space_t as = unw_create_addr_space (&unw_nto_accessors, 0);
+      if (!as) {
+        fprintf (stderr, "unw_create_addr_space() failed");
+        exit (EXIT_FAILURE);
+      }
+
+      void *ui = unw_nto_create (target_pid, (thread_t)1);
+      if (!ui) {
+        fprintf (stderr, "unw_nto_create() failed");
+        exit (EXIT_FAILURE);
+      }
+
+      unw_cursor_t cursor;
+      int ret = unw_init_remote (&cursor, as, ui);
+      if (ret < 0) {
+        fprintf (stderr, "unw_init_remote() failed: ret=%d\\n", ret);
+        exit (EXIT_FAILURE);
+      }
+
+      do {
+        unw_proc_info_t pi;
+        ret = unw_get_proc_info (&cursor, &pi);
+        if (ret == \-UNW_ENOINFO) {
+          fprintf (stdout, "no info\\n");
+        } else if (ret >= 0) {
+          printf ("\\tproc=%#016lx\-%#016lx\\thandler=%#016lx lsda=%#016lx",
+                  (long) pi.start_ip, (long) pi.end_ip,
+                  (long) pi.handler, (long) pi.lsda);
+        }
+        ret = unw_step (&cursor);
+      } while (ret > 0);
+      if (ret < 0) {
+        fprintf (stderr, "unwind failed with ret=%d\\n", ret);
+        exit (EXIT_FAILURE);
+      }
+
+      unw_nto_destroy (ui);
+      unw_destroy_addr_space (as);
+      exit (EXIT_SUCCESS);
+    }
+.Ve
+.PP
 .SH SEE ALSO
 
-.PP
-libunwind(3),
+libunwind(3libunwind)
 .PP
 .\" NOTE: This file is generated, DO NOT EDIT.

--- a/doc/libunwind-nto.tex
+++ b/doc/libunwind-nto.tex
@@ -5,9 +5,8 @@
 
 \begin{document}
 
-\begin{Name}{3}{libunwind-nto}{Blackberry}{Programming Library}{QNX Neutrino support in libunwind}libunwind-nto -- QNX Neutrino support in libunwind
+\begin{Name}{3libunwind}{libunwind-nto}{Blackberry}{Programming Library}{QNX Neutrino remote for libunwind}libunwind-nto -- QNX Neutrino support in libunwind
 \end{Name}
-
 \section{Synopsis}
 
 \File{\#include $<$libunwind-nto.h$>$}\\
@@ -17,7 +16,7 @@
 
 \Type{void~*}\Func{unw\_nto\_create}(\Type{pid\_t}, \Type{pthread\_t});\\
 \noindent
-\Type{void} \Func{unw\_nto\_destroy}(\Type{void~*});\\
+\Type{void}~\Func{unw\_nto\_destroy}(\Type{void~*});\\
 
 \noindent
 \Type{int} \Func{unw\_nto\_find\_proc\_info}(\Type{unw\_addr\_space\_t}, \Type{unw\_word\_t}, \Type{unw\_proc\_info\_t~*}, \Type{int}, \Type{void~*});\\
@@ -39,26 +38,48 @@
 \section{Description}
 
 The QNX operating system makes it possible for a process to
-gain access to the machine-state and virtual memory of \emph{another}
-process.
-With the right set of call-back routines,
-it is therefore possible to hook up \Prog{libunwind} to another process.
+gain access to the machine state and virtual memory of \emph{another}
+process, or a different thread within the same process.
+gain access to the machine state and virtual memory of \emph{another}
+it is possible to hook up \Prog{libunwind} to another process.
 While it's not very difficult to do so directly,
 \Prog{libunwind} further facilitates this task by providing
 ready-to-use callbacks for this purpose.
 The routines and variables
-implementing this facility use a name-prefix of \Func{unw\_nto},
+implementing this facility use a name prefix of \Func{unw\_nto},
 which is stands for ``unwind-via-nto''.
 
-An application that wants to use the \Func{unw\_nto}-facility first needs
-to create a new \Prog{libunwind} address-space that represents the
-target process.  This is done by calling
-\Func{unw\_create\_addr\_space}().  In many cases, the application
-will simply want to pass the address of \Var{unw\_nto\_accessors} as the
-first argument to this routine.  Doing so will ensure that
-\Prog{libunwind} will be able to properly unwind the target process.
-However, in special circumstances, an application may prefer to use
-only portions of the \Prog{unw\_nto}-facility.  For this reason, the
+An application that wants to use the \Prog{libunwind} NTO remote needs
+to take the following steps.
+\begin{enumerate}
+
+    \item Create a new \Prog{libunwind} address-space that represents the target
+        process and thread.  This is done by calling
+        \Func{unw\_create\_addr\_space}().  In many cases, the application will
+        simply want to pass the address of \Var{unw\_nto\_accessors} as the
+        first argument to this routine.  Doing so will ensure that
+        \Prog{libunwind} will be able to properly unwind the target process.
+
+    \item Create an NTO info structure by calling \Func{unw\_nto\_create}(),
+        passing the pid and tid of the target process thread as the arguments.
+        This will stop the target thread.  The process ID (pid) of the target
+        process must be known, and only a single thread can be unwound at a time
+        so the thread ID (tid) must also be specified.
+
+    \item The opaque pointer returned then needs to be passed as the
+        ``argument'' pointer (third argument) to \Func{unw\_init\_remote}().
+
+\end{enumerate}
+
+When the application is done using \Prog{libunwind} on the target process,
+\Func{unw\_nto\_destroy}() needs to be called, passing it the opaque pointer
+that was returned by the call to \Func{unw\_nto\_create}().  This ensures that
+all memory and other resources are freed up.
+
+The \Func{unw\_nto\_resume}() is not supported on the NTO remote.
+
+In special circumstances, an application may prefer to use
+only portions of the \Prog{libunwind} NTO remote.  For this reason, the
 individual callback routines (\Func{unw\_nto\_find\_proc\_info}(),
 \Func{unw\_nto\_put\_unwind\_info}(), etc.)  are also available for direct
 use.  Of course, the addresses of these routines could also be picked
@@ -67,39 +88,19 @@ initialization.  Also, when using \Var{unw\_nto\_accessors}, \emph{all}
 the callback routines will be linked into the application, even if
 they are never actually called.
 
-The process-ID (pid) of the target process must be known,
-and only a single thread can be unwound at a time so the thread-id (tid)
-must also be specified.
-A \Prog{unw\_nto}-info-structure can be created
-by calling \Func{unw\_nto\_create}(), passing the pid and tid of the target
-process thread as the arguments.
-This will stop the target thread.
-The returned void-pointer then needs to be
-passed as the ``argument'' pointer (third argument) to
-\Func{unw\_init\_remote}().
-
-The \Func{unw\_nto\_resume}() routine can be used to resume execution of
-the target process after unwinding.
-
-When the application is done using \Prog{libunwind} on the target
-process, \Func{unw\_nto\_destroy}() needs to be called, passing it the
-void-pointer that was returned by the corresponding call to
-\Func{unw\_nto\_create}().  This ensures that all memory and other
-resources are freed up.
-
 \section{Thread Safety}
 
-The \Prog{unw\_nto}-facility assumes that a single \Prog{unw\_nto}-info
+The \Prog{libunwind} NTO remote assumes that a single \Prog{unw\_nto}-info
 structure is never shared between threads of the unwinding program.
 Because of this,
 no explicit locking is used.
-As long as only one thread uses a \Prog{unw\_nto}-info structure at any given time,
+As long as only one thread uses an NTO info structure at any given time,
 this facility is thread-safe.
 
 \section{Return Value}
 
-\Func{unw\_nto\_create}() may return a \Const{NULL} pointer if it fails
-to create the \Prog{unw\_nto}-info-structure for any reason.
+\Func{unw\_nto\_create}() may return a NULL if it fails
+to create the NTO info structure for any reason.
 
 \section{Files}
 
@@ -111,9 +112,71 @@ to create the \Prog{unw\_nto}-info-structure for any reason.
     functions defined by this library.
 \end{Description}
 
-\section{See Also}
+\section{Example}
+\begin{verbatim}
+    #include <libunwind-nto.h>
+    #include <stdio.h>
+    #include <stdlib.h>
 
-\SeeAlso{libunwind(3)},
+    int
+    main (int argc, char **argv)
+    {
+      if (argc != 2) {
+        fprintf (stderr, "usage: %s PID\n", argv[0]);
+        exit (EXIT_FAILURE);
+      }
+
+      char *endptr;
+      pid_t target_pid = strtoul (argv[1], &endptr, 10);
+      if (target_pid == 0 && argv[1] == endptr) {
+        fprintf (stderr, "usage: %s PID\n", argv[0]);
+        exit (EXIT_FAILURE);
+      }
+
+      unw_addr_space_t as = unw_create_addr_space (&unw_nto_accessors, 0);
+      if (!as) {
+        fprintf (stderr, "unw_create_addr_space() failed");
+        exit (EXIT_FAILURE);
+      }
+
+      void *ui = unw_nto_create (target_pid, (thread_t)1);
+      if (!ui) {
+        fprintf (stderr, "unw_nto_create() failed");
+        exit (EXIT_FAILURE);
+      }
+
+      unw_cursor_t cursor;
+      int ret = unw_init_remote (&cursor, as, ui);
+      if (ret < 0) {
+        fprintf (stderr, "unw_init_remote() failed: ret=%d\n", ret);
+        exit (EXIT_FAILURE);
+      }
+
+      do {
+        unw_proc_info_t pi;
+        ret = unw_get_proc_info (&cursor, &pi);
+        if (ret == -UNW_ENOINFO) {
+          fprintf (stdout, "no info\n");
+        } else if (ret >= 0) {
+          printf ("\tproc=%#016lx-%#016lx\thandler=%#016lx lsda=%#016lx",
+                  (long) pi.start_ip, (long) pi.end_ip,
+                  (long) pi.handler, (long) pi.lsda);
+        }
+        ret = unw_step (&cursor);
+      } while (ret > 0);
+      if (ret < 0) {
+        fprintf (stderr, "unwind failed with ret=%d\n", ret);
+        exit (EXIT_FAILURE);
+      }
+
+      unw_nto_destroy (ui);
+      unw_destroy_addr_space (as);
+      exit (EXIT_SUCCESS);
+    }
+\end{verbatim}
+
+\section{See Also}
+\SeeAlso{libunwind}(3libunwind)
 
 \LatexManEnd
 

--- a/doc/libunwind-ptrace.man
+++ b/doc/libunwind-ptrace.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:44 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 10:53:41 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,10 +12,10 @@
 
 .fi
 ..
-.TH "LIBUNWIND\-PTRACE" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "LIBUNWIND\-PTRACE" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 libunwind\-ptrace
-\-\- ptrace() support in libunwind 
+\-\- ptrace() support in libunwind
 .PP
 .SH SYNOPSIS
 
@@ -27,58 +29,49 @@ _UPT_accessors;
 .PP
 void *_UPT_create(pid_t);
 .br
-void
-_UPT_destroy(void *);
+void _UPT_destroy(void *);
 .br
 .PP
-int
-_UPT_find_proc_info(unw_addr_space_t,
+int _UPT_find_proc_info(unw_addr_space_t,
 unw_word_t,
 unw_proc_info_t *,
 int,
 void *);
 .br
-void
-_UPT_put_unwind_info(unw_addr_space_t,
+void _UPT_put_unwind_info(unw_addr_space_t,
 unw_proc_info_t *,
 void *);
 .br
-int
-_UPT_get_dyn_info_list_addr(unw_addr_space_t,
+int _UPT_get_dyn_info_list_addr(unw_addr_space_t,
 unw_word_t *,
 void *);
 .br
-int
-_UPT_access_mem(unw_addr_space_t,
+int _UPT_access_mem(unw_addr_space_t,
 unw_word_t,
 unw_word_t *,
 int,
 void *);
 .br
-int
-_UPT_access_reg(unw_addr_space_t,
+int _UPT_access_reg(unw_addr_space_t,
 unw_regnum_t,
 unw_word_t *,
 int,
 void *);
 .br
-int
-_UPT_access_fpreg(unw_addr_space_t,
+int _UPT_access_fpreg(unw_addr_space_t,
 unw_regnum_t,
 unw_fpreg_t *,
 int,
 void *);
 .br
-int
-_UPT_get_proc_name(unw_addr_space_t,
+int _UPT_get_proc_name(unw_addr_space_t,
 unw_word_t,
 char *,
 size_t,
 unw_word_t *,
 void *);
 .br
-int
-_UPT_resume(unw_addr_space_t,
+int _UPT_resume(unw_addr_space_t,
 unw_cursor_t *,
 void *);
 .br
@@ -87,9 +80,9 @@ void *);
 
 .PP
 The ptrace(2)
-system\-call makes it possible for a process to 
-gain access to the machine\-state and virtual memory of \fIanother\fP
-process. With the right set of call\-back routines, it is therefore 
+system call makes it possible for a process to 
+gain access to the machine state and virtual memory of \fIanother\fP
+process. With the right set of callback routines, it is therefore 
 possible to hook up libunwind
 to another process via 
 ptrace(2).
@@ -97,117 +90,185 @@ While it\&'s not very difficult to do so directly,
 libunwind
 further facilitates this task by providing 
 ready\-to\-use callbacks for this purpose. The routines and variables 
-implementing this facility use a name\-prefix of _UPT,
+implementing this facility use a name prefix of _UPT,
 which is 
-stands for ``unwind\-via\-ptrace\&''\&. 
+stands for ``unwind via ptrace\&''\&. 
 .PP
-An application that wants to use the _UPT\-facility
-first needs 
-to create a new libunwind
-address\-space that represents the 
-target process. This is done by calling 
-unw_create_addr_space().
-In many cases, the application 
-will simply want to pass the address of _UPT_accessors
-as the 
-first argument to this routine. Doing so will ensure that 
-libunwind
-will be able to properly unwind the target process. 
-However, in special circumstances, an application may prefer to use 
-only portions of the _UPT\-facility.
-For this reason, the 
-individual callback routines (_UPT_find_proc_info(),
+An application that wants to use the libunwind
+ptrace remote needs to 
+take the folowing steps. 
+.PP
+.TP
+1.
+Create a new libunwind address space that represents the target
+process. This is done by calling unw_create_addr_space().
+In 
+many cases, the application will simply want to pass the address of 
+_UPT_accessors
+as the first argument to this routine. Doing so 
+will ensure that libunwind
+will be able to properly unwind the 
+target process. 
+.PP
+.TP
+2.
+Turn on ptrace mode on the target process, either by forking a new 
+process, invoking PTRACE_TRACEME,
+and then starting the target 
+program (via execve(2)),
+or by directly attaching to an already 
+running process (via PTRACE_ATTACH).
+.PP
+.TP
+3.
+Once the process\-ID (pid) of the target process is known, a 
+UPT info structure can be created by calling 
+_UPT_create(),
+passing the pid of the target process as the 
+only argument. 
+.PP
+.TP
+4.
+The opaque pointer returned then needs to be passed as the 
+``argument\&'' pointer (third argument) to unw_init_remote().
+.PP
+In special circumstances, an application may prefer to use only 
+portions of the libunwind
+ptrace remote. For this reason, the individual 
+callback routines (_UPT_find_proc_info(),
 _UPT_put_unwind_info(),
-etc.) are also available for direct 
-use. Of course, the addresses of these routines could also be picked 
-up from _UPT_accessors,
-but doing so would prevent static 
-initialization. Also, when using _UPT_accessors,
+etc.) are also available for direct use. Of 
+course, the addresses of these routines could also be picked up from 
+_UPT_accessors,
+but doing so would prevent static initialization. Also, 
+when using _UPT_accessors,
 \fIall\fP
-the callback routines will be linked into the application, even if 
-they are never actually called. 
-.PP
-Next, the application can turn on ptrace\-mode on the target process, 
-either by forking a new process, invoking PTRACE_TRACEME,
-and 
-then starting the target program (via execve(2)),
-or by 
-directly attaching to an already running process (via 
-PTRACE_ATTACH).
-Either way, once the process\-ID (pid) of the 
-target process is known, a _UPT\-info\-structure
-can be created 
-by calling _UPT_create(),
-passing the pid of the target process 
-as the only argument. The returned void\-pointer then needs to be 
-passed as the ``argument\&'' pointer (third argument) to 
-unw_init_remote().
+the callback routines will be 
+linked into the application, even if they are never actually called. 
 .PP
 The _UPT_resume()
-routine can be used to resume execution of 
-the target process. It simply invokes ptrace(2)
-with a command 
-value of PTRACE_CONT\&.
+routine can be used to resume execution of the target 
+process. It simply invokes ptrace(2)
+with a command value of 
+PTRACE_CONT\&.
 .PP
 When the application is done using libunwind
-on the target 
-process, _UPT_destroy()
-needs to be called, passing it the 
-void\-pointer that was returned by the corresponding call to 
-_UPT_create().
-This ensures that all memory and other 
-resources are freed up. 
+on the target process, 
+_UPT_destroy()
+needs to be called, passing it the opaque pointer that 
+was returned by the call to _UPT_create().
+This ensures that all 
+memory and other resources are freed up. 
 .PP
 .SH AVAILABILITY
 
 .PP
 Since ptrace(2)
-works within a single machine only, the 
-_UPT\-facility
-by definition is not available in 
-libunwind\-versions
-configured for cross\-unwinding. 
+works within a single machine only, the libunwind ptrace 
+remote by definition is not available in libunwind
+versions configured 
+for cross\-unwinding. 
 .PP
 .SH THREAD SAFETY
 
 .PP
-The _UPT\-facility
-assumes that a single _UPT\-info
-structure is never shared between threads. Because of this, no 
-explicit locking is used. As long as only one thread uses 
-a _UPT\-info
-structure at any given time, this facility 
-is thread\-safe. 
+The libunwind
+ptrace remote assumes that a single UPT info structure is 
+never shared between threads. Because of this, no explicit locking is used. As 
+long as only one thread uses a UPT info structure at any given time, this 
+facility is thread\-safe. 
 .PP
 .SH RETURN VALUE
 
 .PP
 _UPT_create()
 may return a NULL
-pointer if it fails 
-to create the _UPT\-info\-structure
-for any reason. For the 
-current implementation, the only reason this call may fail is when the 
-system is out of memory. 
+pointer if it fails to create 
+the UPT info structure for any reason. For the current implementation, the only 
+reason this call may fail is when the system is out of memory. 
 .PP
 .SH FILES
 
 .PP
 .TP
 libunwind\-ptrace.h
- Headerfile to include when using the 
+ Header file to include when using the 
 interface defined by this library. 
 .TP
 \fB\-l\fPunwind\-ptrace \fB\-l\fPunwind\-generic
- Linker\-switches to add when building a program that uses the 
+ Linker switches to add when building a program that uses the 
 functions defined by this library. 
+.PP
+.SH EXAMPLE
+
+.Vb
+    #include <libunwind\-ptrace.h>
+    #include <stdio.h>
+    #include <stdlib.h>
+
+    int
+    main (int argc, char **argv)
+    {
+      if (argc != 2) {
+        fprintf (stderr, "usage: %s PID\\n", argv[0]);
+        exit (EXIT_FAILURE);
+      }
+
+      char *endptr;
+      pid_t target_pid = strtoul (argv[1], &endptr, 10);
+      if (target_pid == 0 && argv[1] == endptr) {
+        fprintf (stderr, "usage: %s PID\\n", argv[0]);
+        exit (EXIT_FAILURE);
+      }
+
+      unw_addr_space_t as = unw_create_addr_space (&_UPT_accessors, 0);
+      if (!as) {
+        fprintf (stderr, "unw_create_addr_space() failed");
+        exit (EXIT_FAILURE);
+      }
+
+      void *ui = _UPT_create (target_pid);
+      if (!ui) {
+        fprintf (stderr, "_UPT_create() failed");
+        exit (EXIT_FAILURE);
+      }
+
+      unw_cursor_t cursor;
+      int ret = unw_init_remote (&cursor, as, ui);
+      if (ret < 0) {
+        fprintf (stderr, "unw_init_remote() failed: ret=%d\\n", ret);
+        exit (EXIT_FAILURE);
+      }
+
+      do {
+        unw_proc_info_t pi;
+        ret = unw_get_proc_info (&cursor, &pi);
+        if (ret == \-UNW_ENOINFO) {
+          fprintf (stdout, "no info\\n");
+        } else if (ret >= 0) {
+          printf ("\\tproc=%#016lx\-%#016lx\\thandler=%#016lx lsda=%#016lx",
+                  (long) pi.start_ip, (long) pi.end_ip,
+                  (long) pi.handler, (long) pi.lsda);
+        }
+        ret = unw_step (&cursor);
+      } while (ret > 0);
+      if (ret < 0) {
+        fprintf (stderr, "unwind failed with ret=%d\\n", ret);
+        exit (EXIT_FAILURE);
+      }
+
+      _UPT_destroy (ui);
+      unw_destroy_addr_space (as);
+      exit (EXIT_SUCCESS);
+    }
+.Ve
 .PP
 .SH SEE ALSO
 
 .PP
-execve(2), 
-libunwind(3),
-ptrace(2) 
+execve(2),
+libunwind(3libunwind),
+ptrace(2)
 .PP
 .SH AUTHOR
 

--- a/doc/libunwind-ptrace.tex
+++ b/doc/libunwind-ptrace.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{libunwind-ptrace}{David Mosberger-Tang}{Programming Library}{ptrace() support in libunwind}libunwind-ptrace -- ptrace() support in libunwind
+\begin{Name}{3libunwind}{libunwind-ptrace}{David Mosberger-Tang}{Programming Library}{ptrace() support in \Prog{libunwind}libunwind-ptrace -- ptrace() support in \Prog{libunwind}
 \end{Name}
 
 \section{Synopsis}
@@ -17,111 +17,178 @@
 
 \Type{void~*}\Func{\_UPT\_create}(\Type{pid\_t});\\
 \noindent
-\Type{void} \Func{\_UPT\_destroy}(\Type{void~*});\\
+\Type{void}~\Func{\_UPT\_destroy}(\Type{void~*});\\
 
 \noindent
-\Type{int} \Func{\_UPT\_find\_proc\_info}(\Type{unw\_addr\_space\_t}, \Type{unw\_word\_t}, \Type{unw\_proc\_info\_t~*}, \Type{int}, \Type{void~*});\\
+\Type{int}~\Func{\_UPT\_find\_proc\_info}(\Type{unw\_addr\_space\_t}, \Type{unw\_word\_t}, \Type{unw\_proc\_info\_t~*}, \Type{int}, \Type{void~*});\\
 \noindent
-\Type{void} \Func{\_UPT\_put\_unwind\_info}(\Type{unw\_addr\_space\_t}, \Type{unw\_proc\_info\_t~*}, \Type{void~*});\\
+\Type{void}~\Func{\_UPT\_put\_unwind\_info}(\Type{unw\_addr\_space\_t}, \Type{unw\_proc\_info\_t~*}, \Type{void~*});\\
 \noindent
-\Type{int} \Func{\_UPT\_get\_dyn\_info\_list\_addr}(\Type{unw\_addr\_space\_t}, \Type{unw\_word\_t~*}, \Type{void~*});\\
+\Type{int}~\Func{\_UPT\_get\_dyn\_info\_list\_addr}(\Type{unw\_addr\_space\_t}, \Type{unw\_word\_t~*}, \Type{void~*});\\
 \noindent
-\Type{int} \Func{\_UPT\_access\_mem}(\Type{unw\_addr\_space\_t}, \Type{unw\_word\_t}, \Type{unw\_word\_t~*}, \Type{int}, \Type{void~*});\\
+\Type{int}~\Func{\_UPT\_access\_mem}(\Type{unw\_addr\_space\_t}, \Type{unw\_word\_t}, \Type{unw\_word\_t~*}, \Type{int}, \Type{void~*});\\
 \noindent
-\Type{int} \Func{\_UPT\_access\_reg}(\Type{unw\_addr\_space\_t}, \Type{unw\_regnum\_t}, \Type{unw\_word\_t~*}, \Type{int}, \Type{void~*});\\
+\Type{int}~\Func{\_UPT\_access\_reg}(\Type{unw\_addr\_space\_t}, \Type{unw\_regnum\_t}, \Type{unw\_word\_t~*}, \Type{int}, \Type{void~*});\\
 \noindent
-\Type{int} \Func{\_UPT\_access\_fpreg}(\Type{unw\_addr\_space\_t}, \Type{unw\_regnum\_t}, \Type{unw\_fpreg\_t~*}, \Type{int}, \Type{void~*});\\
+\Type{int}~\Func{\_UPT\_access\_fpreg}(\Type{unw\_addr\_space\_t}, \Type{unw\_regnum\_t}, \Type{unw\_fpreg\_t~*}, \Type{int}, \Type{void~*});\\
 \noindent
-\Type{int} \Func{\_UPT\_get\_proc\_name}(\Type{unw\_addr\_space\_t}, \Type{unw\_word\_t}, \Type{char~*}, \Type{size\_t}, \Type{unw\_word\_t~*}, \Type{void~*});\\
+\Type{int}~\Func{\_UPT\_get\_proc\_name}(\Type{unw\_addr\_space\_t}, \Type{unw\_word\_t}, \Type{char~*}, \Type{size\_t}, \Type{unw\_word\_t~*}, \Type{void~*});\\
 \noindent
-\Type{int} \Func{\_UPT\_resume}(\Type{unw\_addr\_space\_t}, \Type{unw\_cursor\_t~*}, \Type{void~*});\\
+\Type{int}~\Func{\_UPT\_resume}(\Type{unw\_addr\_space\_t}, \Type{unw\_cursor\_t~*}, \Type{void~*});\\
 
 \section{Description}
 
-The \Func{ptrace}(2) system-call makes it possible for a process to
-gain access to the machine-state and virtual memory of \emph{another}
-process.  With the right set of call-back routines, it is therefore
+The \Func{ptrace}(2) system call makes it possible for a process to
+gain access to the machine state and virtual memory of \emph{another}
+process.  With the right set of callback routines, it is therefore
 possible to hook up \Prog{libunwind} to another process via
 \Func{ptrace}(2).  While it's not very difficult to do so directly,
 \Prog{libunwind} further facilitates this task by providing
 ready-to-use callbacks for this purpose.  The routines and variables
-implementing this facility use a name-prefix of \Func{\_UPT}, which is
-stands for ``unwind-via-ptrace''.
+implementing this facility use a name prefix of \Func{\_UPT}, which is
+stands for ``unwind via ptrace''.
 
-An application that wants to use the \Func{\_UPT}-facility first needs
-to create a new \Prog{libunwind} address-space that represents the
-target process.  This is done by calling
-\Func{unw\_create\_addr\_space}().  In many cases, the application
-will simply want to pass the address of \Var{\_UPT\_accessors} as the
-first argument to this routine.  Doing so will ensure that
-\Prog{libunwind} will be able to properly unwind the target process.
-However, in special circumstances, an application may prefer to use
-only portions of the \Prog{\_UPT}-facility.  For this reason, the
-individual callback routines (\Func{\_UPT\_find\_proc\_info}(),
-\Func{\_UPT\_put\_unwind\_info}(), etc.)  are also available for direct
-use.  Of course, the addresses of these routines could also be picked
-up from \Var{\_UPT\_accessors}, but doing so would prevent static
-initialization.  Also, when using \Var{\_UPT\_accessors}, \emph{all}
-the callback routines will be linked into the application, even if
-they are never actually called.
+An application that wants to use the \Prog{libunwind} ptrace remote needs to
+take the folowing steps.
+\begin{enumerate}
 
-Next, the application can turn on ptrace-mode on the target process,
-either by forking a new process, invoking \Const{PTRACE\_TRACEME}, and
-then starting the target program (via \Func{execve}(2)), or by
-directly attaching to an already running process (via
-\Const{PTRACE\_ATTACH}).  Either way, once the process-ID (pid) of the
-target process is known, a \Prog{\_UPT}-info-structure can be created
-by calling \Func{\_UPT\_create}(), passing the pid of the target process
-as the only argument.  The returned void-pointer then needs to be
-passed as the ``argument'' pointer (third argument) to
-\Func{unw\_init\_remote}().
+    \item Create a new \Prog{libunwind} address space that represents the target
+        process.  This is done by calling \Func{unw\_create\_addr\_space}().  In
+        many cases, the application will simply want to pass the address of
+        \Var{\_UPT\_accessors} as the first argument to this routine.  Doing so
+        will ensure that \Prog{libunwind} will be able to properly unwind the
+        target process.
 
-The \Func{\_UPT\_resume}() routine can be used to resume execution of
-the target process.  It simply invokes \Func{ptrace}(2) with a command
-value of \Const{PTRACE\_CONT}.
+    \item Turn on ptrace mode on the target process, either by forking a new
+        process, invoking \Const{PTRACE\_TRACEME}, and then starting the target
+        program (via \Func{execve}(2)), or by directly attaching to an already
+        running process (via \Const{PTRACE\_ATTACH}).
 
-When the application is done using \Prog{libunwind} on the target
-process, \Func{\_UPT\_destroy}() needs to be called, passing it the
-void-pointer that was returned by the corresponding call to
-\Func{\_UPT\_create}().  This ensures that all memory and other
-resources are freed up.
+    \item Once the process-ID (pid) of the target process is known, a
+        UPT info structure can be created by calling
+        \Func{\_UPT\_create}(), passing the pid of the target process as the
+        only argument.
+
+    \item The opaque pointer returned then needs to be passed as the
+        ``argument'' pointer (third argument) to \Func{unw\_init\_remote}().
+
+\end{enumerate}
+
+In special circumstances, an application may prefer to use only
+portions of the \Prog{libunwind} ptrace remote.  For this reason, the individual
+callback routines (\Func{\_UPT\_find\_proc\_info}(),
+\Func{\_UPT\_put\_unwind\_info}(), etc.)  are also available for direct use.  Of
+course, the addresses of these routines could also be picked up from
+\Var{\_UPT\_accessors}, but doing so would prevent static initialization.  Also,
+when using \Var{\_UPT\_accessors}, \emph{all} the callback routines will be
+linked into the application, even if they are never actually called.
+
+The \Func{\_UPT\_resume}() routine can be used to resume execution of the target
+process.  It simply invokes \Func{ptrace}(2) with a command value of
+\Const{PTRACE\_CONT}.
+
+When the application is done using \Prog{libunwind} on the target process,
+\Func{\_UPT\_destroy}() needs to be called, passing it the opaque pointer that
+was returned by the call to \Func{\_UPT\_create}().  This ensures that all
+memory and other resources are freed up.
 
 \section{Availability}
 
-Since \Func{ptrace}(2) works within a single machine only, the
-\Prog{\_UPT}-facility by definition is not available in
-\Prog{libunwind}-versions configured for cross-unwinding.
+Since \Func{ptrace}(2) works within a single machine only, the libunwind ptrace
+remote by definition is not available in \Prog{libunwind} versions configured
+for cross-unwinding.
 
 \section{Thread Safety}
 
-The \Prog{\_UPT}-facility assumes that a single \Prog{\_UPT}-info
-structure is never shared between threads.  Because of this, no
-explicit locking is used.  As long as only one thread uses
-a \Prog{\_UPT}-info structure at any given time, this facility
-is thread-safe.
+The \Prog{libunwind} ptrace remote assumes that a single UPT info structure is
+never shared between threads.  Because of this, no explicit locking is used.  As
+long as only one thread uses a UPT info structure at any given time, this
+facility is thread-safe.
 
 \section{Return Value}
 
-\Func{\_UPT\_create}() may return a \Const{NULL} pointer if it fails
-to create the \Prog{\_UPT}-info-structure for any reason.  For the
-current implementation, the only reason this call may fail is when the
-system is out of memory.
+\Func{\_UPT\_create}() may return a \Const{NULL} pointer if it fails to create
+the UPT info structure for any reason.  For the current implementation, the only
+reason this call may fail is when the system is out of memory.
 
 \section{Files}
 
 \begin{Description}
-\item[\File{libunwind-ptrace.h}] Headerfile to include when using the
-  interface defined by this library.
+\item[\File{libunwind-ptrace.h}] Header file to include when using the
+    interface defined by this library.
 \item[\Opt{-l}\File{unwind-ptrace} \Opt{-l}\File{unwind-generic}]
-    Linker-switches to add when building a program that uses the
+    Linker switches to add when building a program that uses the
     functions defined by this library.
 \end{Description}
 
+\section{Example}
+\begin{verbatim}
+    #include <libunwind-ptrace.h>
+    #include <stdio.h>
+    #include <stdlib.h>
+
+    int
+    main (int argc, char **argv)
+    {
+      if (argc != 2) {
+        fprintf (stderr, "usage: %s PID\n", argv[0]);
+        exit (EXIT_FAILURE);
+      }
+
+      char *endptr;
+      pid_t target_pid = strtoul (argv[1], &endptr, 10);
+      if (target_pid == 0 && argv[1] == endptr) {
+        fprintf (stderr, "usage: %s PID\n", argv[0]);
+        exit (EXIT_FAILURE);
+      }
+
+      unw_addr_space_t as = unw_create_addr_space (&_UPT_accessors, 0);
+      if (!as) {
+        fprintf (stderr, "unw_create_addr_space() failed");
+        exit (EXIT_FAILURE);
+      }
+
+      void *ui = _UPT_create (target_pid);
+      if (!ui) {
+        fprintf (stderr, "_UPT_create() failed");
+        exit (EXIT_FAILURE);
+      }
+
+      unw_cursor_t cursor;
+      int ret = unw_init_remote (&cursor, as, ui);
+      if (ret < 0) {
+        fprintf (stderr, "unw_init_remote() failed: ret=%d\n", ret);
+        exit (EXIT_FAILURE);
+      }
+
+      do {
+        unw_proc_info_t pi;
+        ret = unw_get_proc_info (&cursor, &pi);
+        if (ret == -UNW_ENOINFO) {
+          fprintf (stdout, "no info\n");
+        } else if (ret >= 0) {
+          printf ("\tproc=%#016lx-%#016lx\thandler=%#016lx lsda=%#016lx",
+                  (long) pi.start_ip, (long) pi.end_ip,
+                  (long) pi.handler, (long) pi.lsda);
+        }
+        ret = unw_step (&cursor);
+      } while (ret > 0);
+      if (ret < 0) {
+        fprintf (stderr, "unwind failed with ret=%d\n", ret);
+        exit (EXIT_FAILURE);
+      }
+
+      _UPT_destroy (ui);
+      unw_destroy_addr_space (as);
+      exit (EXIT_SUCCESS);
+    }
+\end{verbatim}
+
 \section{See Also}
 
-execve(2),
-\SeeAlso{libunwind(3)},
-ptrace(2)
+\SeeAlso{execve}(2),
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{ptrace}(2)
 
 \section{Author}
 

--- a/doc/libunwind-setjmp.man
+++ b/doc/libunwind-setjmp.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:44 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 10:53:41 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "LIBUNWIND\-SETJMP" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "LIBUNWIND\-SETJMP" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 libunwind\-setjmp
 \-\- libunwind\-based non\-local gotos 
@@ -115,11 +117,13 @@ goto routines.
 .PP
 .SH SEE ALSO
 
-.PP
-libunwind(3),
-setjmp(3), longjmp(3), 
-_setjmp(3), _longjmp(3), 
-sigsetjmp(3), siglongjmp(3) 
+libunwind(3libunwind),
+setjmp(3),
+longjmp(3),
+_setjmp(3),
+_longjmp(3),
+sigsetjmp(3),
+siglongjmp(3)
 .PP
 .SH AUTHOR
 

--- a/doc/libunwind-setjmp.tex
+++ b/doc/libunwind-setjmp.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{libunwind-setjmp}{David Mosberger-Tang}{Programming Library}{libunwind-based non-local gotos}libunwind-setjmp -- libunwind-based non-local gotos
+\begin{Name}{3libunwind}{libunwind-setjmp}{David Mosberger-Tang}{Programming Library}{libunwind-based non-local gotos}libunwind-setjmp -- libunwind-based non-local gotos
 \end{Name}
 
 \section{Synopsis}
@@ -70,11 +70,10 @@ that frequently call \Func{setjmp}() but only rarely call
 
 
 \section{See Also}
-
-\SeeAlso{libunwind(3)},
-setjmp(3), longjmp(3),
-\_setjmp(3), \_longjmp(3),
-sigsetjmp(3), siglongjmp(3)
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{setjmp}(3), \SeeAlso{longjmp}(3),
+\SeeAlso{\_setjmp}(3), \SeeAlso{\_longjmp}(3),
+\SeeAlso{sigsetjmp}(3), \SeeAlso{siglongjmp}(3)
 
 \section{Author}
 

--- a/doc/libunwind.man
+++ b/doc/libunwind.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
+.\" Manual page created with latex2man on Tue Aug 29 11:06:25 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "LIBUNWIND" "3" "29 August 2021" "Programming Library " "Programming Library "
+.TH "LIBUNWIND" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 libunwind
 \-\- a (mostly) platform\-independent unwind API 
@@ -129,7 +131,7 @@ unwinding. Say
 you want to unwind the stack while executing in some function 
 F().
 In this function, you would call unw_getcontext()
-to get a snapshot of the CPU registers (machine\-state). Then you 
+to get a snapshot of the CPU registers (machine state). Then you 
 initialize an \fIunwind cursor\fP
 based on this snapshot. This is 
 done with a call to unw_init_local().
@@ -140,7 +142,7 @@ The unwind cursor can then
 be moved ``up\&'' (towards earlier stack frames) by calling 
 unw_step().
 By repeatedly calling this routine, you can 
-uncover the entire call\-chain that led to the activation of function 
+uncover the entire call chain that led to the activation of function 
 F().
 A positive return value from unw_step()
 indicates 
@@ -166,7 +168,7 @@ back prev
 to curr
 whenever that is necessary. In the most 
 extreme case, a program could maintain a separate cursor for each call 
-frame and that way it could move up and down the callframe\-chain at 
+frame and that way it could move up and down the callframe chain at 
 will. 
 .PP
 Given an unwind cursor, it is possible to read and write the CPU 
@@ -226,14 +228,14 @@ before including the headerfile
 It is perfectly OK for a single program to 
 employ both local\-only and generic unwinding. That is, whether or not 
 UNW_LOCAL_ONLY
-is defined is a choice that each source\-file 
-(compilation\-unit) can make on its own. Independent of the setting(s) 
+is defined is a choice that each source file 
+(compilation unit) can make on its own. Independent of the setting(s) 
 of UNW_LOCAL_ONLY,
 you\&'ll always link the same library into 
 the program (normally \fB\-l\fPunwind).
 Furthermore, the 
 portion of libunwind
-that manages unwind\-info for dynamically 
+that manages unwind info for dynamically 
 generated code is not affected by the setting of 
 UNW_LOCAL_ONLY\&.
 .PP
@@ -272,12 +274,12 @@ Remote unwinding is typically
 used by debuggers and instruction\-set simulators, for example. 
 .PP
 Before you can unwind a remote process, you need to create a new 
-address\-space object for that process. This is achieved with the 
+address space object for that process. This is achieved with the 
 unw_create_addr_space()
 routine. The routine takes two 
 arguments: a pointer to a set of \fIaccessor\fP
 routines and an 
-integer that specifies the byte\-order of the target process. The 
+integer that specifies the byte order of the target process. The 
 accessor routines provide libunwind
 with the means to 
 communicate with the remote process. In particular, there are 
@@ -288,7 +290,7 @@ With the address space created, unwinding can be initiated by a call
 to unw_init_remote().
 This routine is very similar to 
 unw_init_local(),
-except that it takes an address\-space 
+except that it takes an address space 
 object and an opaque pointer as arguments. The routine uses these 
 arguments to fetch the initial machine state. Libunwind
 never 
@@ -299,7 +301,7 @@ select, e.g., the thread within a process that is to be unwound.
 Once a cursor has been initialized with unw_init_remote(),
 unwinding works exactly like in the local case. That is, you can use 
 unw_step()
-to move ``up\&'' in the call\-chain, read and write 
+to move ``up\&'' in the call chain, read and write 
 registers, or resume execution at a particular stack frame by calling 
 unw_resume\&.
 .PP
@@ -362,7 +364,7 @@ simultaneously.
 However, any given cursor may be accessed by only one thread at 
 any given time. 
 .PP
-To ensure thread\-safety, some libunwind
+To ensure thread safety, some libunwind
 routines may have to 
 use locking. Such routines \fImust not\fP
 be called from signal 
@@ -374,7 +376,7 @@ any routine that may be needed for \fIlocal\fP
 unwinding is 
 signal\-safe (e.g., unw_step()
 for local unwinding is 
-signal\-safe). For remote\-unwinding, \fInone\fP
+signal\-safe). For remote unwinding, \fInone\fP
 of the 
 libunwind
 routines are guaranteed to be signal\-safe. 
@@ -396,15 +398,15 @@ high\-level language exception handling may not work as expected.
 .PP
 The interface for registering and canceling dynamic unwind info has 
 been designed for maximum efficiency, so as to minimize the 
-performance impact on JIT\-compilers. In particular, both routines are 
+performance impact on JIT compilers. In particular, both routines are 
 guaranteed to execute in ``constant time\&'' (O(1)) and the 
-data\-structure encapsulating the dynamic unwind info has been designed 
+data structure encapsulating the dynamic unwind info has been designed 
 to facilitate sharing, such that similar procedures can share much of 
 the underlying information. 
 .PP
 For more information on the libunwind
 support for dynamically 
-generated code, see libunwind\-dynamic(3)\&.
+generated code, see libunwind\-dynamic(3libunwind).
 .PP
 .SH CACHING OF UNWIND INFO
 
@@ -417,7 +419,7 @@ using
 stale data. For example, this would happen if libunwind
 were 
 to cache information about a shared library which later on gets 
-unloaded (e.g., via \fIdlclose\fP(3)).
+unloaded (e.g., via \fIdlclose\fP(3libunwind)).
 .PP
 To prevent the risk of using stale data, libunwind
 provides two 
@@ -428,7 +430,7 @@ unw_flush_cache().
 The second facility is provided by 
 unw_set_caching_policy(),
 which lets a program 
-select the exact caching policy in use for a given address\-space 
+select the exact caching policy in use for a given address space 
 object. In particular, by selecting the policy 
 UNW_CACHE_NONE,
 it is possible to turn off caching 
@@ -455,11 +457,11 @@ should be
 included. 
 .TP
 \fB\-l\fPunwind
- Linker\-switch to add when building a 
+ Linker switch to add when building a 
 program that does native (same platform) unwinding. 
 .TP
 \fB\-l\fPunwind\-PLAT
- Linker\-switch to add when 
+ Linker switch to add when 
 building a program that unwinds a program on platform PLAT\&.
 For example, to (cross\-)unwind an IA\-64 program, the linker switch 
 \-lunwind\-ia64
@@ -470,33 +472,33 @@ multiple platforms.
 .SH SEE ALSO
 
 .PP
-libunwind\-dynamic(3),
-libunwind\-ia64(3),
-libunwind\-ptrace(3),
-libunwind\-setjmp(3),
-unw_create_addr_space(3),
-unw_destroy_addr_space(3),
-unw_flush_cache(3),
-unw_get_accessors(3),
-unw_get_fpreg(3),
-unw_get_proc_info(3),
-unw_get_proc_name(3),
-unw_get_reg(3),
-unw_getcontext(3),
-unw_init_local(3),
-unw_init_remote(3),
-unw_is_fpreg(3),
-unw_is_signal_frame(3),
-unw_regname(3),
-unw_resume(3),
-unw_set_caching_policy(3),
-unw_set_cache_size(3),
-unw_set_fpreg(3),
-unw_set_reg(3),
-unw_step(3),
-unw_strerror(3),
-_U_dyn_register(3),
-_U_dyn_cancel(3)
+libunwind\-dynamic(3libunwind),
+libunwind\-ia64(3libunwind),
+libunwind\-ptrace(3libunwind),
+libunwind\-setjmp(3libunwind),
+unw_create_addr_space(3libunwind),
+unw_destroy_addr_space(3libunwind),
+unw_flush_cache(3libunwind),
+unw_get_accessors(3libunwind),
+unw_get_fpreg(3libunwind),
+unw_get_proc_info(3libunwind),
+unw_get_proc_name(3libunwind),
+unw_get_reg(3libunwind),
+unw_getcontext(3libunwind),
+unw_init_local(3libunwind),
+unw_init_remote(3libunwind),
+unw_is_fpreg(3libunwind),
+unw_is_signal_frame(3libunwind),
+unw_regname(3libunwind),
+unw_resume(3libunwind),
+unw_set_caching_policy(3libunwind),
+unw_set_cache_size(3libunwind),
+unw_set_fpreg(3libunwind),
+unw_set_reg(3libunwind),
+unw_step(3libunwind),
+unw_strerror(3libunwind),
+_U_dyn_register(3libunwind),
+_U_dyn_cancel(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/libunwind.tex
+++ b/doc/libunwind.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{libunwind}{David Mosberger-Tang}{Programming Library}{Introduction to libunwind}libunwind -- a (mostly) platform-independent unwind API
+\begin{Name}{3libunwind}{libunwind}{David Mosberger-Tang}{Programming Library}{Introduction to libunwind}libunwind -- a (mostly) platform-independent unwind API
 \end{Name}
 
 \section{Synopsis}
@@ -69,14 +69,14 @@
 within a running program.  This is called \emph{local} unwinding.  Say
 you want to unwind the stack while executing in some function
 \Func{F}().  In this function, you would call \Func{unw\_getcontext}()
-to get a snapshot of the CPU registers (machine-state).  Then you
+to get a snapshot of the CPU registers (machine state).  Then you
 initialize an \emph{unwind~cursor} based on this snapshot.  This is
 done with a call to \Func{unw\_init\_local}().  The cursor now points
 to the current frame, that is, the stack frame that corresponds to the
 current activation of function \Func{F}().  The unwind cursor can then
 be moved ``up'' (towards earlier stack frames) by calling
 \Func{unw\_step}().  By repeatedly calling this routine, you can
-uncover the entire call-chain that led to the activation of function
+uncover the entire call chain that led to the activation of function
 \Func{F}().  A positive return value from \Func{unw\_step}() indicates
 that there are more frames in the chain, zero indicates that the end
 of the chain has been reached, and any negative value indicates that
@@ -93,7 +93,7 @@ to \Var{prev} right before calling \Func{unw\_step}().  With this
 approach, the program could move one step ``down'' simply by copying
 back \Var{prev} to \Var{curr} whenever that is necessary.  In the most
 extreme case, a program could maintain a separate cursor for each call
-frame and that way it could move up and down the callframe-chain at
+frame and that way it could move up and down the callframe chain at
 will.
 
 Given an unwind cursor, it is possible to read and write the CPU
@@ -135,11 +135,11 @@ select this optimized version, simply define the macro
 \Const{UNW\_LOCAL\_ONLY} before including the headerfile
 \File{$<$libunwind.h$>$}.  It is perfectly OK for a single program to
 employ both local-only and generic unwinding.  That is, whether or not
-\Const{UNW\_LOCAL\_ONLY} is defined is a choice that each source-file
-(compilation-unit) can make on its own.  Independent of the setting(s)
+\Const{UNW\_LOCAL\_ONLY} is defined is a choice that each source file
+(compilation unit) can make on its own.  Independent of the setting(s)
 of \Const{UNW\_LOCAL\_ONLY}, you'll always link the same library into
 the program (normally \Opt{-l}\File{unwind}).  Furthermore, the
-portion of \Prog{libunwind} that manages unwind-info for dynamically
+portion of \Prog{libunwind} that manages unwind info for dynamically
 generated code is not affected by the setting of
 \Const{UNW\_LOCAL\_ONLY}.
 
@@ -175,10 +175,10 @@ one that is running \Prog{libunwind}.  Remote unwinding is typically
 used by debuggers and instruction-set simulators, for example.
 
 Before you can unwind a remote process, you need to create a new
-address-space object for that process.  This is achieved with the
+address space object for that process.  This is achieved with the
 \Func{unw\_create\_addr\_space}() routine.  The routine takes two
 arguments: a pointer to a set of \emph{accessor} routines and an
-integer that specifies the byte-order of the target process.  The
+integer that specifies the byte order of the target process.  The
 accessor routines provide \Func{libunwind} with the means to
 communicate with the remote process.  In particular, there are
 callbacks to read and write the process's memory, its registers, and
@@ -186,7 +186,7 @@ to access unwind information which may be needed by \Func{libunwind}.
 
 With the address space created, unwinding can be initiated by a call
 to \Func{unw\_init\_remote}().  This routine is very similar to
-\Func{unw\_init\_local}(), except that it takes an address-space
+\Func{unw\_init\_local}(), except that it takes an address space
 object and an opaque pointer as arguments.  The routine uses these
 arguments to fetch the initial machine state.  \Prog{Libunwind} never
 uses the opaque pointer on its own, but instead just passes it on to
@@ -195,7 +195,7 @@ select, e.g., the thread within a process that is to be unwound.
 
 Once a cursor has been initialized with \Func{unw\_init\_remote}(),
 unwinding works exactly like in the local case.  That is, you can use
-\Func{unw\_step}() to move ``up'' in the call-chain, read and write
+\Func{unw\_step}() to move ``up'' in the call chain, read and write
 registers, or resume execution at a particular stack frame by calling
 \Func{unw\_resume}.
 
@@ -242,14 +242,14 @@ that multiple threads may use \Prog{libunwind} simultaneously.
 However, any given cursor may be accessed by only one thread at
 any given time.
 
-To ensure thread-safety, some \Prog{libunwind} routines may have to
+To ensure thread safety, some \Prog{libunwind} routines may have to
 use locking.  Such routines \emph{must~not} be called from signal
 handlers (directly or indirectly) and are therefore \emph{not}
 signal-safe.  The manual page for each \Prog{libunwind} routine
 identifies whether or not it is signal-safe, but as a general rule,
 any routine that may be needed for \emph{local} unwinding is
 signal-safe (e.g., \Func{unw\_step}() for local unwinding is
-signal-safe).  For remote-unwinding, \emph{none} of the
+signal-safe).  For remote unwinding, \emph{none} of the
 \Prog{libunwind} routines are guaranteed to be signal-safe.
 
 
@@ -265,14 +265,14 @@ high-level language exception handling may not work as expected.
 
 The interface for registering and canceling dynamic unwind info has
 been designed for maximum efficiency, so as to minimize the
-performance impact on JIT-compilers.  In particular, both routines are
+performance impact on JIT compilers.  In particular, both routines are
 guaranteed to execute in ``constant time'' (O(1)) and the
-data-structure encapsulating the dynamic unwind info has been designed
+data structure encapsulating the dynamic unwind info has been designed
 to facilitate sharing, such that similar procedures can share much of
 the underlying information.
 
 For more information on the \Prog{libunwind} support for dynamically
-generated code, see \SeeAlso{libunwind-dynamic(3)}.
+generated code, see \SeeAlso{libunwind-dynamic}(3libunwind).
 
 
 \section{Caching of Unwind Info}
@@ -282,7 +282,7 @@ information it needs to perform unwinding.  If a process changes
 during its lifetime, this creates a risk of \Prog{libunwind} using
 stale data.  For example, this would happen if \Prog{libunwind} were
 to cache information about a shared library which later on gets
-unloaded (e.g., via \Cmd{dlclose}{3}).
+unloaded (e.g., via \Cmd{dlclose}{3libunwind}).
 
 To prevent the risk of using stale data, \Prog{libunwind} provides two
 facilities: first, it is possible to flush the cached information
@@ -290,7 +290,7 @@ associated with a specific address range in the target process (or the
 entire address space, if desired).  This functionality is provided by
 \Func{unw\_flush\_cache}().  The second facility is provided by
 \Func{unw\_set\_caching\_policy}(), which lets a program
-select the exact caching policy in use for a given address-space
+select the exact caching policy in use for a given address space
 object.  In particular, by selecting the policy
 \Const{UNW\_CACHE\_NONE}, it is possible to turn off caching
 completely, therefore eliminating the risk of stale data altogether
@@ -308,9 +308,9 @@ local unwinding only.  The cache size can be dynamically changed with
   the unwind target runs on platform \Var{PLAT}.  For example, to unwind
   an IA-64 program, the header file \File{libunwind-ia64.h} should be
   included.
-\item[\Opt{-l}\File{unwind}] Linker-switch to add when building a
+\item[\Opt{-l}\File{unwind}] Linker switch to add when building a
   program that does native (same platform) unwinding.
-\item[\Opt{-l}\File{unwind-}\Var{PLAT}] Linker-switch to add when
+\item[\Opt{-l}\File{unwind-}\Var{PLAT}] Linker switch to add when
   building a program that unwinds a program on platform \Var{PLAT}.
   For example, to (cross-)unwind an IA-64 program, the linker switch
   \File{-lunwind-ia64} should be added.  Note: multiple such switches
@@ -320,33 +320,33 @@ local unwinding only.  The cache size can be dynamically changed with
 
 \section{See Also}
 
-\SeeAlso{libunwind-dynamic(3)},
-\SeeAlso{libunwind-ia64(3)},
-\SeeAlso{libunwind-ptrace(3)},
-\SeeAlso{libunwind-setjmp(3)},
-\SeeAlso{unw\_create\_addr\_space(3)},
-\SeeAlso{unw\_destroy\_addr\_space(3)},
-\SeeAlso{unw\_flush\_cache(3)},
-\SeeAlso{unw\_get\_accessors(3)},
-\SeeAlso{unw\_get\_fpreg(3)},
-\SeeAlso{unw\_get\_proc\_info(3)},
-\SeeAlso{unw\_get\_proc\_name(3)},
-\SeeAlso{unw\_get\_reg(3)},
-\SeeAlso{unw\_getcontext(3)},
-\SeeAlso{unw\_init\_local(3)},
-\SeeAlso{unw\_init\_remote(3)},
-\SeeAlso{unw\_is\_fpreg(3)},
-\SeeAlso{unw\_is\_signal\_frame(3)},
-\SeeAlso{unw\_regname(3)},
-\SeeAlso{unw\_resume(3)},
-\SeeAlso{unw\_set\_caching\_policy(3)},
-\SeeAlso{unw\_set\_cache\_size(3)},
-\SeeAlso{unw\_set\_fpreg(3)},
-\SeeAlso{unw\_set\_reg(3)},
-\SeeAlso{unw\_step(3)},
-\SeeAlso{unw\_strerror(3)},
-\SeeAlso{\_U\_dyn\_register(3)},
-\SeeAlso{\_U\_dyn\_cancel(3)}
+\SeeAlso{libunwind-dynamic}(3libunwind),
+\SeeAlso{libunwind-ia64}(3libunwind),
+\SeeAlso{libunwind-ptrace}(3libunwind),
+\SeeAlso{libunwind-setjmp}(3libunwind),
+\SeeAlso{unw\_create\_addr\_space}(3libunwind),
+\SeeAlso{unw\_destroy\_addr\_space}(3libunwind),
+\SeeAlso{unw\_flush\_cache}(3libunwind),
+\SeeAlso{unw\_get\_accessors}(3libunwind),
+\SeeAlso{unw\_get\_fpreg}(3libunwind),
+\SeeAlso{unw\_get\_proc\_info}(3libunwind),
+\SeeAlso{unw\_get\_proc\_name}(3libunwind),
+\SeeAlso{unw\_get\_reg}(3libunwind),
+\SeeAlso{unw\_getcontext}(3libunwind),
+\SeeAlso{unw\_init\_local}(3libunwind),
+\SeeAlso{unw\_init\_remote}(3libunwind),
+\SeeAlso{unw\_is\_fpreg}(3libunwind),
+\SeeAlso{unw\_is\_signal\_frame}(3libunwind),
+\SeeAlso{unw\_regname}(3libunwind),
+\SeeAlso{unw\_resume}(3libunwind),
+\SeeAlso{unw\_set\_caching\_policy}(3libunwind),
+\SeeAlso{unw\_set\_cache\_size}(3libunwind),
+\SeeAlso{unw\_set\_fpreg}(3libunwind),
+\SeeAlso{unw\_set\_reg}(3libunwind),
+\SeeAlso{unw\_step}(3libunwind),
+\SeeAlso{unw\_strerror}(3libunwind),
+\SeeAlso{\_U\_dyn\_register}(3libunwind),
+\SeeAlso{\_U\_dyn\_cancel}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_apply_reg_state.man
+++ b/doc/unw_apply_reg_state.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Wed Aug 16 11:09:44 PDT 2017
+.\" Manual page created with latex2man on Tue Aug 29 12:09:48 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_APPLY\\_REG\\_STATE" "3" "16 August 2017" "Programming Library " "Programming Library "
+.TH "UNW\\_APPLY\\_REG\\_STATE" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_apply_reg_state
 \-\- apply a register state update to a cursor 
@@ -39,16 +41,16 @@ which have been obtained by calling unw_reg_states_iterate\&.
 .PP
 On successful completion, unw_apply_reg_state()
 returns 0. 
-Otherwise the negative value of one of the error\-codes below is 
+Otherwise the negative value of one of the error codes below is 
 returned. 
 .PP
 .SH THREAD AND SIGNAL SAFETY
 
 .PP
 unw_apply_reg_state()
-is thread\-safe. If cursor cp
+is thread safe. If cursor cp
 is 
-in the local address\-space, this routine is also safe to use from a 
+in the local address space, this routine is also safe to use from a 
 signal handler. 
 .PP
 .SH ERRORS
@@ -64,20 +66,20 @@ was unable to locate
 unwind\-info for the procedure. 
 .TP
 UNW_EBADVERSION
- The unwind\-info for the procedure has 
+ The unwind info for the procedure has 
 version or format that is not understood by libunwind\&.
 .PP
 In addition, unw_apply_reg_state()
 may return any error 
 returned by the access_mem()
 call\-back (see 
-unw_create_addr_space(3)).
+unw_create_addr_space(3libunwind)).
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_reg_states_iterate(3)
+libunwind(3libunwind),
+unw_reg_states_iterate(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_apply_reg_state.tex
+++ b/doc/unw_apply_reg_state.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_apply\_reg\_state}{David Mosberger-Tang}{Programming Library}{unw\_apply\_reg\_state}unw\_apply\_reg\_state -- apply a register state update to a cursor
+\begin{Name}{3libunwind}{unw\_apply\_reg\_state}{David Mosberger-Tang}{Programming Library}{unw\_apply\_reg\_state}unw\_apply\_reg\_state -- apply a register state update to a cursor
 \end{Name}
 
 \section{Synopsis}
@@ -25,13 +25,13 @@ which have been obtained by calling \Var{unw\_reg\_states\_iterate}.
 \section{Return Value}
 
 On successful completion, \Func{unw\_apply\_reg\_state}() returns 0.
-Otherwise the negative value of one of the error-codes below is
+Otherwise the negative value of one of the error codes below is
 returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_apply\_reg\_state}() is thread-safe.  If cursor \Var{cp} is
-in the local address-space, this routine is also safe to use from a
+\Func{unw\_apply\_reg\_state}() is thread safe.  If cursor \Var{cp} is
+in the local address space, this routine is also safe to use from a
 signal handler.
 
 \section{Errors}
@@ -40,17 +40,17 @@ signal handler.
 \item[\Const{UNW\_EUNSPEC}] An unspecified error occurred.
 \item[\Const{UNW\_ENOINFO}] \Prog{Libunwind} was unable to locate
   unwind-info for the procedure.
-\item[\Const{UNW\_EBADVERSION}] The unwind-info for the procedure has
+\item[\Const{UNW\_EBADVERSION}] The unwind info for the procedure has
   version or format that is not understood by \Prog{libunwind}.
 \end{Description}
 In addition, \Func{unw\_apply\_reg\_state}() may return any error
 returned by the \Func{access\_mem}() call-back (see
-\Func{unw\_create\_addr\_space}(3)).
+\Func{unw\_create\_addr\_space}(3libunwind)).
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_reg\_states\_iterate(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_reg\_states\_iterate}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_backtrace.man
+++ b/doc/unw_backtrace.man
@@ -1,7 +1,7 @@
 .\" *********************************** start of \input{common.tex}
 .\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Jan  5 15:33:00 2023
+.\" Manual page created with latex2man on Tue Aug 29 12:09:48 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -12,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_BACKTRACE" "3" "05 January 2023" "Programming Library " "Programming Library "
+.TH "UNW\\_BACKTRACE" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_backtrace
 \-\- return backtrace for the calling program 
@@ -91,8 +91,8 @@ stored.
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_step(3)
+libunwind(3libunwind),
+unw_step(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_backtrace.tex
+++ b/doc/unw_backtrace.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_backtrace}{David Mosberger-Tang}{Programming Library}{unw\_backtrace}unw\_backtrace -- return backtrace for the calling program
+\begin{Name}{3libunwind}{unw\_backtrace}{David Mosberger-Tang}{Programming Library}{unw\_backtrace}unw\_backtrace -- return backtrace for the calling program
 \end{Name}
 
 \section{Synopsis}
@@ -34,8 +34,8 @@ calling \Func{backtrace}() is linked against \Prog{libunwind}, it may end up
 calling \Func{unw\_backtrace}().
 
 In case you want to obtain the backtrace from a specific \Type{unw\_context\_t},
-you can call \Func{unw\_backtrace2} with that context passing \Const{0} for flag. 
-If the \Type{unw\_context_t} is known to be a signal frame (i.e., from the third argument
+you can call \Func{unw\_backtrace2} with that context passing \Const{0} for flag.
+If the \Type{unw\_context\_t} is known to be a signal frame (i.e., from the third argument
 in a sigaction handler on linux), \Func{unw\_backtrace2} can be used to collect
 only the frames before the signal frame passing the \Const{UNW\_INIT\_SIGNAL\_FRAME} flag.
 
@@ -47,8 +47,8 @@ stored.
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_step(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_step}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_create_addr_space.man
+++ b/doc/unw_create_addr_space.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 10:53:41 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_CREATE\\_ADDR\\_SPACE" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_CREATE\\_ADDR\\_SPACE" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_create_addr_space
 \-\- create address space for remote unwinding 
@@ -32,54 +34,54 @@ byteorder);
 .PP
 The unw_create_addr_space()
 routine creates a new unwind 
-address\-space and initializes it based on the call\-back routines 
+address space and initializes it based on the callback routines 
 passed via the ap
 pointer and the specified byteorder\&.
-The call\-back routines are described in detail below. The 
+The callback routines are described in detail below. The 
 byteorder
-can be set to 0 to request the default byte\-order of 
-the unwind target. To request a particular byte\-order, 
+can be set to 0 to request the default byte order of 
+the unwind target. To request a particular byte order, 
 byteorder
 can be set to any constant defined by 
 <endian.h>\&.
-In particular, __LITTLE_ENDIAN
+In particular, UNW_LITTLE_ENDIAN
 would 
-request little\-endian byte\-order and __BIG_ENDIAN
+request little\-endian byte order and UNW_BIG_ENDIAN
 would 
-request big\-endian byte\-order. Whether or not a particular byte\-order 
+request big\-endian byte order. Whether or not a particular byte order 
 is supported depends on the target platform. 
 .PP
-.SH CALL\-BACK ROUTINES
+.SH CALLBACK ROUTINES
 
 .PP
 Libunwind
-uses a set of call\-back routines to access the 
-information it needs to unwind a chain of stack\-frames. These 
+uses a set of callback routines to access the 
+information it needs to unwind a chain of stack frames. These 
 routines are specified via the ap
 argument, which points to a 
 variable of type unw_accessors_t\&.
 The contents of this 
-variable is copied into the newly\-created address space, so the 
+variable is copied into the newly created address space, so the 
 variable must remain valid only for the duration of the call to 
 unw_create_addr_space().
 .PP
-The first argument to every call\-back routine is an address\-space 
+The first argument to every callback routine is an address space 
 identifier (as)
 and the last argument is an arbitrary, 
-application\-specified void\-pointer (arg).
+application specified void pointer (arg).
 When invoking a 
-call\-back routine, libunwind
+callback routine, libunwind
 sets the as
 argument to the 
-address\-space on whose behalf the invocation is made and the arg
+address space on whose behalf the invocation is made and the arg
 argument to the value that was specified when 
-unw_init_remote(3)
+unw_init_remote(3libunwind)
 was called. 
 .PP
-The synopsis and a detailed description of every call\-back routine 
+The synopsis and a detailed description of every callback routine 
 follows below. 
 .PP
-.SS CALL\-BACK ROUTINE SYNOPSIS
+.SS CALLBACK ROUTINE SYNOPSIS
 .PP
 int
 find_proc_info(unw_addr_space_t
@@ -169,19 +171,19 @@ unw_word_t *offp,
 .PP
 Libunwind
 invokes the find_proc_info()
-call\-back to 
+callback to 
 locate the information need to unwind a particular procedure. The 
 ip
-argument is an instruction\-address inside the procedure whose 
+argument is an instruction address inside the procedure whose 
 information is needed. The pip
 argument is a pointer to the 
 variable used to return the desired information. The type of this 
 variable is unw_proc_info_t\&.
 See 
-unw_get_proc_info(3)
+unw_get_proc_info(3libunwind)
 for details. Argument 
 need_unwind_info
-is zero if the call\-back does not need to 
+is zero if the callback does not need to 
 provide values for the following members in the 
 unw_proc_info_t
 structure: format,
@@ -194,22 +196,22 @@ in these members. Furthermore, the contents of the memory addressed
 by the unwind_info
 member must remain valid until the info is 
 released via the put_unwind_info
-call\-back (see below). 
+callback (see below). 
 .PP
 On successful completion, the find_proc_info()
-call\-back must 
+callback must 
 return zero. Otherwise, the negative value of one of the 
 unw_error_t
-error\-codes may be returned. In particular, this 
-call\-back may return \-UNW_ESTOPUNWIND
+error codes may be returned. In particular, this 
+callback may return \-UNW_ESTOPUNWIND
 to signal the end of 
-the frame\-chain. 
+the frame chain. 
 .PP
 .SS PUT_UNWIND_INFO
 .PP
 Libunwind
 invokes the put_unwind_info()
-call\-back to 
+callback to 
 release the resources (such as memory) allocated by a previous call to 
 find_proc_info()
 with the need_unwind_info
@@ -229,36 +231,36 @@ argument.
 .PP
 Libunwind
 invokes the get_dyn_info_list_addr()
-call\-back to obtain the address of the head of the dynamic unwind\-info 
+callback to obtain the address of the head of the dynamic unwind info 
 registration list. The variable stored at the returned address must 
 have a type of unw_dyn_info_list_t
 (see 
-_U_dyn_register(3)).
+_U_dyn_register(3libunwind)).
 The dliap
 argument is a pointer 
 to a variable of type unw_word_t
 which is used to return the 
-address of the dynamic unwind\-info registration list. If no dynamic 
-unwind\-info registration list exist, the value pointed to by 
+address of the dynamic unwind info registration list. If no dynamic 
+unwind info registration list exist, the value pointed to by 
 dliap
 must be cleared to zero. Libunwind
 will cache the 
 value returned by get_dyn_info_list_addr()
 if caching is 
-enabled for the given address\-space. The cache can be cleared with a 
+enabled for the given address space. The cache can be cleared with a 
 call to unw_flush_cache().
 .PP
 On successful completion, the get_dyn_info_list_addr()
-call\-back must return zero. Otherwise, the negative value of one of 
+callback must return zero. Otherwise, the negative value of one of 
 the unw_error_t
-error\-codes may be returned. 
+error codes may be returned. 
 .PP
 .SS ACCESS_MEM
 .PP
 Libunwind
 invokes the access_mem()
-call\-back to read 
-from or write to a word of memory in the target address\-space. The 
+callback to read 
+from or write to a word of memory in the target address space. The 
 address of the word to be accessed is passed in argument addr\&.
 To read memory, libunwind
 sets argument write
@@ -272,21 +274,21 @@ value and valp
 to point to the word that contains the value to 
 be written. The word that valp
 points to is always in the 
-byte\-order of the host\-platform, regardless of the byte\-order of the 
-target. In other words, it is the responsibility of the call\-back 
-routine to convert between the target\&'s and the host\&'s byte\-order, if 
+byte order of the host platform, regardless of the byte order of the 
+target. In other words, it is the responsibility of the callback 
+routine to convert between the target\&'s and the host\&'s byte order, if 
 necessary. 
 .PP
 On successful completion, the access_mem()
-call\-back must return zero. Otherwise, the negative value of one of 
+callback must return zero. Otherwise, the negative value of one of 
 the unw_error_t
-error\-codes may be returned. 
+error codes may be returned. 
 .PP
 .SS ACCESS_REG
 .PP
 Libunwind
 invokes the access_reg()
-call\-back to read 
+callback to read 
 from or write to a scalar (non\-floating\-point) CPU register. The 
 index of the register to be accessed is passed in argument 
 regnum\&.
@@ -301,22 +303,22 @@ write
 to a non\-zero value and valp
 to point to the word 
 that contains the value to be written. The word that valp
-points to is always in the byte\-order of the host\-platform, regardless 
-of the byte\-order of the target. In other words, it is the 
-responsibility of the call\-back routine to convert between the 
-target\&'s and the host\&'s byte\-order, if necessary. 
+points to is always in the byte order of the host platform, regardless 
+of the byte order of the target. In other words, it is the 
+responsibility of the callback routine to convert between the 
+target\&'s and the host\&'s byte order, if necessary. 
 .PP
 On successful completion, the access_reg()
-call\-back must 
+callback must 
 return zero. Otherwise, the negative value of one of the 
 unw_error_t
-error\-codes may be returned. 
+error codes may be returned. 
 .PP
 .SS ACCESS_FPREG
 .PP
 Libunwind
 invokes the access_fpreg()
-call\-back to read 
+callback to read 
 from or write to a floating\-point CPU register. The index of the 
 register to be accessed is passed in argument regnum\&.
 To read a 
@@ -335,62 +337,62 @@ the variable of type unw_fpreg_t
 that contains the value to 
 be written. The word that fpvalp
 points to is always in the 
-byte\-order of the host\-platform, regardless of the byte\-order of the 
-target. In other words, it is the responsibility of the call\-back 
-routine to convert between the target\&'s and the host\&'s byte\-order, if 
+byte order of the host platform, regardless of the byte order of the 
+target. In other words, it is the responsibility of the callback 
+routine to convert between the target\&'s and the host\&'s byte order, if 
 necessary. 
 .PP
 On successful completion, the access_fpreg()
-call\-back must 
+callback must 
 return zero. Otherwise, the negative value of one of the 
 unw_error_t
-error\-codes may be returned. 
+error codes may be returned. 
 .PP
 .SS RESUME
 .PP
 Libunwind
 invokes the resume()
-call\-back to resume 
+callback to resume 
 execution in the target address space. Argument cp
 is the 
-unwind\-cursor that identifies the stack\-frame in which execution 
+unwind cursor that identifies the stack frame in which execution 
 should resume. By the time libunwind
 invokes the resume
-call\-back, it has already established the desired machine\- and 
-memory\-state via calls to the access_reg(),
+callback, it has already established the desired machine and 
+memory state via calls to the access_reg(),
 access_fpreg,
 and access_mem()
-call\-backs. Thus, all 
-the call\-back needs to do is perform whatever action is needed to 
+callbacks. Thus, all 
+the callback needs to do is perform whatever action is needed to 
 actually resume execution. 
 .PP
 The resume
-call\-back is invoked only in response to a call to 
-unw_resume(3),
+callback is invoked only in response to a call to 
+unw_resume(3libunwind),
 so applications which never invoke 
-unw_resume(3)
+unw_resume(3libunwind)
 need not define the resume
 callback. 
 .PP
 On successful completion, the resume()
-call\-back must return 
+callback must return 
 zero. Otherwise, the negative value of one of the 
 unw_error_t
-error\-codes may be returned. As a special case, 
-when resuming execution in the local address space, the call\-back will 
+error codes may be returned. As a special case, 
+when resuming execution in the local address space, the callback will 
 not return on success. 
 .PP
 .SS GET_PROC_NAME
 .PP
 Libunwind
 invokes the get_proc_name()
-call\-back to 
-obtain the procedure\-name of a static (not dynamically generated) 
+callback to 
+obtain the procedure name of a static (not dynamically generated) 
 procedure. Argument addr
-is an instruction\-address within the 
+is an instruction address within the 
 procedure whose name is to be obtained. The bufp
 argument is a 
-pointer to a character\-buffer used to return the procedure name. The 
+pointer to a character buffer used to return the procedure name. The 
 size of this buffer is specified in argument buf_len\&.
 The 
 returned name must be terminated by a NUL character. If the 
@@ -402,7 +404,7 @@ buffer set to the NUL character and \-UNW_ENOMEM
 must be 
 returned. Argument offp
 is a pointer to a word which is used to 
-return the byte\-offset relative to the start of the procedure whose 
+return the byte offset relative to the start of the procedure whose 
 name is being returned. For example, if procedure foo()
 starts 
 at address 0x40003000, then invoking get_proc_name()
@@ -414,10 +416,10 @@ pointed to by offp
 bytes long). 
 .PP
 On successful completion, the get_proc_name()
-call\-back must 
+callback must 
 return zero. Otherwise, the negative value of one of the 
 unw_error_t
-error\-codes may be returned. 
+error codes may be returned. 
 .PP
 .SH RETURN VALUE
 
@@ -426,7 +428,7 @@ On successful completion, unw_create_addr_space()
 returns a 
 non\-NULL
 value that represents the newly created 
-address\-space. Otherwise, NULL
+address space. Otherwise, NULL
 is returned. 
 .PP
 .SH THREAD AND SIGNAL SAFETY
@@ -439,12 +441,12 @@ safe to use from a signal handler.
 .SH SEE ALSO
 
 .PP
-_U_dyn_register(3),
-libunwind(3),
-unw_destroy_addr_space(3),
-unw_get_proc_info(3),
-unw_init_remote(3),
-unw_resume(3)
+_U_dyn_register(3libunwind),
+libunwind(3libunwind),
+unw_destroy_addr_space(3libunwind),
+unw_get_proc_info(3libunwind),
+unw_init_remote(3libunwind),
+unw_resume(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_create_addr_space.tex
+++ b/doc/unw_create_addr_space.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_create\_addr\_space}{David Mosberger-Tang}{Programming Library}{unw\_create\_addr\_space}unw\_create\_addr\_space -- create address space for remote unwinding
+\begin{Name}{3libunwind}{unw\_create\_addr\_space}{David Mosberger-Tang}{Programming Library}{unw\_create\_addr\_space}unw\_create\_addr\_space -- create address space for remote unwinding
 \end{Name}
 
 \section{Synopsis}
@@ -17,39 +17,39 @@
 \section{Description}
 
 The \Func{unw\_create\_addr\_space}() routine creates a new unwind
-address-space and initializes it based on the call-back routines
+address space and initializes it based on the callback routines
 passed via the \Var{ap} pointer and the specified \Var{byteorder}.
-The call-back routines are described in detail below.  The
-\Var{byteorder} can be set to 0 to request the default byte-order of
-the unwind target.  To request a particular byte-order,
+The callback routines are described in detail below.  The
+\Var{byteorder} can be set to 0 to request the default byte order of
+the unwind target.  To request a particular byte order,
 \Var{byteorder} can be set to any constant defined by
-\File{$<$endian.h$>$}.  In particular, \Const{\_\_LITTLE\_ENDIAN} would
-request little-endian byte-order and \Const{\_\_BIG\_ENDIAN} would
-request big-endian byte-order.  Whether or not a particular byte-order
+\File{$<$endian.h$>$}.  In particular, \Const{UNW\_LITTLE\_ENDIAN} would
+request little-endian byte order and \Const{UNW\_BIG\_ENDIAN} would
+request big-endian byte order.  Whether or not a particular byte order
 is supported depends on the target platform.
 
-\section{Call-back Routines}
+\section{Callback Routines}
 
-\Prog{Libunwind} uses a set of call-back routines to access the
-information it needs to unwind a chain of stack-frames.  These
+\Prog{Libunwind} uses a set of callback routines to access the
+information it needs to unwind a chain of stack frames.  These
 routines are specified via the \Var{ap} argument, which points to a
 variable of type \Type{unw\_accessors\_t}.  The contents of this
-variable is copied into the newly-created address space, so the
+variable is copied into the newly created address space, so the
 variable must remain valid only for the duration of the call to
 \Func{unw\_create\_addr\_space}().
 
-The first argument to every call-back routine is an address-space
+The first argument to every callback routine is an address space
 identifier (\Var{as}) and the last argument is an arbitrary,
-application-specified void-pointer (\Var{arg}).  When invoking a
-call-back routine, \Prog{libunwind} sets the \Var{as} argument to the
-address-space on whose behalf the invocation is made and the \Var{arg}
+application specified void pointer (\Var{arg}).  When invoking a
+callback routine, \Prog{libunwind} sets the \Var{as} argument to the
+address space on whose behalf the invocation is made and the \Var{arg}
 argument to the value that was specified when
-\Func{unw\_init\_remote}(3) was called.
+\Func{unw\_init\_remote}(3libunwind) was called.
 
-The synopsis and a detailed description of every call-back routine
+The synopsis and a detailed description of every callback routine
 follows below.
 
-\subsection{Call-back Routine Synopsis}
+\subsection{Callback Routine Synopsis}
 
 \Type{int} \Func{find\_proc\_info}(\Type{unw\_addr\_space\_t} \Var{as},\\
 \SP\SP\SP\SP\SP\SP\SP\SP\SP\SP\SP\SP\SP\SP\SP\SP\Type{unw\_word\_t} \Var{ip}, \Type{unw\_proc\_info\_t~*}\Var{pip},\\
@@ -76,31 +76,31 @@ follows below.
 
 \subsection{find\_proc\_info}
 
-\Prog{Libunwind} invokes the \Func{find\_proc\_info}() call-back to
+\Prog{Libunwind} invokes the \Func{find\_proc\_info}() callback to
 locate the information need to unwind a particular procedure.  The
-\Var{ip} argument is an instruction-address inside the procedure whose
+\Var{ip} argument is an instruction address inside the procedure whose
 information is needed.  The \Var{pip} argument is a pointer to the
 variable used to return the desired information.  The type of this
 variable is \Type{unw\_proc\_info\_t}.  See
-\Func{unw\_get\_proc\_info(3)} for details.  Argument
-\Var{need\_unwind\_info} is zero if the call-back does not need to
+\Func{unw\_get\_proc\_info}(3libunwind) for details.  Argument
+\Var{need\_unwind\_info} is zero if the callback does not need to
 provide values for the following members in the
 \Type{unw\_proc\_info\_t} structure: \Var{format},
 \Var{unwind\_info\_size}, and \Var{unwind\_info}.  If
 \Var{need\_unwind\_info} is non-zero, valid values need to be returned
 in these members.  Furthermore, the contents of the memory addressed
 by the \Var{unwind\_info} member must remain valid until the info is
-released via the \Func{put\_unwind\_info} call-back (see below).
+released via the \Func{put\_unwind\_info} callback (see below).
 
-On successful completion, the \Func{find\_proc\_info}() call-back must
+On successful completion, the \Func{find\_proc\_info}() callback must
 return zero.  Otherwise, the negative value of one of the
-\Type{unw\_error\_t} error-codes may be returned.  In particular, this
-call-back may return -\Const{UNW\_ESTOPUNWIND} to signal the end of
-the frame-chain.
+\Type{unw\_error\_t} error codes may be returned.  In particular, this
+callback may return -\Const{UNW\_ESTOPUNWIND} to signal the end of
+the frame chain.
 
 \subsection{put\_unwind\_info}
 
-\Prog{Libunwind} invokes the \Func{put\_unwind\_info}() call-back to
+\Prog{Libunwind} invokes the \Func{put\_unwind\_info}() callback to
 release the resources (such as memory) allocated by a previous call to
 \Func{find\_proc\_info}() with the \Var{need\_unwind\_info} argument
 set to a non-zero value.  The \Var{pip} argument has the same value as
@@ -113,44 +113,44 @@ with a zero \Var{need\_unwind\_info} argument.
 \subsection{get\_dyn\_info\_list\_addr}
 
 \Prog{Libunwind} invokes the \Func{get\_dyn\_info\_list\_addr}()
-call-back to obtain the address of the head of the dynamic unwind-info
+callback to obtain the address of the head of the dynamic unwind info
 registration list.  The variable stored at the returned address must
 have a type of \Type{unw\_dyn\_info\_list\_t} (see
-\Func{\_U\_dyn\_register}(3)).  The \Var{dliap} argument is a pointer
+\Func{\_U\_dyn\_register}(3libunwind)).  The \Var{dliap} argument is a pointer
 to a variable of type \Type{unw\_word\_t} which is used to return the
-address of the dynamic unwind-info registration list.  If no dynamic
-unwind-info registration list exist, the value pointed to by
+address of the dynamic unwind info registration list.  If no dynamic
+unwind info registration list exist, the value pointed to by
 \Var{dliap} must be cleared to zero.  \Prog{Libunwind} will cache the
 value returned by \Func{get\_dyn\_info\_list\_addr}() if caching is
-enabled for the given address-space.  The cache can be cleared with a
+enabled for the given address space.  The cache can be cleared with a
 call to \Func{unw\_flush\_cache}().
 
 On successful completion, the \Func{get\_dyn\_info\_list\_addr}()
-call-back must return zero.  Otherwise, the negative value of one of
-the \Type{unw\_error\_t} error-codes may be returned.
+callback must return zero.  Otherwise, the negative value of one of
+the \Type{unw\_error\_t} error codes may be returned.
 
 \subsection{access\_mem}
 
-\Prog{Libunwind} invokes the \Func{access\_mem}() call-back to read
-from or write to a word of memory in the target address-space.  The
+\Prog{Libunwind} invokes the \Func{access\_mem}() callback to read
+from or write to a word of memory in the target address space.  The
 address of the word to be accessed is passed in argument \Var{addr}.
 To read memory, \Prog{libunwind} sets argument \Var{write} to zero and
 \Var{valp} to point to the word that receives the read value.  To
 write memory, \Prog{libunwind} sets argument \Var{write} to a non-zero
 value and \Var{valp} to point to the word that contains the value to
 be written.  The word that \Var{valp} points to is always in the
-byte-order of the host-platform, regardless of the byte-order of the
-target.  In other words, it is the responsibility of the call-back
-routine to convert between the target's and the host's byte-order, if
+byte order of the host platform, regardless of the byte order of the
+target.  In other words, it is the responsibility of the callback
+routine to convert between the target's and the host's byte order, if
 necessary.
 
 On successful completion, the \Func{access\_mem}()
-call-back must return zero.  Otherwise, the negative value of one of
-the \Type{unw\_error\_t} error-codes may be returned.
+callback must return zero.  Otherwise, the negative value of one of
+the \Type{unw\_error\_t} error codes may be returned.
 
 \subsection{access\_reg}
 
-\Prog{Libunwind} invokes the \Func{access\_reg}() call-back to read
+\Prog{Libunwind} invokes the \Func{access\_reg}() callback to read
 from or write to a scalar (non-floating-point) CPU register.  The
 index of the register to be accessed is passed in argument
 \Var{regnum}.  To read a register, \Prog{libunwind} sets argument
@@ -158,18 +158,18 @@ index of the register to be accessed is passed in argument
 the read value.  To write a register, \Prog{libunwind} sets argument
 \Var{write} to a non-zero value and \Var{valp} to point to the word
 that contains the value to be written.  The word that \Var{valp}
-points to is always in the byte-order of the host-platform, regardless
-of the byte-order of the target.  In other words, it is the
-responsibility of the call-back routine to convert between the
-target's and the host's byte-order, if necessary.
+points to is always in the byte order of the host platform, regardless
+of the byte order of the target.  In other words, it is the
+responsibility of the callback routine to convert between the
+target's and the host's byte order, if necessary.
 
-On successful completion, the \Func{access\_reg}() call-back must
+On successful completion, the \Func{access\_reg}() callback must
 return zero.  Otherwise, the negative value of one of the
-\Type{unw\_error\_t} error-codes may be returned.
+\Type{unw\_error\_t} error codes may be returned.
 
 \subsection{access\_fpreg}
 
-\Prog{Libunwind} invokes the \Func{access\_fpreg}() call-back to read
+\Prog{Libunwind} invokes the \Func{access\_fpreg}() callback to read
 from or write to a floating-point CPU register.  The index of the
 register to be accessed is passed in argument \Var{regnum}.  To read a
 register, \Prog{libunwind} sets argument \Var{write} to zero and
@@ -178,67 +178,67 @@ receives the read value.  To write a register, \Prog{libunwind} sets
 argument \Var{write} to a non-zero value and \Var{fpvalp} to point to
 the variable of type \Type{unw\_fpreg\_t} that contains the value to
 be written.  The word that \Var{fpvalp} points to is always in the
-byte-order of the host-platform, regardless of the byte-order of the
-target.  In other words, it is the responsibility of the call-back
-routine to convert between the target's and the host's byte-order, if
+byte order of the host platform, regardless of the byte order of the
+target.  In other words, it is the responsibility of the callback
+routine to convert between the target's and the host's byte order, if
 necessary.
 
-On successful completion, the \Func{access\_fpreg}() call-back must
+On successful completion, the \Func{access\_fpreg}() callback must
 return zero.  Otherwise, the negative value of one of the
-\Type{unw\_error\_t} error-codes may be returned.
+\Type{unw\_error\_t} error codes may be returned.
 
 \subsection{resume}
 
-\Prog{Libunwind} invokes the \Func{resume}() call-back to resume
+\Prog{Libunwind} invokes the \Func{resume}() callback to resume
 execution in the target address space.  Argument \Var{cp} is the
-unwind-cursor that identifies the stack-frame in which execution
+unwind cursor that identifies the stack frame in which execution
 should resume.  By the time \Prog{libunwind} invokes the \Func{resume}
-call-back, it has already established the desired machine- and
-memory-state via calls to the \Func{access\_reg}(),
-\Func{access\_fpreg}, and \Func{access\_mem}() call-backs.  Thus, all
-the call-back needs to do is perform whatever action is needed to
+callback, it has already established the desired machine and
+memory state via calls to the \Func{access\_reg}(),
+\Func{access\_fpreg}, and \Func{access\_mem}() callbacks.  Thus, all
+the callback needs to do is perform whatever action is needed to
 actually resume execution.
 
-The \Func{resume} call-back is invoked only in response to a call to
-\Func{unw\_resume}(3), so applications which never invoke
-\Func{unw\_resume}(3) need not define the \Func{resume} callback.
+The \Func{resume} callback is invoked only in response to a call to
+\Func{unw\_resume}(3libunwind), so applications which never invoke
+\Func{unw\_resume}(3libunwind) need not define the \Func{resume} callback.
 
-On successful completion, the \Func{resume}() call-back must return
+On successful completion, the \Func{resume}() callback must return
 zero.  Otherwise, the negative value of one of the
-\Type{unw\_error\_t} error-codes may be returned.  As a special case,
-when resuming execution in the local address space, the call-back will
+\Type{unw\_error\_t} error codes may be returned.  As a special case,
+when resuming execution in the local address space, the callback will
 not return on success.
 
 \subsection{get\_proc\_name}
 
-\Prog{Libunwind} invokes the \Func{get\_proc\_name}() call-back to
-obtain the procedure-name of a static (not dynamically generated)
-procedure.  Argument \Var{addr} is an instruction-address within the
+\Prog{Libunwind} invokes the \Func{get\_proc\_name}() callback to
+obtain the procedure name of a static (not dynamically generated)
+procedure.  Argument \Var{addr} is an instruction address within the
 procedure whose name is to be obtained.  The \Var{bufp} argument is a
-pointer to a character-buffer used to return the procedure name.  The
+pointer to a character buffer used to return the procedure name.  The
 size of this buffer is specified in argument \Var{buf\_len}.  The
 returned name must be terminated by a NUL character.  If the
 procedure's name is longer than \Var{buf\_len} bytes, it must be
 truncated to \Var{buf\_len}\Prog{-1} bytes, with the last byte in the
 buffer set to the NUL character and -\Const{UNW\_ENOMEM} must be
 returned.  Argument \Var{offp} is a pointer to a word which is used to
-return the byte-offset relative to the start of the procedure whose
+return the byte offset relative to the start of the procedure whose
 name is being returned.  For example, if procedure \Func{foo}() starts
 at address 0x40003000, then invoking \Func{get\_proc\_name}() with
 \Var{addr} set to 0x40003080 should return a value of 0x80 in the word
 pointed to by \Var{offp} (assuming the procedure is at least 0x80
 bytes long).
 
-On successful completion, the \Func{get\_proc\_name}() call-back must
+On successful completion, the \Func{get\_proc\_name}() callback must
 return zero.  Otherwise, the negative value of one of the
-\Type{unw\_error\_t} error-codes may be returned.
+\Type{unw\_error\_t} error codes may be returned.
 
 
 \section{Return Value}
 
 On successful completion, \Func{unw\_create\_addr\_space}() returns a
 non-\Const{NULL} value that represents the newly created
-address-space.  Otherwise, \Const{NULL} is returned.
+address space.  Otherwise, \Const{NULL} is returned.
 
 \section{Thread and Signal Safety}
 
@@ -247,12 +247,12 @@ safe to use from a signal handler.
 
 \section{See Also}
 
-\SeeAlso{\_U\_dyn\_register(3)},
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_destroy\_addr\_space(3)},
-\SeeAlso{unw\_get\_proc\_info(3)},
-\SeeAlso{unw\_init\_remote(3)},
-\SeeAlso{unw\_resume(3)}
+\SeeAlso{\_U\_dyn\_register}(3libunwind),
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_destroy\_addr\_space}(3libunwind),
+\SeeAlso{unw\_get\_proc\_info}(3libunwind),
+\SeeAlso{unw\_init\_remote}(3libunwind),
+\SeeAlso{unw\_resume}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_destroy_addr_space.man
+++ b/doc/unw_destroy_addr_space.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 12:09:49 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_DESTROY\\_ADDR\\_SPACE" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_DESTROY\\_ADDR\\_SPACE" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_destroy_addr_space
 \-\- destroy unwind address space 
@@ -43,8 +45,8 @@ undefined behavior (e.g., the application may crash).
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_create_addr_space(3)
+libunwind(3libunwind),
+unw_create_addr_space(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_destroy_addr_space.tex
+++ b/doc/unw_destroy_addr_space.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_destroy\_addr\_space}{David Mosberger-Tang}{Programming Library}{unw\_destroy\_addr\_space}unw\_destroy\_addr\_space -- destroy unwind address space
+\begin{Name}{3libunwind}{unw\_destroy\_addr\_space}{David Mosberger-Tang}{Programming Library}{unw\_destroy\_addr\_space}unw\_destroy\_addr\_space -- destroy unwind address space
 \end{Name}
 
 \section{Synopsis}
@@ -26,8 +26,8 @@ undefined behavior (e.g., the application may crash).
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_create\_addr\_space(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_create\_addr\_space}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_flush_cache.man
+++ b/doc/unw_flush_cache.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Fri Dec  2 16:09:33 PST 2016
+.\" Manual page created with latex2man on Tue Aug 29 12:09:48 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_FLUSH\\_CACHE" "3" "02 December 2016" "Programming Library " "Programming Library "
+.TH "UNW\\_FLUSH\\_CACHE" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_flush_cache
 \-\- flush cached info 
@@ -35,15 +37,15 @@ hi);
 .PP
 The unw_flush_cache()
 routine flushes all cached info as it 
-relates to address\-range lo
+relates to address range lo
 to hi
 (non\-inclusive) in the 
-target address\-space as\&.
+target address space as\&.
 In addition, all info cached for 
-address\-space as
-that is not tied to a particular code\-range is 
+address space as
+that is not tied to a particular code range is 
 also flushed. For example, the address of the dynamic registration 
-list is not tied to a code\-range and its cached value (if any) is 
+list is not tied to a code range and its cached value (if any) is 
 flushed by a call to this routine. The address range specified by 
 lo
 and hi
@@ -72,15 +74,15 @@ return a value.
 
 .PP
 The unw_flush_cache()
-routine is thread\-safe as well as safe to 
+routine is thread safe as well as safe to 
 use from a signal handler. 
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_set_caching_policy(3)
-unw_set_cache_size(3)
+libunwind(3libunwind),
+unw_set_caching_policy(3libunwind)
+unw_set_cache_size(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_flush_cache.tex
+++ b/doc/unw_flush_cache.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_flush\_cache}{David Mosberger-Tang}{Programming Library}{unw\_flush\_cache}unw\_flush\_cache -- flush cached info
+\begin{Name}{3libunwind}{unw\_flush\_cache}{David Mosberger-Tang}{Programming Library}{unw\_flush\_cache}unw\_flush\_cache -- flush cached info
 \end{Name}
 
 \section{Synopsis}
@@ -17,11 +17,11 @@
 \section{Description}
 
 The \Func{unw\_flush\_cache}() routine flushes all cached info as it
-relates to address-range \Var{lo} to \Var{hi} (non-inclusive) in the
-target address-space \Var{as}.  In addition, all info cached for
-address-space \Var{as} that is not tied to a particular code-range is
+relates to address range \Var{lo} to \Var{hi} (non-inclusive) in the
+target address space \Var{as}.  In addition, all info cached for
+address space \Var{as} that is not tied to a particular code range is
 also flushed.  For example, the address of the dynamic registration
-list is not tied to a code-range and its cached value (if any) is
+list is not tied to a code range and its cached value (if any) is
 flushed by a call to this routine.  The address range specified by
 \Var{lo} and \Var{hi} should be understood as a hint:
 \Func{unw\_flush\_cache}() may flush more information than requested,
@@ -38,14 +38,14 @@ return a value.
 
 \section{Thread and Signal Safety}
 
-The \Func{unw\_flush\_cache}() routine is thread-safe as well as safe to
+The \Func{unw\_flush\_cache}() routine is thread safe as well as safe to
 use from a signal handler.
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_set\_caching\_policy(3)}
-\SeeAlso{unw\_set\_cache\_size(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_set\_caching\_policy}(3libunwind)
+\SeeAlso{unw\_set\_cache\_size}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_get_accessors.man
+++ b/doc/unw_get_accessors.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:44 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 12:09:48 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_GET\\_ACCESSORS" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_GET\\_ACCESSORS" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_get_accessors
 \-\- get pointer to accessor call\-backs 
@@ -30,18 +32,18 @@ unw_accessors_t *unw_get_accessors(unw_addr_space_t as);
 The unw_get_accessors()
 routine returns a pointer to a 
 unw_accessors_t
-structure, which contains the call\-back 
+structure, which contains the callback 
 routines that were specified when address space as
 was created 
-(see unw_create_addr_space(3)).
+(see unw_create_addr_space(3libunwind)).
 The returned pointer is 
 guaranteed to remain valid until address space as
 is destroyed 
-by a call to unw_destroy_addr_space(3).
+by a call to unw_destroy_addr_space(3libunwind).
 .PP
 Note that unw_get_accessors()
 can be used to retrieve the 
-call\-back routines for the local address space 
+callback routines for the local address space 
 unw_local_addr_space\&.
 .PP
 .SH RETURN VALUE
@@ -58,15 +60,15 @@ structure.
 
 .PP
 The unw_get_accessors()
-routine is thread\-safe as well as 
+routine is thread safe as well as 
 safe to use from a signal handler. 
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_create_addr_space(3),
-unw_destroy_addr_space(3)
+libunwind(3libunwind),
+unw_create_addr_space(3libunwind),
+unw_destroy_addr_space(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_get_accessors.tex
+++ b/doc/unw_get_accessors.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_get\_accessors}{David Mosberger-Tang}{Programming Library}{unw\_get\_accessors}unw\_get\_accessors -- get pointer to accessor call-backs
+\begin{Name}{3libunwind}{unw\_get\_accessors}{David Mosberger-Tang}{Programming Library}{unw\_get\_accessors}unw\_get\_accessors -- get pointer to accessor call-backs
 \end{Name}
 
 \section{Synopsis}
@@ -17,14 +17,14 @@
 \section{Description}
 
 The \Func{unw\_get\_accessors}() routine returns a pointer to a
-\Type{unw\_accessors\_t} structure, which contains the call-back
+\Type{unw\_accessors\_t} structure, which contains the callback
 routines that were specified when address space \Var{as} was created
-(see \Func{unw\_create\_addr\_space}(3)).  The returned pointer is
+(see \Func{unw\_create\_addr\_space}(3libunwind)).  The returned pointer is
 guaranteed to remain valid until address space \Var{as} is destroyed
-by a call to \Func{unw\_destroy\_addr\_space}(3).
+by a call to \Func{unw\_destroy\_addr\_space}(3libunwind).
 
 Note that \Func{unw\_get\_accessors}() can be used to retrieve the
-call-back routines for the local address space
+callback routines for the local address space
 \Var{unw\_local\_addr\_space}.
 
 \section{Return Value}
@@ -35,14 +35,14 @@ returns a valid (non-\Const{NULL}) pointer to an
 
 \section{Thread and Signal Safety}
 
-The \Func{unw\_get\_accessors}() routine is thread-safe as well as
+The \Func{unw\_get\_accessors}() routine is thread safe as well as
 safe to use from a signal handler.
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_create\_addr\_space(3)},
-\SeeAlso{unw\_destroy\_addr\_space(3)}
+\SeeAlso{libunwind(3libunwind)},
+\SeeAlso{unw\_create\_addr\_space(3libunwind)},
+\SeeAlso{unw\_destroy\_addr\_space(3libunwind)}
 
 \section{Author}
 

--- a/doc/unw_get_fpreg.man
+++ b/doc/unw_get_fpreg.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 11:45:59 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_GET\\_FPREG" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_GET\\_FPREG" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_get_fpreg
 \-\- get contents of floating\-point register 
@@ -38,20 +40,20 @@ in the stack frame identified by cursor cp
 and stores the value in the variable pointed to by valp\&.
 .PP
 The register numbering is target\-dependent and described in separate 
-manual pages (e.g., libunwind\-ia64(3) for the IA\-64 target). 
+manual pages (e.g., libunwind\-ia64(3libunwind) for the IA\-64 target). 
 Furthermore, the exact set of accessible registers may depend on the 
 type of frame that cp
 is referring to. For ordinary stack 
 frames, it is normally possible to access only the preserved 
 (``callee\-saved\&'') registers and frame\-related registers (such as the 
 stack\-pointer). However, for signal frames (see 
-unw_is_signal_frame(3)),
+unw_is_signal_frame(3libunwind)),
 it is usually possible to access 
 all registers. 
 .PP
 Note that unw_get_fpreg()
 can only read the contents of 
-floating\-point registers. See unw_get_fpreg(3)
+floating\-point registers. See unw_get_fpreg(3libunwind)
 for a way to 
 read registers which fit in a single word. 
 .PP
@@ -60,14 +62,14 @@ read registers which fit in a single word.
 .PP
 On successful completion, unw_get_fpreg()
 returns 0. 
-Otherwise the negative value of one of the error\-codes below is 
+Otherwise the negative value of one of the error codes below is 
 returned. 
 .PP
 .SH THREAD AND SIGNAL SAFETY
 
 .PP
 unw_get_fpreg()
-is thread\-safe as well as safe to use 
+is thread safe as well as safe to use 
 from a signal handler. 
 .PP
 .SH ERRORS
@@ -88,17 +90,17 @@ access_reg(),
 and 
 access_fpreg()
 call\-backs (see 
-unw_create_addr_space(3)).
+unw_create_addr_space(3libunwind)).
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-libunwind\-ia64(3),
-unw_get_reg(3),
-unw_is_fpreg(3),
-unw_is_signal_frame(3),
-unw_set_fpreg(3)
+libunwind(3libunwind),
+libunwind\-ia64(3libunwind),
+unw_get_reg(3libunwind),
+unw_is_fpreg(3libunwind),
+unw_is_signal_frame(3libunwind),
+unw_set_fpreg(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_get_fpreg.tex
+++ b/doc/unw_get_fpreg.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_get\_fpreg}{David Mosberger-Tang}{Programming Library}{unw\_get\_fpreg}unw\_get\_fpreg -- get contents of floating-point register
+\begin{Name}{3libunwind}{unw\_get\_fpreg}{David Mosberger-Tang}{Programming Library}{unw\_get\_fpreg}unw\_get\_fpreg -- get contents of floating-point register
 \end{Name}
 
 \section{Synopsis}
@@ -21,28 +21,28 @@ register \Var{reg} in the stack frame identified by cursor \Var{cp}
 and stores the value in the variable pointed to by \Var{valp}.
 
 The register numbering is target-dependent and described in separate
-manual pages (e.g., libunwind-ia64(3) for the IA-64 target).
+manual pages (e.g., libunwind-ia64(3libunwind) for the IA-64 target).
 Furthermore, the exact set of accessible registers may depend on the
 type of frame that \Var{cp} is referring to.  For ordinary stack
 frames, it is normally possible to access only the preserved
 (``callee-saved'') registers and frame-related registers (such as the
 stack-pointer).  However, for signal frames (see
-\Func{unw\_is\_signal\_frame}(3)), it is usually possible to access
+\Func{unw\_is\_signal\_frame}(3libunwind)), it is usually possible to access
 all registers.
 
 Note that \Func{unw\_get\_fpreg}() can only read the contents of
-floating-point registers.  See \Func{unw\_get\_fpreg}(3) for a way to
+floating-point registers.  See \Func{unw\_get\_fpreg}(3libunwind) for a way to
 read registers which fit in a single word.
 
 \section{Return Value}
 
 On successful completion, \Func{unw\_get\_fpreg}() returns 0.
-Otherwise the negative value of one of the error-codes below is
+Otherwise the negative value of one of the error codes below is
 returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_get\_fpreg}() is thread-safe as well as safe to use
+\Func{unw\_get\_fpreg}() is thread safe as well as safe to use
 from a signal handler.
 
 \section{Errors}
@@ -55,16 +55,16 @@ from a signal handler.
 In addition, \Func{unw\_get\_fpreg}() may return any error returned by
 the \Func{access\_mem}(), \Func{access\_reg}(), and
 \Func{access\_fpreg}() call-backs (see
-\Func{unw\_create\_addr\_space}(3)).
+\Func{unw\_create\_addr\_space}(3libunwind)).
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{libunwind-ia64(3)},
-\SeeAlso{unw\_get\_reg(3)},
-\SeeAlso{unw\_is\_fpreg(3)},
-\SeeAlso{unw\_is\_signal\_frame(3)},
-\SeeAlso{unw\_set\_fpreg(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{libunwind-ia64}(3libunwind),
+\SeeAlso{unw\_get\_reg}(3libunwind),
+\SeeAlso{unw\_is\_fpreg}(3libunwind),
+\SeeAlso{unw\_is\_signal\_frame}(3libunwind),
+\SeeAlso{unw\_set\_fpreg}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_get_proc_info.man
+++ b/doc/unw_get_proc_info.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
+.\" Manual page created with latex2man on Tue Aug 29 12:09:48 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_GET\\_PROC\\_INFO" "3" "29 August 2021" "Programming Library " "Programming Library "
+.TH "UNW\\_GET\\_PROC\\_INFO" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_get_proc_info
 \-\- get info on current procedure 
@@ -59,7 +61,7 @@ member is cleared to 0.
 .TP
 unw_word_t lsda
  The address of the 
-language\-specific data\-area (LSDA). This area normally contains 
+language\-specific data area (LSDA). This area normally contains 
 language\-specific information needed during exception handling. If 
 the procedure has no such area, this member is cleared to 0. 
 .br
@@ -73,11 +75,11 @@ member is cleared to 0.
 .br
 .TP
 unw_word_t gp
- The global\-pointer of the 
+ The global pointer of the 
 procedure. On platforms that do not use a global pointer, this 
 member may contain an undefined value. On all other platforms, it 
-must be set either to the correct global\-pointer value of the 
-procedure or to 0 if the proper global\-pointer cannot be 
+must be set either to the correct global pointer value of the 
+procedure or to 0 if the proper global pointer cannot be 
 obtained for some reason. 
 .br
 .TP
@@ -86,23 +88,23 @@ unw_word_t flags
 currently no target\-independent flags. For the IA\-64 target, the 
 flag UNW_PI_FLAG_IA64_RBS_SWITCH
 is set if the 
-procedure may switch the register\-backing store.
+procedure may switch the register backing store.
 .br
 .TP
 int format
- The format of the unwind\-info for this 
-procedure. If the unwind\-info consists of dynamic procedure info, 
+ The format of the unwind info for this 
+procedure. If the unwind info consists of dynamic procedure info, 
 format
 is equal to UNW_INFO_FORMAT_DYNAMIC\&.
 If the 
-unwind\-info consists of a (target\-specific) unwind table, it is 
+unwind info consists of a (target\-specific) unwind table, it is 
 equal to UNW_INFO_FORMAT_TABLE\&.
 All other values are 
 reserved for future use by libunwind\&.
 This member exists 
 for use by the find_proc_info()
-call\-back (see 
-unw_create_addr_space(3)).
+callback (see 
+unw_create_addr_space(3libunwind)).
 The 
 unw_get_proc_info()
 routine 
@@ -110,11 +112,11 @@ may return an undefined value in this member.
 .br
 .TP
 int unwind_info_size
- The size of the unwind\-info 
+ The size of the unwind info 
 in bytes. This member exists for use by the 
 find_proc_info()
-call\-back (see 
-unw_create_addr_space(3)).
+callback (see 
+unw_create_addr_space(3libunwind)).
 The 
 unw_get_proc_info()
 routine 
@@ -122,13 +124,13 @@ may return an undefined value in this member.
 .br
 .TP
 void *unwind_info
- The pointer to the unwind\-info. 
+ The pointer to the unwind info. 
 If no unwind info is available, this member must be set to 
 NULL\&.
 This member exists for use by the 
 find_proc_info()
-call\-back (see 
-unw_create_addr_space(3)).
+callback (see 
+unw_create_addr_space(3libunwind)).
 The 
 unw_get_proc_info()
 routine 
@@ -151,16 +153,16 @@ separate procedure.
 .PP
 On successful completion, unw_get_proc_info()
 returns 0. 
-Otherwise the negative value of one of the error\-codes below is 
+Otherwise the negative value of one of the error codes below is 
 returned. 
 .PP
 .SH THREAD AND SIGNAL SAFETY
 
 .PP
 unw_get_proc_info()
-is thread\-safe. If cursor cp
+is thread safe. If cursor cp
 is 
-in the local address\-space, this routine is also safe to use from a 
+in the local address space, this routine is also safe to use from a 
 signal handler. 
 .PP
 .SH ERRORS
@@ -173,24 +175,24 @@ UNW_EUNSPEC
 UNW_ENOINFO
  Libunwind
 was unable to locate 
-unwind\-info for the procedure. 
+unwind info for the procedure. 
 .TP
 UNW_EBADVERSION
- The unwind\-info for the procedure has 
+ The unwind info for the procedure has 
 version or format that is not understood by libunwind\&.
 .PP
 In addition, unw_get_proc_info()
 may return any error 
 returned by the access_mem()
-call\-back (see 
-unw_create_addr_space(3)).
+callback (see 
+unw_create_addr_space(3libunwind)).
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_create_addr_space(3),
-unw_get_proc_name(3)
+libunwind(3libunwind),
+unw_create_addr_space(3libunwind),
+unw_get_proc_name(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_get_proc_info.tex
+++ b/doc/unw_get_proc_info.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_get\_proc\_info}{David Mosberger-Tang}{Programming Library}{unw\_get\_proc\_info}unw\_get\_proc\_info -- get info on current procedure
+\begin{Name}{3libunwind}{unw\_get\_proc\_info}{David Mosberger-Tang}{Programming Library}{unw\_get\_proc\_info}unw\_get\_proc\_info -- get info on current procedure
 \end{Name}
 
 \section{Synopsis}
@@ -32,44 +32,44 @@ following members:
   cannot be determined (e.g., due to lack of unwind information),
   the \Var{end\_ip} member is cleared to 0.  \\
 \item[\Type{unw\_word\_t} \Var{lsda}] The address of the
-  language-specific data-area (LSDA).  This area normally contains
+  language-specific data area (LSDA).  This area normally contains
   language-specific information needed during exception handling.  If
   the procedure has no such area, this member is cleared to 0.  \\
 \item[\Type{unw\_word\_t} \Var{handler}] The address of the exception
   handler routine.  This is sometimes called the \emph{personality}
   routine.  If the procedure does not define
   a personality routine, the \Var{handler} member is cleared to 0.  \\
-\item[\Type{unw\_word\_t} \Var{gp}] The global-pointer of the
+\item[\Type{unw\_word\_t} \Var{gp}] The global pointer of the
   procedure.  On platforms that do not use a global pointer, this
   member may contain an undefined value.  On all other platforms, it
-  must be set either to the correct global-pointer value of the
-  procedure or to 0 if the proper global-pointer cannot be
+  must be set either to the correct global pointer value of the
+  procedure or to 0 if the proper global pointer cannot be
   obtained for some reason.  \\
 \item[\Type{unw\_word\_t} \Var{flags}] A set of flags.  There are
   currently no target-independent flags.  For the IA-64 target, the
   flag \Const{UNW\_PI\_FLAG\_IA64\_RBS\_SWITCH} is set if the
-  procedure may switch the register-backing store.\\
-\item[\Type{int} \Var{format}] The format of the unwind-info for this
-  procedure.  If the unwind-info consists of dynamic procedure info,
+  procedure may switch the register backing store.\\
+\item[\Type{int} \Var{format}] The format of the unwind info for this
+  procedure.  If the unwind info consists of dynamic procedure info,
   \Var{format} is equal to \Const{UNW\_INFO\_FORMAT\_DYNAMIC}.  If the
-  unwind-info consists of a (target-specific) unwind table, it is
+  unwind info consists of a (target-specific) unwind table, it is
   equal to \Const{UNW\_INFO\_FORMAT\_TABLE}.  All other values are
   reserved for future use by \Prog{libunwind}.  This member exists
-  for use by the \Func{find\_proc\_info}() call-back (see
-  \Func{unw\_create\_addr\_space}(3)).  The
+  for use by the \Func{find\_proc\_info}() callback (see
+  \Func{unw\_create\_addr\_space}(3libunwind)).  The
   \Func{unw\_get\_proc\_info}() routine
   may return an undefined value in this member. \\
-\item[\Type{int} \Var{unwind\_info\_size}] The size of the unwind-info
+\item[\Type{int} \Var{unwind\_info\_size}] The size of the unwind info
   in bytes.  This member exists for use by the
-  \Func{find\_proc\_info}() call-back (see
-  \Func{unw\_create\_addr\_space}(3)).  The
+  \Func{find\_proc\_info}() callback (see
+  \Func{unw\_create\_addr\_space}(3libunwind)).  The
   \Func{unw\_get\_proc\_info}() routine
   may return an undefined value in this member.\\
-\item[\Type{void~*}\Var{unwind\_info}] The pointer to the unwind-info.
+\item[\Type{void~*}\Var{unwind\_info}] The pointer to the unwind info.
   If no unwind info is available, this member must be set to
   \Const{NULL}.  This member exists for use by the
-  \Func{find\_proc\_info}() call-back (see
-  \Func{unw\_create\_addr\_space}(3)).  The
+  \Func{find\_proc\_info}() callback (see
+  \Func{unw\_create\_addr\_space}(3libunwind)).  The
   \Func{unw\_get\_proc\_info}() routine
   may return an undefined value in this member.\\
 \end{description}
@@ -84,13 +84,13 @@ separate procedure.
 \section{Return Value}
 
 On successful completion, \Func{unw\_get\_proc\_info}() returns 0.
-Otherwise the negative value of one of the error-codes below is
+Otherwise the negative value of one of the error codes below is
 returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_get\_proc\_info}() is thread-safe.  If cursor \Var{cp} is
-in the local address-space, this routine is also safe to use from a
+\Func{unw\_get\_proc\_info}() is thread safe.  If cursor \Var{cp} is
+in the local address space, this routine is also safe to use from a
 signal handler.
 
 \section{Errors}
@@ -98,19 +98,19 @@ signal handler.
 \begin{Description}
 \item[\Const{UNW\_EUNSPEC}] An unspecified error occurred.
 \item[\Const{UNW\_ENOINFO}] \Prog{Libunwind} was unable to locate
-  unwind-info for the procedure.
-\item[\Const{UNW\_EBADVERSION}] The unwind-info for the procedure has
+  unwind info for the procedure.
+\item[\Const{UNW\_EBADVERSION}] The unwind info for the procedure has
   version or format that is not understood by \Prog{libunwind}.
 \end{Description}
 In addition, \Func{unw\_get\_proc\_info}() may return any error
-returned by the \Func{access\_mem}() call-back (see
-\Func{unw\_create\_addr\_space}(3)).
+returned by the \Func{access\_mem}() callback (see
+\Func{unw\_create\_addr\_space}(3libunwind)).
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_create\_addr\_space(3)},
-\SeeAlso{unw\_get\_proc\_name(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_create\_addr\_space}(3libunwind),
+\SeeAlso{unw\_get\_proc\_name}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_get_proc_info_by_ip.man
+++ b/doc/unw_get_proc_info_by_ip.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
+.\" Manual page created with latex2man on Tue Aug 29 11:45:59 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_GET\\_PROC\\_INFO\\_BY\\_IP" "3" "29 August 2021" "Programming Library " "Programming Library "
+.TH "UNW\\_GET\\_PROC\\_INFO\\_BY\\_IP" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_get_proc_info_by_ip
 \-\- get procedure info by IP 
@@ -38,13 +40,13 @@ unw_get_proc_info(),
 except that the info is looked up by 
 instruction\-pointer (IP) instead of a cursor. This is more flexible 
 because it is possible to look up the info for an arbitrary procedure, 
-even if it is not part of the current call\-chain. However, since it 
+even if it is not part of the current call chain. However, since it 
 is more flexible, it also tends to run slower (and often much slower) 
 than unw_get_proc_info().
 .PP
 The routine expects the following arguments: as
 is the 
-address\-space in which the instruction\-pointer should be looked up. 
+address\-space in which the instruction pointer should be looked up. 
 For a look\-up in the local address\-space, 
 unw_local_addr_space
 can be passed for this argument. 
@@ -55,11 +57,11 @@ is a pointer to a structure of
 type unw_proc_info_t
 which is used to return the info. 
 Lastly, arg
-is the address\-space argument that should be used 
-when accessing the address\-space. It has the same purpose as the 
+is the address space argument that should be used 
+when accessing the address space. It has the same purpose as the 
 argument of the same name for unw_init_remote().
 When 
-accessing the local address\-space (first argument is 
+accessing the local address space (first argument is 
 unw_local_addr_space),
 NULL
 must be passed for this 
@@ -87,8 +89,8 @@ below is returned.
 
 .PP
 unw_get_proc_info_by_ip()
-is thread\-safe. If the local 
-address\-space is passed in argument as,
+is thread safe. If the local 
+address space is passed in argument as,
 this routine is also 
 safe to use from a signal handler. 
 .PP
@@ -111,17 +113,17 @@ version or format that is not understood by libunwind\&.
 In addition, unw_get_proc_info_by_ip()
 may return any 
 error returned by the access_mem()
-call\-back (see 
-unw_create_addr_space(3)).
+callback (see 
+unw_create_addr_space(3libunwind)).
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_create_addr_space(3),
-unw_get_proc_name(3),
-unw_get_proc_info(3),
-unw_init_remote(3)
+libunwind(3libunwind),
+unw_create_addr_space(3libunwind),
+unw_get_proc_name(3libunwind),
+unw_get_proc_info(3libunwind),
+unw_init_remote(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_get_proc_info_by_ip.tex
+++ b/doc/unw_get_proc_info_by_ip.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_get\_proc\_info\_by\_ip}{David Mosberger-Tang}{Programming Library}{unw\_get\_proc\_info\_by\_ip}unw\_get\_proc\_info\_by\_ip -- get procedure info by IP
+\begin{Name}{3libunwind}{unw\_get\_proc\_info\_by\_ip}{David Mosberger-Tang}{Programming Library}{unw\_get\_proc\_info\_by\_ip}unw\_get\_proc\_info\_by\_ip -- get procedure info by IP
 \end{Name}
 
 \section{Synopsis}
@@ -21,21 +21,21 @@ kind of auxiliary information about a procedure as
 \Func{unw\_get\_proc\_info}(), except that the info is looked up by
 instruction-pointer (IP) instead of a cursor.  This is more flexible
 because it is possible to look up the info for an arbitrary procedure,
-even if it is not part of the current call-chain.  However, since it
+even if it is not part of the current call chain.  However, since it
 is more flexible, it also tends to run slower (and often much slower)
 than \Func{unw\_get\_proc\_info}().
 
 The routine expects the following arguments: \Var{as} is the
-address-space in which the instruction-pointer should be looked up.
+address-space in which the instruction pointer should be looked up.
 For a look-up in the local address-space,
 \Var{unw\_local\_addr\_space} can be passed for this argument.
 Argument \Var{ip} is the instruction-pointer for which the procedure
 info should be looked up and \Var{pip} is a pointer to a structure of
 type \Type{unw\_proc\_info\_t} which is used to return the info.
-Lastly, \Var{arg} is the address-space argument that should be used
-when accessing the address-space.  It has the same purpose as the
+Lastly, \Var{arg} is the address space argument that should be used
+when accessing the address space.  It has the same purpose as the
 argument of the same name for \Func{unw\_init\_remote}().  When
-accessing the local address-space (first argument is
+accessing the local address space (first argument is
 \Var{unw\_local\_addr\_space}), \Const{NULL} must be passed for this
 argument.
 
@@ -55,8 +55,8 @@ below is returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_get\_proc\_info\_by\_ip}() is thread-safe.  If the local
-address-space is passed in argument \Var{as}, this routine is also
+\Func{unw\_get\_proc\_info\_by\_ip}() is thread safe.  If the local
+address space is passed in argument \Var{as}, this routine is also
 safe to use from a signal handler.
 
 \section{Errors}
@@ -69,16 +69,16 @@ safe to use from a signal handler.
   version or format that is not understood by \Prog{libunwind}.
 \end{Description}
 In addition, \Func{unw\_get\_proc\_info\_by\_ip}() may return any
-error returned by the \Func{access\_mem}() call-back (see
-\Func{unw\_create\_addr\_space}(3)).
+error returned by the \Func{access\_mem}() callback (see
+\Func{unw\_create\_addr\_space}(3libunwind)).
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_create\_addr\_space(3)},
-\SeeAlso{unw\_get\_proc\_name(3)},
-\SeeAlso{unw\_get\_proc\_info(3)},
-\SeeAlso{unw\_init\_remote(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_create\_addr\_space}(3libunwind),
+\SeeAlso{unw\_get\_proc\_name}(3libunwind),
+\SeeAlso{unw\_get\_proc\_info}(3libunwind),
+\SeeAlso{unw\_init\_remote}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_get_proc_info_in_range.man
+++ b/doc/unw_get_proc_info_in_range.man
@@ -1,7 +1,7 @@
 .\" *********************************** start of \input{common.tex}
 .\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Wed Jun 29 18:53:42 2022
+.\" Manual page created with latex2man on Tue Aug 29 11:45:59 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -12,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_GET\\_PROC\\_INFO\\_IN\\_RANGE" "3" "29 June 2022" "Programming Library " "Programming Library "
+.TH "UNW\\_GET\\_PROC\\_INFO\\_IN\\_RANGE" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_get_proc_info_in_range
 \-\- get procedure info in IP range and a frame index table 
@@ -42,9 +42,9 @@ routine returns the same
 kind of auxiliary information about a procedure as 
 unw_get_proc_info_by_ip(),
 except that the info is looked up in 
-instruction\-pointer (IP) range and frame table instead of just at IP. This 
+instruction pointer (IP) range and frame table instead of just at IP. This 
 is equally flexible because it is possible to look up the info for an arbitrary 
-procedure, even if it is not part of the current call\-chain. However, since it 
+procedure, even if it is not part of the current call chain. However, since it 
 is more flexible, it also tends to run slower (and often much slower) 
 than unw_get_proc_info().
 .PP
@@ -59,8 +59,8 @@ below is returned.
 
 .PP
 unw_get_proc_info_in_range()
-is thread\-safe. If the local 
-address\-space is passed in argument as,
+is thread safe. If the local 
+address space is passed in argument as,
 this routine is also 
 safe to use from a signal handler. 
 .PP
@@ -86,17 +86,17 @@ UNW_EINVAL
 In addition, unw_get_proc_info_by_ip()
 may return any 
 error returned by the access_mem()
-call\-back (see 
-unw_create_addr_space(3)).
+callback (see 
+unw_create_addr_space(3libunwind)).
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_get_proc_info_in_range(3),
-unw_create_addr_space(3),
-unw_get_proc_name(3),
-unw_get_proc_info(3)
+libunwind(3libunwind),
+unw_get_proc_info_in_range(3libunwind),
+unw_create_addr_space(3libunwind),
+unw_get_proc_name(3libunwind),
+unw_get_proc_info(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_get_proc_info_in_range.tex
+++ b/doc/unw_get_proc_info_in_range.tex
@@ -5,23 +5,23 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_get\_proc\_info\_in\_range}{David Mosberger-Tang}{Programming Library}{unw\_get\_proc\_info\_in\_range}unw\_get\_proc\_info\_in\_range -- get procedure info in IP range and a frame index table
+\begin{Name}{3libunwind}{unw\_get\_proc\_info\_in\_range}{David Mosberger-Tang}{Programming Library}{unw\_get\_proc\_info\_in\_range}unw\_get\_proc\_info\_in\_range -- get procedure info in IP range and a frame index table
 \end{Name}
 
 \section{Synopsis}
 
 \File{\#include $<$libunwind.h$>$}\\
 
-\Type{int} \Func{unw\_get\_proc\_info\_in\_range}(\Type{unw\_word\_t~}\Var{start_ip}, \Type{unw\_word\_t~}\Var{end_ip}, \Type{unw\_word\_t~}\Var{eh_frame_table}, \Type{unw\_word\_t~}\Var{eh_frame_table_len}, \Type{unw\_word\_t~}\Var{exidx_frame_table}, \Type{unw\_word\_t~}\Var{exidx_frame_table_len,}, \Type{unw\_addr\_space\_t~*}\Var{as}, \Type{void~*}\Var{arg});\\
+\Type{int} \Func{unw\_get\_proc\_info\_in\_range}(\Type{unw\_word\_t~}\Var{start\_ip}, \Type{unw\_word\_t~}\Var{end_ip}, \Type{unw\_word\_t~}\Var{eh_frame_table}, \Type{unw\_word\_t~}\Var{eh_frame_table_len}, \Type{unw\_word\_t~}\Var{exidx_frame_table}, \Type{unw\_word\_t~}\Var{exidx_frame_table_len,}, \Type{unw\_addr\_space\_t~*}\Var{as}, \Type{void~*}\Var{arg});\\
 
 \section{Description}
 
 The \Func{unw\_get\_proc\_info\_in\_range}() routine returns the same
 kind of auxiliary information about a procedure as
 \Func{unw\_get\_proc\_info\_by\_ip}(), except that the info is looked up in
-instruction-pointer (IP) range and frame table instead of just at IP.  This
+instruction pointer (IP) range and frame table instead of just at IP.  This
 is equally flexible because it is possible to look up the info for an arbitrary
-procedure, even if it is not part of the current call-chain.  However, since it
+procedure, even if it is not part of the current call chain.  However, since it
 is more flexible, it also tends to run slower (and often much slower)
 than \Func{unw\_get\_proc\_info}().
 
@@ -33,8 +33,8 @@ below is returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_get\_proc\_info\_in\_range}() is thread-safe.  If the local
-address-space is passed in argument \Var{as}, this routine is also
+\Func{unw\_get\_proc\_info\_in\_range}() is thread safe.  If the local
+address space is passed in argument \Var{as}, this routine is also
 safe to use from a signal handler.
 
 \section{Errors}
@@ -48,16 +48,16 @@ safe to use from a signal handler.
 \item[\Const{UNW\_EINVAL}] An unsupported table encoding was specified.
 \end{Description}
 In addition, \Func{unw\_get\_proc\_info\_by\_ip}() may return any
-error returned by the \Func{access\_mem}() call-back (see
-\Func{unw\_create\_addr\_space}(3)).
+error returned by the \Func{access\_mem}() callback (see
+\Func{unw\_create\_addr\_space}(3libunwind)).
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_get\_proc\_info\_in\_range(3)},
-\SeeAlso{unw\_create\_addr\_space(3)},
-\SeeAlso{unw\_get\_proc\_name(3)},
-\SeeAlso{unw\_get\_proc\_info(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_get\_proc\_info\_in\_range}(3libunwind),
+\SeeAlso{unw\_create\_addr\_space}(3libunwind),
+\SeeAlso{unw\_get\_proc\_name}(3libunwind),
+\SeeAlso{unw\_get\_proc\_info}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_get_proc_name.man
+++ b/doc/unw_get_proc_name.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
+.\" Manual page created with latex2man on Tue Aug 29 12:09:48 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_GET\\_PROC\\_NAME" "3" "29 August 2021" "Programming Library " "Programming Library "
+.TH "UNW\\_GET\\_PROC\\_NAME" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_get_proc_name
 \-\- get name of current procedure 
@@ -42,14 +44,14 @@ that is at least len
 bytes long. This buffer is used to return 
 the name of the procedure. The offp
 argument is a pointer to a 
-word that is used to return the byte\-offset of the instruction\-pointer 
+word that is used to return the byte offset of the instruction\-pointer 
 saved in the stack frame identified by cp,
 relative to the start 
 of the procedure. For example, if procedure foo()
 starts at 
 address 0x40003000, then invoking unw_get_proc_name()
 on a 
-stack frame with an instruction\-pointer value of 0x40003080 would 
+stack frame with an instruction pointer value of 0x40003080 would 
 return a value of 0x80 in the word pointed to by offp
 (assuming 
 the procedure is at least 0x80 bytes long). 
@@ -64,23 +66,23 @@ However, the offset returned through offp
 is always relative to 
 the returned name, which ensures that the value (address) of the 
 returned name plus the returned offset will always be equal to the 
-instruction\-pointer of the stack frame identified by cp\&.
+instruction pointer of the stack frame identified by cp\&.
 .PP
 .SH RETURN VALUE
 
 .PP
 On successful completion, unw_get_proc_name()
 returns 0. 
-Otherwise the negative value of one of the error\-codes below is 
+Otherwise the negative value of one of the error codes below is 
 returned. 
 .PP
 .SH THREAD AND SIGNAL SAFETY
 
 .PP
 unw_get_proc_name()
-is thread\-safe. If cursor cp
+is thread safe. If cursor cp
 is 
-in the local address\-space, this routine is also safe to use from a 
+in the local address space, this routine is also safe to use from a 
 signal handler. 
 .PP
 .SH ERRORS
@@ -103,14 +105,14 @@ returned.
 In addition, unw_get_proc_name()
 may return any error 
 returned by the access_mem()
-call\-back (see 
-unw_create_addr_space(3)).
+callback (see 
+unw_create_addr_space(3libunwind)).
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_get_proc_info(3)
+libunwind(3libunwind),
+unw_get_proc_info(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_get_proc_name.tex
+++ b/doc/unw_get_proc_name.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_get\_proc\_name}{David Mosberger-Tang}{Programming Library}{unw\_get\_proc\_name}unw\_get\_proc\_name -- get name of current procedure
+\begin{Name}{3libunwind}{unw\_get\_proc\_name}{David Mosberger-Tang}{Programming Library}{unw\_get\_proc\_name}unw\_get\_proc\_name -- get name of current procedure
 \end{Name}
 
 \section{Synopsis}
@@ -21,11 +21,11 @@ procedure that created the stack frame identified by argument
 \Var{cp}.  The \Var{bufp} argument is a pointer to a character buffer
 that is at least \Var{len} bytes long.  This buffer is used to return
 the name of the procedure.  The \Var{offp} argument is a pointer to a
-word that is used to return the byte-offset of the instruction-pointer
+word that is used to return the byte offset of the instruction-pointer
 saved in the stack frame identified by \Var{cp}, relative to the start
 of the procedure.  For example, if procedure \Func{foo}() starts at
 address 0x40003000, then invoking \Func{unw\_get\_proc\_name}() on a
-stack frame with an instruction-pointer value of 0x40003080 would
+stack frame with an instruction pointer value of 0x40003080 would
 return a value of 0x80 in the word pointed to by \Var{offp} (assuming
 the procedure is at least 0x80 bytes long).
 
@@ -38,18 +38,18 @@ may return the name of a label or a preceding (nearby) procedure.
 However, the offset returned through \Var{offp} is always relative to
 the returned name, which ensures that the value (address) of the
 returned name plus the returned offset will always be equal to the
-instruction-pointer of the stack frame identified by \Var{cp}.
+instruction pointer of the stack frame identified by \Var{cp}.
 
 \section{Return Value}
 
 On successful completion, \Func{unw\_get\_proc\_name}() returns 0.
-Otherwise the negative value of one of the error-codes below is
+Otherwise the negative value of one of the error codes below is
 returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_get\_proc\_name}() is thread-safe.  If cursor \Var{cp} is
-in the local address-space, this routine is also safe to use from a
+\Func{unw\_get\_proc\_name}() is thread safe.  If cursor \Var{cp} is
+in the local address space, this routine is also safe to use from a
 signal handler.
 
 \section{Errors}
@@ -63,13 +63,13 @@ signal handler.
   returned.
 \end{Description}
 In addition, \Func{unw\_get\_proc\_name}() may return any error
-returned by the \Func{access\_mem}() call-back (see
-\Func{unw\_create\_addr\_space}(3)).
+returned by the \Func{access\_mem}() callback (see
+\Func{unw\_create\_addr\_space}(3libunwind)).
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_get\_proc\_info(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_get\_proc\_info}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_get_proc_name_by_ip.man
+++ b/doc/unw_get_proc_name_by_ip.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Mon Aug 30 08:48:42 CEST 2021
+.\" Manual page created with latex2man on Tue Aug 29 12:09:48 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,10 +12,10 @@
 
 .fi
 ..
-.TH "UNW\\_GET\\_PROC\\_NAME\\_BY\\_IP" "3" "30 August 2021" "Programming Library " "Programming Library "
+.TH "UNW\\_GET\\_PROC\\_NAME\\_BY\\_IP" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_get_proc_name_by_ip
-\-\- get procedure name
+\-\- get procedure name 
 .PP
 .SH SYNOPSIS
 
@@ -35,98 +37,98 @@ void *arg);
 
 .PP
 The unw_get_proc_name_by_ip()
-routine returns the name of
+routine returns the name of 
 a procedure just like unw_get_proc_name(),
-except that the
-name is looked up by instruction\-pointer (IP) instead of a cursor.
+except that the 
+name is looked up by instruction pointer (IP) instead of a cursor. 
 .PP
 The routine expects the following arguments: as
-is the
-address\-space in which the instruction\-pointer should be looked up.
-For a look\-up in the local address\-space,
+is the 
+address\-space in which the instruction pointer should be looked up. 
+For a look\-up in the local address\-space, 
 unw_local_addr_space
-can be passed for this argument.
+can be passed for this argument. 
 Argument ip
-is the instruction\-pointer for which the procedure
+is the instruction\-pointer for which the procedure 
 name should be looked up. The bufp
-argument is a pointer to
+argument is a pointer to 
 a character buffer that is at least len
-bytes long. This buffer
+bytes long. This buffer 
 is used to return the name of the procedure. The offp
-argument
-is a pointer to a word that is used to return the byte\-offset of the
-instruction\-pointer relative to the start of the procedure.
+argument 
+is a pointer to a word that is used to return the byte offset of the 
+instruction\-pointer relative to the start of the procedure. 
 Lastly, arg
-is the address\-space argument that should be used
-when accessing the address\-space. It has the same purpose as the
+is the address space argument that should be used 
+when accessing the address space. It has the same purpose as the 
 argument of the same name for unw_init_remote().
-When
-accessing the local address\-space (first argument is
+When 
+accessing the local address space (first argument is 
 unw_local_addr_space),
 NULL
-must be passed for this
-argument.
+must be passed for this 
+argument. 
 .PP
-Note that on some platforms there is no reliable way to distinguish
-between procedure names and ordinary labels. Furthermore, if symbol
-information has been stripped from a program, procedure names may be
-completely unavailable or may be limited to those exported via a
-dynamic symbol table. In such cases,
+Note that on some platforms there is no reliable way to distinguish 
+between procedure names and ordinary labels. Furthermore, if symbol 
+information has been stripped from a program, procedure names may be 
+completely unavailable or may be limited to those exported via a 
+dynamic symbol table. In such cases, 
 unw_get_proc_name_by_ip()
-may return the name of a label
-or a preceding (nearby) procedure. However, the offset returned
+may return the name of a label 
+or a preceding (nearby) procedure. However, the offset returned 
 through offp
-is always relative to the returned name, which
-ensures that the value (address) of the returned name plus the
-returned offset will always be equal to the instruction\-pointer
+is always relative to the returned name, which 
+ensures that the value (address) of the returned name plus the 
+returned offset will always be equal to the instruction pointer 
 ip\&.
 .PP
 .SH RETURN VALUE
 
 .PP
 On successful completion, unw_get_proc_name_by_ip()
-returns 0. Otherwise the negative value of one of the error\-codes
-below is returned.
+returns 0. Otherwise the negative value of one of the error codes 
+below is returned. 
 .PP
 .SH THREAD AND SIGNAL SAFETY
 
 .PP
 unw_get_proc_name_by_ip()
-is thread\-safe. If the local
+is thread safe. If the local 
 address\-space is passed in argument as,
-this routine is also
-safe to use from a signal handler.
+this routine is also 
+safe to use from a signal handler. 
 .PP
 .SH ERRORS
 
 .PP
 .TP
 UNW_EUNSPEC
- An unspecified error occurred.
+ An unspecified error occurred. 
 .TP
 UNW_ENOINFO
  Libunwind
-was unable to determine
-the name of the procedure.
+was unable to determine 
+the name of the procedure. 
 .TP
 UNW_ENOMEM
- The procedure name is too long to fit
-in the buffer provided. A truncated version of the name has been
-returned.
+ The procedure name is too long to fit 
+in the buffer provided. A truncated version of the name has been 
+returned. 
 .PP
 In addition, unw_get_proc_name_by_ip()
-may return any error
+may return any error 
 returned by the access_mem()
-call\-back (see
-unw_create_addr_space(3)).
+callback (see 
+unw_create_addr_space(3libunwind)).
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_create_addr_space(3),
-unw_get_proc_name(3),
-unw_init_remote(3)
+libunwind(3libunwind),
+unw_create_addr_space(3libunwind),
+unw_get_proc_name(3libunwind),
+unw_init_remote(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_get_proc_name_by_ip.tex
+++ b/doc/unw_get_proc_name_by_ip.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_get\_proc\_name\_by\_ip}{David Mosberger-Tang}{Programming Library}{unw\_get\_proc\_name}unw\_get\_proc\_name\_by\_ip -- get procedure name
+\begin{Name}{3libunwind}{unw\_get\_proc\_name\_by\_ip}{David Mosberger-Tang}{Programming Library}{unw\_get\_proc\_name}unw\_get\_proc\_name\_by\_ip -- get procedure name
 \end{Name}
 
 \section{Synopsis}
@@ -18,22 +18,22 @@
 
 The \Func{unw\_get\_proc\_name\_by\_ip}() routine returns the name of
 a procedure just like \Func{unw\_get\_proc\_name}(), except that the
-name is looked up by instruction-pointer (IP) instead of a cursor.
+name is looked up by instruction pointer (IP) instead of a cursor.
 
 The routine expects the following arguments: \Var{as} is the
-address-space in which the instruction-pointer should be looked up.
+address-space in which the instruction pointer should be looked up.
 For a look-up in the local address-space,
 \Var{unw\_local\_addr\_space} can be passed for this argument.
 Argument \Var{ip} is the instruction-pointer for which the procedure
 name should be looked up.  The \Var{bufp} argument is a pointer to
 a character buffer that is at least \Var{len} bytes long.  This buffer
 is used to return the name of the procedure.  The \Var{offp} argument
-is a pointer to a word that is used to return the byte-offset of the
+is a pointer to a word that is used to return the byte offset of the
 instruction-pointer relative to the start of the procedure.
-Lastly, \Var{arg} is the address-space argument that should be used
-when accessing the address-space.  It has the same purpose as the
+Lastly, \Var{arg} is the address space argument that should be used
+when accessing the address space.  It has the same purpose as the
 argument of the same name for \Func{unw\_init\_remote}().  When
-accessing the local address-space (first argument is
+accessing the local address space (first argument is
 \Var{unw\_local\_addr\_space}), \Const{NULL} must be passed for this
 argument.
 
@@ -46,18 +46,18 @@ dynamic symbol table.  In such cases,
 or a preceding (nearby) procedure.  However, the offset returned
 through \Var{offp} is always relative to the returned name, which
 ensures that the value (address) of the returned name plus the
-returned offset will always be equal to the instruction-pointer
+returned offset will always be equal to the instruction pointer
 \Var{ip}.
 
 \section{Return Value}
 
 On successful completion, \Func{unw\_get\_proc\_name\_by\_ip}()
-returns 0.  Otherwise the negative value of one of the error-codes
+returns 0.  Otherwise the negative value of one of the error codes
 below is returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_get\_proc\_name\_by\_ip}() is thread-safe.  If the local
+\Func{unw\_get\_proc\_name\_by\_ip}() is thread safe.  If the local
 address-space is passed in argument \Var{as}, this routine is also
 safe to use from a signal handler.
 
@@ -72,15 +72,15 @@ safe to use from a signal handler.
   returned.
 \end{Description}
 In addition, \Func{unw\_get\_proc\_name\_by\_ip}() may return any error
-returned by the \Func{access\_mem}() call-back (see
-\Func{unw\_create\_addr\_space}(3)).
+returned by the \Func{access\_mem}() callback (see
+\Func{unw\_create\_addr\_space}(3libunwind)).
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_create\_addr\_space(3)},
-\SeeAlso{unw\_get\_proc\_name(3)},
-\SeeAlso{unw\_init\_remote(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_create\_addr\_space}(3libunwind),
+\SeeAlso{unw\_get\_proc\_name}(3libunwind),
+\SeeAlso{unw\_init\_remote}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_get_reg.man
+++ b/doc/unw_get_reg.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 12:09:48 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_GET\\_REG" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_GET\\_REG" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_get_reg
 \-\- get register contents 
@@ -38,22 +40,22 @@ in the stack frame identified by cursor cp
 and stores 
 the value in the word pointed to by valp\&.
 .PP
-The register numbering is target\-dependent and described in separate 
-manual pages (e.g., libunwind\-ia64(3) for the IA\-64 target). 
+The register numbering is target dependent and described in separate 
+manual pages (e.g., libunwind\-ia64(3libunwind) for the IA\-64 target). 
 Furthermore, the exact set of accessible registers may depend on the 
 type of frame that cp
 is referring to. For ordinary stack 
 frames, it is normally possible to access only the preserved 
 (``callee\-saved\&'') registers and frame\-related registers (such as the 
 stack\-pointer). However, for signal frames (see 
-unw_is_signal_frame(3)),
+unw_is_signal_frame(3libunwind)),
 it is usually possible to access 
 all registers. 
 .PP
 Note that unw_get_reg()
 can only read the contents of 
 registers whose values fit in a single word. See 
-unw_get_fpreg(3)
+unw_get_fpreg(3libunwind)
 for a way to read registers which do not fit 
 this constraint. 
 .PP
@@ -62,14 +64,14 @@ this constraint.
 .PP
 On successful completion, unw_get_reg()
 returns 0. 
-Otherwise the negative value of one of the error\-codes below is 
+Otherwise the negative value of one of the error codes below is 
 returned. 
 .PP
 .SH THREAD AND SIGNAL SAFETY
 
 .PP
 unw_get_reg()
-is thread\-safe as well as safe to use 
+is thread safe as well as safe to use 
 from a signal handler. 
 .PP
 .SH ERRORS
@@ -89,17 +91,17 @@ the access_mem(),
 access_reg(),
 and 
 access_fpreg()
-call\-backs (see 
-unw_create_addr_space(3)).
+callbacks (see 
+unw_create_addr_space(3libunwind)).
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-libunwind\-ia64(3),
-unw_get_fpreg(3),
-unw_is_signal_frame(3),
-unw_set_reg(3)
+libunwind(3libunwind),
+libunwind\-ia64(3libunwind),
+unw_get_fpreg(3libunwind),
+unw_is_signal_frame(3libunwind),
+unw_set_reg(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_get_reg.tex
+++ b/doc/unw_get_reg.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_get\_reg}{David Mosberger-Tang}{Programming Library}{unw\_get\_reg}unw\_get\_reg -- get register contents
+\begin{Name}{3libunwind}{unw\_get\_reg}{David Mosberger-Tang}{Programming Library}{unw\_get\_reg}unw\_get\_reg -- get register contents
 \end{Name}
 
 \section{Synopsis}
@@ -20,30 +20,30 @@ The \Func{unw\_get\_reg}() routine reads the value of register
 \Var{reg} in the stack frame identified by cursor \Var{cp} and stores
 the value in the word pointed to by \Var{valp}.
 
-The register numbering is target-dependent and described in separate
-manual pages (e.g., libunwind-ia64(3) for the IA-64 target).
+The register numbering is target dependent and described in separate
+manual pages (e.g., libunwind-ia64(3libunwind) for the IA-64 target).
 Furthermore, the exact set of accessible registers may depend on the
 type of frame that \Var{cp} is referring to.  For ordinary stack
 frames, it is normally possible to access only the preserved
 (``callee-saved'') registers and frame-related registers (such as the
 stack-pointer).  However, for signal frames (see
-\Func{unw\_is\_signal\_frame}(3)), it is usually possible to access
+\Func{unw\_is\_signal\_frame}(3libunwind)), it is usually possible to access
 all registers.
 
 Note that \Func{unw\_get\_reg}() can only read the contents of
 registers whose values fit in a single word.  See
-\Func{unw\_get\_fpreg}(3) for a way to read registers which do not fit
+\Func{unw\_get\_fpreg}(3libunwind) for a way to read registers which do not fit
 this constraint.
 
 \section{Return Value}
 
 On successful completion, \Func{unw\_get\_reg}() returns 0.
-Otherwise the negative value of one of the error-codes below is
+Otherwise the negative value of one of the error codes below is
 returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_get\_reg}() is thread-safe as well as safe to use
+\Func{unw\_get\_reg}() is thread safe as well as safe to use
 from a signal handler.
 
 \section{Errors}
@@ -55,16 +55,16 @@ from a signal handler.
 \end{Description}
 In addition, \Func{unw\_get\_reg}() may return any error returned by
 the \Func{access\_mem}(), \Func{access\_reg}(), and
-\Func{access\_fpreg}() call-backs (see
-\Func{unw\_create\_addr\_space}(3)).
+\Func{access\_fpreg}() callbacks (see
+\Func{unw\_create\_addr\_space}(3libunwind)).
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{libunwind-ia64(3)},
-\SeeAlso{unw\_get\_fpreg(3)},
-\SeeAlso{unw\_is\_signal\_frame(3)},
-\SeeAlso{unw\_set\_reg(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{libunwind-ia64}(3libunwind),
+\SeeAlso{unw\_get\_fpreg}(3libunwind),
+\SeeAlso{unw\_is\_signal\_frame}(3libunwind),
+\SeeAlso{unw\_set\_reg}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_getcontext.man
+++ b/doc/unw_getcontext.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 12:09:48 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_GETCONTEXT" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_GETCONTEXT" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_getcontext
 \-\- get initial machine\-state 
@@ -31,12 +33,12 @@ unw_getcontext(unw_context_t *ucp);
 The unw_getcontext()
 routine initializes the context structure 
 pointed to by ucp
-with the machine\-state of the call\-site. The 
+with the machine state of the call site. The 
 exact set of registers stored by unw_getcontext()
 is 
 platform\-specific, but, in general, at least all preserved 
 (``callee\-saved\&'') and all frame\-related registers, such as the 
-stack\-pointer, will be stored. 
+stack pointer, will be stored. 
 .PP
 This routine is normally implemented as a macro and applications 
 should not attempt to take its address. 
@@ -73,14 +75,14 @@ Otherwise, a value of \-1 is returned.
 
 .PP
 unw_getcontext()
-is thread\-safe as well as safe to use 
+is thread safe as well as safe to use 
 from a signal handler. 
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_init_local(3)
+libunwind(3libunwind),
+unw_init_local(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_getcontext.tex
+++ b/doc/unw_getcontext.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_getcontext}{David Mosberger-Tang}{Programming Library}{unw\_getcontext}unw\_getcontext -- get initial machine-state
+\begin{Name}{3libunwind}{unw\_getcontext}{David Mosberger-Tang}{Programming Library}{unw\_getcontext}unw\_getcontext -- get initial machine-state
 \end{Name}
 
 \section{Synopsis}
@@ -17,11 +17,11 @@
 \section{Description}
 
 The \Func{unw\_getcontext}() routine initializes the context structure
-pointed to by \Var{ucp} with the machine-state of the call-site.  The
+pointed to by \Var{ucp} with the machine state of the call site.  The
 exact set of registers stored by \Func{unw\_getcontext}() is
 platform-specific, but, in general, at least all preserved
 (``callee-saved'') and all frame-related registers, such as the
-stack-pointer, will be stored.
+stack pointer, will be stored.
 
 This routine is normally implemented as a macro and applications
 should not attempt to take its address.
@@ -44,13 +44,13 @@ Otherwise, a value of -1 is returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_getcontext}() is thread-safe as well as safe to use
+\Func{unw\_getcontext}() is thread safe as well as safe to use
 from a signal handler.
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_init\_local(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_init\_local}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_init_local.man
+++ b/doc/unw_init_local.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
+.\" Manual page created with latex2man on Tue Aug 29 11:41:44 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_INIT\\_LOCAL" "3" "29 August 2021" "Programming Library " "Programming Library "
+.TH "UNW\\_INIT\\_LOCAL" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_init_local
 \-\- initialize cursor for local unwinding 
@@ -38,18 +40,18 @@ flag);
 The unw_init_local()
 routine initializes the unwind cursor 
 pointed to by c
-with the machine\-state in the context structure 
+with the machine state in the context structure 
 pointed to by ctxt\&.
-As such, the machine\-state pointed to by 
+As such, the machine state pointed to by 
 ctxt
 identifies the initial stack frame at which unwinding 
-starts. The machine\-state is expected to be one provided by a call to 
+starts. The machine state is expected to be one provided by a call to 
 unw_getcontext();
 as such, the instruction pointer may point to 
 the instruction after the last instruction of a function, and 
 libunwind
 will back\-up the instruction pointer before beginning 
-a walk up the call stack. The machine\-state must remain valid for the 
+a walk up the call stack. The machine state must remain valid for the 
 duration for which the cursor c
 is in use. 
 .PP
@@ -81,14 +83,14 @@ flag.
 .PP
 On successful completion, unw_init_local()
 returns 0. 
-Otherwise the negative value of one of the error\-codes below is 
+Otherwise the negative value of one of the error codes below is 
 returned. 
 .PP
 .SH THREAD AND SIGNAL SAFETY
 
 .PP
 unw_init_local()
-is thread\-safe as well as safe to use from a 
+is thread safe as well as safe to use from a 
 signal handler. 
 .PP
 .SH ERRORS
@@ -114,8 +116,8 @@ wasn\&'t accessible.
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_init_remote(3)
+libunwind(3libunwind),
+unw_init_remote(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_init_local.tex
+++ b/doc/unw_init_local.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_init\_local}{David Mosberger-Tang}{Programming Library}{unw\_init\_local}unw\_init\_local -- initialize cursor for local unwinding
+\begin{Name}{3libunwind}{unw\_init\_local}{David Mosberger-Tang}{Programming Library}{unw\_init\_local}unw\_init\_local -- initialize cursor for local unwinding
 \end{Name}
 
 \section{Synopsis}
@@ -18,14 +18,14 @@
 \section{Description}
 
 The \Func{unw\_init\_local}() routine initializes the unwind cursor
-pointed to by \Var{c} with the machine-state in the context structure
-pointed to by \Var{ctxt}.  As such, the machine-state pointed to by
+pointed to by \Var{c} with the machine state in the context structure
+pointed to by \Var{ctxt}.  As such, the machine state pointed to by
 \Var{ctxt} identifies the initial stack frame at which unwinding
-starts.  The machine-state is expected to be one provided by a call to
+starts.  The machine state is expected to be one provided by a call to
 \Func{unw\_getcontext}(); as such, the instruction pointer may point to
 the instruction after the last instruction of a function, and
 \Prog{libunwind} will back-up the instruction pointer before beginning
-a walk up the call stack.  The machine-state must remain valid for the
+a walk up the call stack.  The machine state must remain valid for the
 duration for which the cursor \Var{c} is in use.
 
 The \Func{unw\_init\_local}() routine can be used only for unwinding in
@@ -45,12 +45,12 @@ on some platforms, passing the \Const{UNW\_INIT\_SIGNAL\_FRAME} flag.
 \section{Return Value}
 
 On successful completion, \Func{unw\_init\_local}() returns 0.
-Otherwise the negative value of one of the error-codes below is
+Otherwise the negative value of one of the error codes below is
 returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_init\_local}() is thread-safe as well as safe to use from a
+\Func{unw\_init\_local}() is thread safe as well as safe to use from a
 signal handler.
 
 \section{Errors}
@@ -67,7 +67,8 @@ signal handler.
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)}, \SeeAlso{unw\_init\_remote(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_init\_remote}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_init_remote.man
+++ b/doc/unw_init_remote.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 11:41:44 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_INIT\\_REMOTE" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_INIT\\_REMOTE" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_init_remote
 \-\- initialize cursor for remote unwinding 
@@ -42,18 +44,18 @@ unw_local_addr_space
 address space created with unw_create_addr_space().
 .PP
 The arg
-void\-pointer tells the address space exactly what entity 
+opaque pointer tells the address space exactly what entity 
 should be unwound. For example, if unw_local_addr_space
 is 
 passed in as,
 then arg
 needs to be a pointer to a context 
 structure containing the machine\-state of the initial stack frame. 
-However, other address\-spaces may instead expect a process\-id, a 
-thread\-id, or a pointer to an arbitrary structure which identifies the 
-stack\-frame chain to be unwound. In other words, the interpretation 
+However, other address spaces may instead expect a process ID, a 
+thread ID, or a pointer to an arbitrary structure which identifies the 
+stack frame chain to be unwound. In other words, the interpretation 
 of arg
-is entirely dependent on the address\-space in use; 
+is entirely dependent on the address space in use; 
 libunwind
 never interprets the argument in any way on its own. 
 .PP
@@ -78,7 +80,7 @@ returned.
 
 .PP
 unw_init_remote()
-is thread\-safe. If the local address\-space 
+is thread safe. If the local address space 
 is passed in argument as,
 this routine is also safe to use from 
 a signal handler. 
@@ -108,9 +110,9 @@ wasn\&'t accessible.
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_create_addr_space(3),
-unw_init_local(3)
+libunwind(3libunwind),
+unw_create_addr_space(3libunwind),
+unw_init_local(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_init_remote.tex
+++ b/doc/unw_init_remote.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_init\_remote}{David Mosberger-Tang}{Programming Library}{unw\_init\_remote}unw\_init\_remote -- initialize cursor for remote unwinding
+\begin{Name}{3libunwind}{unw\_init\_remote}{David Mosberger-Tang}{Programming Library}{unw\_init\_remote}unw\_init\_remote -- initialize cursor for remote unwinding
 \end{Name}
 
 \section{Synopsis}
@@ -22,14 +22,14 @@ pointed to by \Var{c} for unwinding in the address space identified by
 \Var{unw\_local\_addr\_space} (local address space) or to an arbitrary
 address space created with \Func{unw\_create\_addr\_space}().
 
-The \Var{arg} void-pointer tells the address space exactly what entity
+The \Var{arg} opaque pointer tells the address space exactly what entity
 should be unwound.  For example, if \Var{unw\_local\_addr\_space} is
 passed in \Var{as}, then \Var{arg} needs to be a pointer to a context
 structure containing the machine-state of the initial stack frame.
-However, other address-spaces may instead expect a process-id, a
-thread-id, or a pointer to an arbitrary structure which identifies the
-stack-frame chain to be unwound.  In other words, the interpretation
-of \Var{arg} is entirely dependent on the address-space in use;
+However, other address spaces may instead expect a process ID, a
+thread ID, or a pointer to an arbitrary structure which identifies the
+stack frame chain to be unwound.  In other words, the interpretation
+of \Var{arg} is entirely dependent on the address space in use;
 \Prog{libunwind} never interprets the argument in any way on its own.
 
 Note that \Func{unw\_init\_remote}() can be used to initiate unwinding
@@ -46,7 +46,7 @@ returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_init\_remote}() is thread-safe.  If the local address-space
+\Func{unw\_init\_remote}() is thread safe.  If the local address space
 is passed in argument \Var{as}, this routine is also safe to use from
 a signal handler.
 
@@ -65,8 +65,9 @@ a signal handler.
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)}, \SeeAlso{unw\_create\_addr\_space(3)},
-\SeeAlso{unw\_init\_local(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_create\_addr\_space}(3libunwind),
+\SeeAlso{unw\_init\_local}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_is_fpreg.man
+++ b/doc/unw_is_fpreg.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 11:41:44 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_IS\\_FPREG" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_IS\\_FPREG" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_is_fpreg
 \-\- check if a register is a floating\-point register 
@@ -50,17 +52,17 @@ of 0.
 
 .PP
 unw_is_fpreg()
-is thread\-safe as well as safe to use 
+is thread safe as well as safe to use 
 from a signal handler. 
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_get_reg(3),
-unw_set_reg(3),
-unw_get_fpreg(3),
-unw_set_fpreg(3)
+libunwind(3libunwind),
+unw_get_reg(3libunwind),
+unw_set_reg(3libunwind),
+unw_get_fpreg(3libunwind),
+unw_set_fpreg(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_is_fpreg.tex
+++ b/doc/unw_is_fpreg.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_is\_fpreg}{David Mosberger-Tang}{Programming Library}{unw\_is\_fpreg}unw\_is\_fpreg -- check if a register is a floating-point register
+\begin{Name}{3libunwind}{unw\_is\_fpreg}{David Mosberger-Tang}{Programming Library}{unw\_is\_fpreg}unw\_is\_fpreg -- check if a register is a floating-point register
 \end{Name}
 
 \section{Synopsis}
@@ -30,16 +30,16 @@ of 0.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_is\_fpreg}() is thread-safe as well as safe to use
+\Func{unw\_is\_fpreg}() is thread safe as well as safe to use
 from a signal handler.
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_get\_reg(3)},
-\SeeAlso{unw\_set\_reg(3)},
-\SeeAlso{unw\_get\_fpreg(3)},
-\SeeAlso{unw\_set\_fpreg(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_get\_reg}(3libunwind),
+\SeeAlso{unw\_set\_reg}(3libunwind),
+\SeeAlso{unw\_get\_fpreg}(3libunwind),
+\SeeAlso{unw\_set\_fpreg}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_is_signal_frame.man
+++ b/doc/unw_is_signal_frame.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 11:06:25 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_IS\\_SIGNAL\\_FRAME" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_IS\\_SIGNAL\\_FRAME" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_is_signal_frame
 \-\- check if current frame is a signal frame 
@@ -31,12 +33,15 @@ unw_is_signal_frame(unw_cursor_t *cp);
 The unw_is_signal_frame()
 routine returns a positive value 
 if the current frame identified by cp
-is a signal frame, and a 
-value of 0 otherwise. For the purpose of this discussion, a signal 
-frame is a frame that was created in response to a potentially 
-asynchronous interruption. For UNIX and UNIX\-like platforms, such 
-frames are normally created by the kernel when delivering a signal. 
-In a kernel\-environment, a signal frame might, for example, correspond 
+is a signal frame, 
+also known as a signal trampoline, 
+and a value of 0 otherwise. 
+For the purpose of this discussion, 
+a signal frame is a frame that was created in response to a potentially 
+asynchronous interruption. 
+For UNIX and UNIX\-like platforms, 
+such frames are normally created by the kernel when delivering a signal. 
+In a kernel environment, a signal frame might, for example, correspond 
 to a frame created in response to a device interrupt. 
 .PP
 Signal frames are somewhat unusual because the asynchronous nature of 
@@ -49,14 +54,14 @@ that are normally treated as scratch (``caller\-saved\&'') registers.
 On successful completion, unw_is_signal_frame()
 returns a 
 positive value if the current frame is a signal frame, or 0 if it is 
-not. Otherwise, a negative value of one of the error\-codes below is 
+not. Otherwise, a negative value of one of the error codes below is 
 returned. 
 .PP
 .SH THREAD AND SIGNAL SAFETY
 
 .PP
 unw_is_signal_frame()
-is thread\-safe as well as safe to use 
+is thread safe as well as safe to use 
 from a signal handler. 
 .PP
 .SH ERRORS
@@ -71,11 +76,11 @@ whether or not the current frame is a signal frame.
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_get_reg(3),
-unw_set_reg(3),
-unw_get_fpreg(3),
-unw_set_fpreg(3)
+libunwind(3libunwind),
+unw_get_reg(3libunwind),
+unw_set_reg(3libunwind),
+unw_get_fpreg(3libunwind),
+unw_set_fpreg(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_is_signal_frame.tex
+++ b/doc/unw_is_signal_frame.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_is\_signal\_frame}{David Mosberger-Tang}{Programming Library}{unw\_is\_signal\_frame}unw\_is\_signal\_frame -- check if current frame is a signal frame
+\begin{Name}{3libunwind}{unw\_is\_signal\_frame}{David Mosberger-Tang}{Programming Library}{unw\_is\_signal\_frame}unw\_is\_signal\_frame -- check if current frame is a signal frame
 \end{Name}
 
 \section{Synopsis}
@@ -17,12 +17,15 @@
 \section{Description}
 
 The \Func{unw\_is\_signal\_frame}() routine returns a positive value
-if the current frame identified by \Var{cp} is a signal frame, and a
-value of 0 otherwise.  For the purpose of this discussion, a signal
-frame is a frame that was created in response to a potentially
-asynchronous interruption.  For UNIX and UNIX-like platforms, such
-frames are normally created by the kernel when delivering a signal.
-In a kernel-environment, a signal frame might, for example, correspond
+if the current frame identified by \Var{cp} is a signal frame,
+also known as a signal trampoline,
+and a value of 0 otherwise.
+For the purpose of this discussion,
+a signal frame is a frame that was created in response to a potentially
+asynchronous interruption.
+For UNIX and UNIX-like platforms,
+such frames are normally created by the kernel when delivering a signal.
+In a kernel environment, a signal frame might, for example, correspond
 to a frame created in response to a device interrupt.
 
 Signal frames are somewhat unusual because the asynchronous nature of
@@ -33,12 +36,12 @@ that are normally treated as scratch (``caller-saved'') registers.
 
 On successful completion, \Func{unw\_is\_signal\_frame}() returns a
 positive value if the current frame is a signal frame, or 0 if it is
-not.  Otherwise, a negative value of one of the error-codes below is
+not.  Otherwise, a negative value of one of the error codes below is
 returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_is\_signal\_frame}() is thread-safe as well as safe to use
+\Func{unw\_is\_signal\_frame}() is thread safe as well as safe to use
 from a signal handler.
 
 \section{Errors}
@@ -50,11 +53,11 @@ from a signal handler.
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_get\_reg(3)},
-\SeeAlso{unw\_set\_reg(3)},
-\SeeAlso{unw\_get\_fpreg(3)},
-\SeeAlso{unw\_set\_fpreg(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_get\_reg}(3libunwind),
+\SeeAlso{unw\_set\_reg}(3libunwind),
+\SeeAlso{unw\_get\_fpreg}(3libunwind),
+\SeeAlso{unw\_set\_fpreg}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_reg_states_iterate.man
+++ b/doc/unw_reg_states_iterate.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Sun Aug 29 23:45:06 CEST 2021
+.\" Manual page created with latex2man on Tue Aug 29 11:41:44 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_REG\\_STATES\\_ITERATE" "3" "29 August 2021" "Programming Library " "Programming Library "
+.TH "UNW\\_REG\\_STATES\\_ITERATE" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_reg_states_iterate
 \-\- get register state info on current procedure 
@@ -87,15 +89,15 @@ On successful completion, unw_reg_states_iterate()
 returns 
 0. If the callback function returns a nonzero value, that indicates 
 failure and the function returns immediately. Otherwise the negative 
-value of one of the error\-codes below is returned. 
+value of one of the error codes below is returned. 
 .PP
 .SH THREAD AND SIGNAL SAFETY
 
 .PP
 unw_reg_states_iterate()
-is thread\-safe. If cursor cp
+is thread safe. If cursor cp
 is 
-in the local address\-space, this routine is also safe to use from a 
+in the local address space, this routine is also safe to use from a 
 signal handler. 
 .PP
 .SH ERRORS
@@ -118,13 +120,13 @@ In addition, unw_reg_states_iterate()
 may return any error 
 returned by the access_mem()
 call\-back (see 
-unw_create_addr_space(3)).
+unw_create_addr_space(3libunwind)).
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_apply_reg_state(3)
+libunwind(3libunwind),
+unw_apply_reg_state(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_reg_states_iterate.tex
+++ b/doc/unw_reg_states_iterate.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_reg\_states\_iterate}{David Mosberger-Tang}{Programming Library}{unw\_reg\_states\_iterate}unw\_reg\_states\_iterate -- get register state info on current procedure
+\begin{Name}{3libunwind}{unw\_reg\_states\_iterate}{David Mosberger-Tang}{Programming Library}{unw\_reg\_states\_iterate}unw\_reg\_states\_iterate -- get register state info on current procedure
 \end{Name}
 
 \section{Synopsis}
@@ -46,12 +46,12 @@ The callback function may be invoked several times for each call of \Func{unw\_r
 On successful completion, \Func{unw\_reg\_states\_iterate}() returns
 0.  If the callback function returns a nonzero value, that indicates
 failure and the function returns immediately.  Otherwise the negative
-value of one of the error-codes below is returned.
+value of one of the error codes below is returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_reg\_states\_iterate}() is thread-safe.  If cursor \Var{cp} is
-in the local address-space, this routine is also safe to use from a
+\Func{unw\_reg\_states\_iterate}() is thread safe.  If cursor \Var{cp} is
+in the local address space, this routine is also safe to use from a
 signal handler.
 
 \section{Errors}
@@ -65,12 +65,12 @@ signal handler.
 \end{Description}
 In addition, \Func{unw\_reg\_states\_iterate}() may return any error
 returned by the \Func{access\_mem}() call-back (see
-\Func{unw\_create\_addr\_space}(3)).
+\Func{unw\_create\_addr\_space}(3libunwind)).
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_apply\_reg\_state(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_apply\_reg\_state}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_regname.man
+++ b/doc/unw_regname.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 11:41:44 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_REGNAME" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_REGNAME" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_regname
 \-\- get register name 
@@ -49,13 +51,13 @@ string.
 
 .PP
 The unw_regname()
-routine is thread\-safe as well as safe to 
+routine is thread safe as well as safe to 
 use from a signal handler. 
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3)
+libunwind(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_regname.tex
+++ b/doc/unw_regname.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_regname}{David Mosberger-Tang}{Programming Library}{unw\_regname}unw\_regname -- get register name
+\begin{Name}{3libunwind}{unw\_regname}{David Mosberger-Tang}{Programming Library}{unw\_regname}unw\_regname -- get register name
 \end{Name}
 
 \section{Synopsis}
@@ -29,12 +29,12 @@ valid (non-\Const{NULL}) string.
 
 \section{Thread and Signal Safety}
 
-The \Func{unw\_regname}() routine is thread-safe as well as safe to
+The \Func{unw\_regname}() routine is thread safe as well as safe to
 use from a signal handler.
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)}
+\SeeAlso{libunwind}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_resume.man
+++ b/doc/unw_resume.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 11:41:44 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_RESUME" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_RESUME" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_resume
 \-\- resume execution in a particular stack frame 
@@ -86,7 +88,7 @@ handlers (aka, ``personality routines\&''). If a program needs this, it
 will have to do so on its own by obtaining the unw_proc_info_t
 of each unwound frame and appropriately processing its unwind handler 
 and language\-specific data area (lsda). These steps are generally 
-dependent on the target\-platform and are regulated by the 
+dependent on the target platform and are regulated by the 
 processor\-specific ABI (application\-binary interface). 
 .PP
 .SH RETURN VALUE
@@ -131,9 +133,9 @@ is not valid.
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_set_reg(3),
-sigprocmask(2) 
+libunwind(3libunwind),
+unw_set_reg(3libunwind),
+sigprocmask(2)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_resume.tex
+++ b/doc/unw_resume.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_resume}{David Mosberger-Tang}{Programming Library}{unw\_resume}unw\_resume -- resume execution in a particular stack frame
+\begin{Name}{3libunwind}{unw\_resume}{David Mosberger-Tang}{Programming Library}{unw\_resume}unw\_resume -- resume execution in a particular stack frame
 \end{Name}
 
 \section{Synopsis}
@@ -55,7 +55,7 @@ handlers (aka, ``personality routines'').  If a program needs this, it
 will have to do so on its own by obtaining the \Type{unw\_proc\_info\_t}
 of each unwound frame and appropriately processing its unwind handler
 and language-specific data area (lsda).  These steps are generally
-dependent on the target-platform and are regulated by the
+dependent on the target platform and are regulated by the
 processor-specific ABI (application-binary interface).
 
 \section{Return Value}
@@ -84,9 +84,9 @@ handler.
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_set\_reg(3)},
-sigprocmask(2)
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_set\_reg}(3libunwind),
+\SeeAlso{sigprocmask}(2)
 
 \section{Author}
 

--- a/doc/unw_set_cache_size.man
+++ b/doc/unw_set_cache_size.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Fri Jan 13 08:33:21 PST 2017
+.\" Manual page created with latex2man on Tue Aug 29 11:41:44 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_SET\\_CACHE\\_SIZE" "3" "13 January 2017" "Programming Library " "Programming Library "
+.TH "UNW\\_SET\\_CACHE\\_SIZE" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_set_cache_size
 \-\- set unwind cache size 
@@ -72,10 +74,10 @@ established because the application is out of memory.
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_create_addr_space(3),
-unw_set_caching_policy(3),
-unw_flush_cache(3)
+libunwind(3libunwind),
+unw_create_addr_space(3libunwind),
+unw_set_caching_policy(3libunwind),
+unw_flush_cache(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_set_cache_size.tex
+++ b/doc/unw_set_cache_size.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_set\_cache\_size}{Dave Watson}{Programming Library}{unw\_set\_cache\_size}unw\_set\_cache\_size -- set unwind cache size
+\begin{Name}{3libunwind}{unw\_set\_cache\_size}{Dave Watson}{Programming Library}{unw\_set\_cache\_size}unw\_set\_cache\_size -- set unwind cache size
 \end{Name}
 
 \section{Synopsis}
@@ -43,10 +43,10 @@ to use from a signal handler.
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_create\_addr\_space(3)},
-\SeeAlso{unw\_set\_caching\_policy(3)},
-\SeeAlso{unw\_flush\_cache(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_create\_addr\_space}(3libunwind),
+\SeeAlso{unw\_set\_caching\_policy}(3libunwind),
+\SeeAlso{unw\_flush\_cache}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_set_caching_policy.man
+++ b/doc/unw_set_caching_policy.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Fri Dec  2 16:09:33 PST 2016
+.\" Manual page created with latex2man on Tue Aug 29 11:41:44 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_SET\\_CACHING\\_POLICY" "3" "02 December 2016" "Programming Library " "Programming Library "
+.TH "UNW\\_SET\\_CACHING\\_POLICY" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_set_caching_policy
 \-\- set unwind caching policy 
@@ -71,7 +73,7 @@ unw_flush_cache()
 would have to be called (at least) for the 
 address\-range that was covered by the shared library. 
 .PP
-For address spaces created via unw_create_addr_space(3),
+For address spaces created via unw_create_addr_space(3libunwind),
 caching is turned off by default. For the local address space 
 unw_local_addr_space,
 caching is turned on by default. 
@@ -103,10 +105,10 @@ established because the application is out of memory.
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_create_addr_space(3),
-unw_set_cache_size(3),
-unw_flush_cache(3)
+libunwind(3libunwind),
+unw_create_addr_space(3libunwind),
+unw_set_cache_size(3libunwind),
+unw_flush_cache(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_set_caching_policy.tex
+++ b/doc/unw_set_caching_policy.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_set\_caching\_policy}{David Mosberger-Tang}{Programming Library}{unw\_set\_caching\_policy}unw\_set\_caching\_policy -- set unwind caching policy
+\begin{Name}{3libunwind}{unw\_set\_caching\_policy}{David Mosberger-Tang}{Programming Library}{unw\_set\_caching\_policy}unw\_set\_caching\_policy -- set unwind caching policy
 \end{Name}
 
 \section{Synopsis}
@@ -41,7 +41,7 @@ For example, after unloading (removing) a shared library,
 \Func{unw\_flush\_cache}() would have to be called (at least) for the
 address-range that was covered by the shared library.
 
-For address spaces created via \Func{unw\_create\_addr\_space}(3),
+For address spaces created via \Func{unw\_create\_addr\_space}(3libunwind),
 caching is turned off by default.  For the local address space
 \Func{unw\_local\_addr\_space}, caching is turned on by default.
 
@@ -65,10 +65,10 @@ to use from a signal handler.
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_create\_addr\_space(3)},
-\SeeAlso{unw\_set\_cache\_size(3)},
-\SeeAlso{unw\_flush\_cache(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_create\_addr\_space}(3libunwind),
+\SeeAlso{unw\_set\_cache\_size}(3libunwind),
+\SeeAlso{unw\_flush\_cache}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_set_fpreg.man
+++ b/doc/unw_set_fpreg.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 11:06:25 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_SET\\_FPREG" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_SET\\_FPREG" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_set_fpreg
 \-\- set contents of floating\-point register 
@@ -40,20 +42,20 @@ to the
 value passed in val\&.
 .PP
 The register numbering is target\-dependent and described in separate 
-manual pages (e.g., libunwind\-ia64(3) for the IA\-64 target). 
+manual pages (e.g., libunwind\-ia64(3libunwind) for the IA\-64 target). 
 Furthermore, the exact set of accessible registers may depend on the 
 type of frame that cp
 is referring to. For ordinary stack 
 frames, it is normally possible to access only the preserved 
 (``callee\-saved\&'') registers and frame\-related registers (such as the 
 stack\-pointer). However, for signal frames (see 
-unw_is_signal_frame(3)),
+unw_is_signal_frame(3libunwind)),
 it is usually possible to access 
 all registers. 
 .PP
 Note that unw_set_fpreg()
 can only write the contents of 
-floating\-point registers. See unw_set_reg(3)
+floating\-point registers. See unw_set_reg(3libunwind)
 for a way to 
 write registers which fit in a single word. 
 .PP
@@ -62,14 +64,14 @@ write registers which fit in a single word.
 .PP
 On successful completion, unw_set_fpreg()
 returns 0. 
-Otherwise the negative value of one of the error\-codes below is 
+Otherwise the negative value of one of the error codes below is 
 returned. 
 .PP
 .SH THREAD AND SIGNAL SAFETY
 
 .PP
 unw_set_fpreg()
-is thread\-safe as well as safe to use 
+is thread safe as well as safe to use 
 from a signal handler. 
 .PP
 .SH ERRORS
@@ -93,18 +95,18 @@ the access_mem(),
 access_reg(),
 and 
 access_fpreg()
-call\-backs (see 
-unw_create_addr_space(3)).
+callbacks (see 
+unw_create_addr_space(3libunwind)).
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-libunwind\-ia64(3),
-unw_get_fpreg(3),
-unw_is_fpreg(3),
-unw_is_signal_frame(3),
-unw_set_reg(3)
+libunwind(3libunwind),
+libunwind\-ia64(3libunwind),
+unw_get_fpreg(3libunwind),
+unw_is_fpreg(3libunwind),
+unw_is_signal_frame(3libunwind),
+unw_set_reg(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_set_fpreg.tex
+++ b/doc/unw_set_fpreg.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_set\_fpreg}{David Mosberger-Tang}{Programming Library}{unw\_set\_fpreg}unw\_set\_fpreg -- set contents of floating-point register
+\begin{Name}{3libunwind}{unw\_set\_fpreg}{David Mosberger-Tang}{Programming Library}{unw\_set\_fpreg}unw\_set\_fpreg -- set contents of floating-point register
 \end{Name}
 
 \section{Synopsis}
@@ -21,28 +21,28 @@ The \Func{unw\_set\_fpreg}() routine sets the value of register
 value passed in \Var{val}.
 
 The register numbering is target-dependent and described in separate
-manual pages (e.g., libunwind-ia64(3) for the IA-64 target).
+manual pages (e.g., libunwind-ia64(3libunwind) for the IA-64 target).
 Furthermore, the exact set of accessible registers may depend on the
 type of frame that \Var{cp} is referring to.  For ordinary stack
 frames, it is normally possible to access only the preserved
 (``callee-saved'') registers and frame-related registers (such as the
 stack-pointer).  However, for signal frames (see
-\Func{unw\_is\_signal\_frame}(3)), it is usually possible to access
+\Func{unw\_is\_signal\_frame}(3libunwind)), it is usually possible to access
 all registers.
 
 Note that \Func{unw\_set\_fpreg}() can only write the contents of
-floating-point registers.  See \Func{unw\_set\_reg}(3) for a way to
+floating-point registers.  See \Func{unw\_set\_reg}(3libunwind) for a way to
 write registers which fit in a single word.
 
 \section{Return Value}
 
 On successful completion, \Func{unw\_set\_fpreg}() returns 0.
-Otherwise the negative value of one of the error-codes below is
+Otherwise the negative value of one of the error codes below is
 returned.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_set\_fpreg}() is thread-safe as well as safe to use
+\Func{unw\_set\_fpreg}() is thread safe as well as safe to use
 from a signal handler.
 
 \section{Errors}
@@ -56,17 +56,17 @@ from a signal handler.
 \end{Description}
 In addition, \Func{unw\_set\_fpreg}() may return any error returned by
 the \Func{access\_mem}(), \Func{access\_reg}(), and
-\Func{access\_fpreg}() call-backs (see
-\Func{unw\_create\_addr\_space}(3)).
+\Func{access\_fpreg}() callbacks (see
+\Func{unw\_create\_addr\_space}(3libunwind)).
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{libunwind-ia64(3)},
-\SeeAlso{unw\_get\_fpreg(3)},
-\SeeAlso{unw\_is\_fpreg(3)},
-\SeeAlso{unw\_is\_signal\_frame(3)},
-\SeeAlso{unw\_set\_reg(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{libunwind-ia64}(3libunwind),
+\SeeAlso{unw\_get\_fpreg}(3libunwind),
+\SeeAlso{unw\_is\_fpreg}(3libunwind),
+\SeeAlso{unw\_is\_signal\_frame}(3libunwind),
+\SeeAlso{unw\_set\_reg}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_set_iterate_phdr_function.man
+++ b/doc/unw_set_iterate_phdr_function.man
@@ -1,7 +1,7 @@
 .\" *********************************** start of \input{common.tex}
 .\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Sun May  7 19:41:20 2023
+.\" Manual page created with latex2man on Tue Aug 29 11:10:10 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -12,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_SET\\_ITERATE\\_PHDR\\_FUNCTION" "3" "07 May 2023" "Programming Library " "Programming Library "
+.TH "UNW\\_SET\\_ITERATE\\_PHDR\\_FUNCTION" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_set_iterate_phdr_function
 \-\- set dl_iterate_phdr
@@ -45,8 +45,8 @@ function);
 
 .PP
 The unw_set_iterate_phdr_function()
-routine sets the dl_iterate_phdr\-implementation
-of address space as
+routine sets the dl_iterate_phdr
+implementation of address space as
 to the function by argument function\&.
 The function
 will be called whenever libunwind
@@ -60,7 +60,7 @@ Though the burden lies on the user of libunwind\&.
 
 .PP
 unw_set_iterate_phdr_function()
-is thread\-safe. If the local address\-space 
+is thread safe. If the local address space 
 is passed in argument as,
 this routine is also safe to use from 
 a signal handler. 
@@ -68,9 +68,9 @@ a signal handler.
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_create_addr_space(3),
-dl_iterate_phdr(3),
+libunwind(3libunwind),
+unw_create_addr_space(3libunwind),
+dl_iterate_phdr(3libunwind),
 .PP
 .SH AUTHOR
 

--- a/doc/unw_set_iterate_phdr_function.tex
+++ b/doc/unw_set_iterate_phdr_function.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_set\_iterate\_phdr\_function}{Bert Wesarg}{Programming Library}{unw\_set\_iterate\_phdr\_function}unw\_set\_iterate\_phdr\_function -- set \Func{dl\_iterate\_phdr} implementation
+\begin{Name}{3libunwind}{unw\_set\_iterate\_phdr\_function}{Bert Wesarg}{Programming Library}{unw\_set\_iterate\_phdr\_function}unw\_set\_iterate\_phdr\_function -- set \Func{dl\_iterate\_phdr} implementation
 \end{Name}
 
 \section{Synopsis}
@@ -13,14 +13,21 @@
 
 \File{\#include $<$libunwind.h$>$}\\
 
-\Type{typedef~int} \Func{(*unw_iterate_phdr_callback_t)}(\Type{struct~dl_phdr_info~*}, \Type{size_t}, \Type{void~*});\\
-\Type{typedef~int} \Func{(*unw_iterate_phdr_func_t)}(\Type{unw_iterate_phdr_callback_t}, \Type{void~*});\\
+\noindent
+\Type{typedef~int}
+\Func{(*unw\_iterate\_phdr\_callback\_t)}(\Type{struct~dl\_phdr\_info~*},
+        \Type{size\_t}, \Type{void~*});\\
+\noindent
+\Type{typedef~int} \Func{(*unw\_iterate\_phdr\_func\_t)}(\Type{unw\_iterate\_phdr\_callback\_t},
+        \Type{void~*});\\
 
-\Type{void} \Func{unw\_set\_iterate\_phdr\_function}(\Type{unw\_addr\_space\_t} \Var{as}, \Type{unw_iterate_phdr_func_t} \Var{function});\\
+\noindent
+\Type{void} \Func{unw\_set\_iterate\_phdr\_function}(\Type{unw\_addr\_space\_t}
+        \Var{as}, \Type{unw\_iterate\_phdr\_func\_t} \Var{function});\\
 
 \section{Description}
 
-The \Func{unw\_set\_iterate\_phdr\_function}() routine sets the \Func{dl\_iterate\_phdr}-implementation of address space \Var{as} to the function by argument \Var{function}.
+The \Func{unw\_set\_iterate\_phdr\_function}() routine sets the \Func{dl\_iterate\_phdr} implementation of address space \Var{as} to the function by argument \Var{function}.
 The \Var{function} will be called whenever \Prog{libunwind} needs to iterate over the program headers of the application.
 This is normally done by calling \Func{dl\_iterate\_phdr}, but this function is not signal safe.
 With the help of a custom implementation caching and iterating over the program headers is also possible in an signal-safe manner.
@@ -28,16 +35,16 @@ Though the burden lies on the user of \Prog{libunwind}.
 
 \section{Thread and Signal Safety}
 
-\Func{unw\_set\_iterate\_phdr\_function}() is thread-safe.  If the local address-space
+\Func{unw\_set\_iterate\_phdr\_function}() is thread safe.  If the local address space
 is passed in argument \Var{as}, this routine is also safe to use from
 a signal handler.
 
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_create\_addr\_space(3)},
-\SeeAlso{dl\_iterate\_phdr(3)},
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_create\_addr\_space}(3libunwind),
+\SeeAlso{dl\_iterate\_phdr}(3libunwind),
 
 \section{Author}
 

--- a/doc/unw_set_reg.man
+++ b/doc/unw_set_reg.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 11:06:25 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_SET\\_REG" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_SET\\_REG" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_set_reg
 \-\- set register contents 
@@ -39,22 +41,22 @@ in the stack frame identified by cursor cp
 to the 
 value passed in val\&.
 .PP
-The register numbering is target\-dependent and described in separate 
-manual pages (e.g., libunwind\-ia64(3) for the IA\-64 target). 
+The register numbering is target dependent and described in separate 
+manual pages (e.g., libunwind\-ia64(3libunwind) for the IA\-64 target). 
 Furthermore, the exact set of accessible registers may depend on the 
 type of frame that cp
 is referring to. For ordinary stack 
 frames, it is normally possible to access only the preserved 
 (``callee\-saved\&'') registers and frame\-related registers (such as the 
-stack\-pointer). However, for signal frames (see 
-unw_is_signal_frame(3)),
+stack pointer). However, for signal frames (see 
+unw_is_signal_frame(3libunwind)),
 it is usually possible to access 
 all registers. 
 .PP
 Note that unw_set_reg()
 can only write the contents of 
 registers whose values fit in a single word. See 
-unw_set_fpreg(3)
+unw_set_fpreg(3libunwind)
 for a way to write registers which do not 
 fit this constraint. 
 .PP
@@ -63,7 +65,7 @@ fit this constraint.
 .PP
 On successful completion, unw_set_reg()
 returns 0. 
-Otherwise the negative value of one of the error\-codes below is 
+Otherwise the negative value of one of the error codes below is 
 returned. 
 .PP
 .SH THREAD AND SIGNAL SAFETY
@@ -94,17 +96,17 @@ the access_mem(),
 access_reg(),
 and 
 access_fpreg()
-call\-backs (see 
-unw_create_addr_space(3)).
+callbacks (see 
+unw_create_addr_space(3libunwind)).
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-libunwind\-ia64(3),
-unw_get_reg(3),
-unw_is_signal_frame(3),
-unw_set_fpreg(3)
+libunwind(3libunwind),
+libunwind\-ia64(3libunwind),
+unw_get_reg(3libunwind),
+unw_is_signal_frame(3libunwind),
+unw_set_fpreg(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_set_reg.tex
+++ b/doc/unw_set_reg.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_set\_reg}{David Mosberger-Tang}{Programming Library}{unw\_set\_reg}unw\_set\_reg -- set register contents
+\begin{Name}{3libunwind}{unw\_set\_reg}{David Mosberger-Tang}{Programming Library}{unw\_set\_reg}unw\_set\_reg -- set register contents
 \end{Name}
 
 \section{Synopsis}
@@ -20,25 +20,25 @@ The \Func{unw\_set\_reg}() routine sets the value of register
 \Var{reg} in the stack frame identified by cursor \Var{cp} to the
 value passed in \Var{val}.
 
-The register numbering is target-dependent and described in separate
-manual pages (e.g., libunwind-ia64(3) for the IA-64 target).
+The register numbering is target dependent and described in separate
+manual pages (e.g., libunwind-ia64(3libunwind) for the IA-64 target).
 Furthermore, the exact set of accessible registers may depend on the
 type of frame that \Var{cp} is referring to.  For ordinary stack
 frames, it is normally possible to access only the preserved
 (``callee-saved'') registers and frame-related registers (such as the
-stack-pointer).  However, for signal frames (see
-\Func{unw\_is\_signal\_frame}(3)), it is usually possible to access
+stack pointer).  However, for signal frames (see
+\Func{unw\_is\_signal\_frame}(3libunwind)), it is usually possible to access
 all registers.
 
 Note that \Func{unw\_set\_reg}() can only write the contents of
 registers whose values fit in a single word.  See
-\Func{unw\_set\_fpreg}(3) for a way to write registers which do not
+\Func{unw\_set\_fpreg}(3libunwind) for a way to write registers which do not
 fit this constraint.
 
 \section{Return Value}
 
 On successful completion, \Func{unw\_set\_reg}() returns 0.
-Otherwise the negative value of one of the error-codes below is
+Otherwise the negative value of one of the error codes below is
 returned.
 
 \section{Thread and Signal Safety}
@@ -57,16 +57,16 @@ from a signal handler.
 \end{Description}
 In addition, \Func{unw\_set\_reg}() may return any error returned by
 the \Func{access\_mem}(), \Func{access\_reg}(), and
-\Func{access\_fpreg}() call-backs (see
-\Func{unw\_create\_addr\_space}(3)).
+\Func{access\_fpreg}() callbacks (see
+\Func{unw\_create\_addr\_space}(3libunwind)).
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{libunwind-ia64(3)},
-\SeeAlso{unw\_get\_reg(3)},
-\SeeAlso{unw\_is\_signal\_frame(3)},
-\SeeAlso{unw\_set\_fpreg(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{libunwind-ia64}(3libunwind),
+\SeeAlso{unw\_get\_reg}(3libunwind),
+\SeeAlso{unw\_is\_signal\_frame}(3libunwind),
+\SeeAlso{unw\_set\_fpreg}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_step.man
+++ b/doc/unw_step.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Thu Aug 16 09:44:45 MDT 2007
+.\" Manual page created with latex2man on Tue Aug 29 10:53:42 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_STEP" "3" "16 August 2007" "Programming Library " "Programming Library "
+.TH "UNW\\_STEP" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_step
 \-\- advance to next stack frame 
@@ -87,13 +89,13 @@ get_dyn_info_list_addr(),
 access_mem(),
 access_reg(),
 or access_fpreg()
-call\-backs (see unw_create_addr_space(3)).
+call\-backs (see unw_create_addr_space(3libunwind)).
 .PP
 .SH SEE ALSO
 
 .PP
-libunwind(3),
-unw_create_addr_space(3)
+libunwind(3libunwind),
+unw_create_addr_space(3libunwind)
 .PP
 .SH AUTHOR
 

--- a/doc/unw_step.tex
+++ b/doc/unw_step.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_step}{David Mosberger-Tang}{Programming Library}{unw\_step}unw\_step -- advance to next stack frame
+\begin{Name}{3libunwind}{unw\_step}{David Mosberger-Tang}{Programming Library}{unw\_step}unw\_step -- advance to next stack frame
 \end{Name}
 
 \section{Synopsis}
@@ -50,12 +50,12 @@ address-space, this routine is also safe to use from a signal handler.
 In addition, \Func{unw\_step}() may return any error returned by the
 \Func{find\_proc\_info}(), \Func{get\_dyn\_info\_list\_addr}(),
 \Func{access\_mem}(), \Func{access\_reg}(), or \Func{access\_fpreg}()
-call-backs (see \Func{unw\_create\_addr\_space}(3)).
+call-backs (see \Func{unw\_create\_addr\_space}(3libunwind)).
 
 \section{See Also}
 
-\SeeAlso{libunwind(3)},
-\SeeAlso{unw\_create\_addr\_space(3)}
+\SeeAlso{libunwind}(3libunwind),
+\SeeAlso{unw\_create\_addr\_space}(3libunwind)
 
 \section{Author}
 

--- a/doc/unw_strerror.man
+++ b/doc/unw_strerror.man
@@ -1,5 +1,7 @@
+.\" *********************************** start of \input{common.tex}
+.\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Wed Aug 18 16:51:29 CEST 2004
+.\" Manual page created with latex2man on Tue Aug 29 10:53:42 2023
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -10,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_STRERROR" "3" "18 August 2004" "Programming Library " "Programming Library "
+.TH "UNW\\_STRERROR" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
 .SH NAME
 unw_strerror
 \-\- get text corresponding to error code 
@@ -53,11 +55,11 @@ from a signal handler.
 
 .PP
 Thomas Hallgren
-.br 
+.br
 BEA Systems
-.br 
+.br
 Stockholm, Sweden
-.br 
+.br
 Email: \fBthallgre@bea.com\fP
 .br
 .\" NOTE: This file is generated, DO NOT EDIT.

--- a/doc/unw_strerror.tex
+++ b/doc/unw_strerror.tex
@@ -5,7 +5,7 @@
 
 \begin{document}
 
-\begin{Name}{3}{unw\_strerror}{Thomas Hallgren}{Programming Library}{unw\_strerror}unw\_strerror -- get text corresponding to error code
+\begin{Name}{3libunwind}{unw\_strerror}{Thomas Hallgren}{Programming Library}{unw\_strerror}unw\_strerror -- get text corresponding to error code
 \end{Name}
 
 \section{Synopsis}


### PR DESCRIPTION
It's a convention that unadorned section 3 man pages are libc functions and other libraries adorn the section name.

Also added example code to the ptrace and nto remotes and fixed some unusual Engish-language constructs.

Regenerated all man pages from their LaTEX sources.