### PR TITLE
Fix lose caller frame of kernel call on QNX aarch64

### DIFF
--- a/include/libunwind-common.h.in
+++ b/include/libunwind-common.h.in
@@ -208,6 +208,13 @@ typedef struct unw_accessors
     int (*get_proc_name) (unw_addr_space_t, unw_word_t, char *, size_t,
 			  unw_word_t *, void *);
 
+    /* Optional call back to obtain the start and end ip of a procedure.
+     * procedure ip range is [start, end), the range is without end.
+     * This callback is optional and may be set to NULL.
+     */
+    int (*get_proc_ip_range) (unw_addr_space_t, unw_word_t, unw_word_t *,
+			  unw_word_t *, void *);
+
     /* Optional call back to return a mask to be used with pointer
      * authentication on arm64.
      *

--- a/include/libunwind-nto.h
+++ b/include/libunwind-nto.h
@@ -53,6 +53,7 @@ extern int unw_nto_access_mem(unw_addr_space_t, unw_word_t, unw_word_t *, int, v
 extern int unw_nto_access_reg(unw_addr_space_t, unw_regnum_t, unw_word_t *, int, void *);
 extern int unw_nto_access_fpreg(unw_addr_space_t, unw_regnum_t, unw_fpreg_t *, int, void *);
 extern int unw_nto_get_proc_name(unw_addr_space_t, unw_word_t, char *, size_t, unw_word_t *, void *);
+extern int unw_nto_get_proc_ip_range (unw_addr_space_t as, unw_word_t ip, unw_word_t *start, unw_word_t *end, void *);
 extern int unw_nto_resume(unw_addr_space_t, unw_cursor_t *, void *);
 
 /**

--- a/src/elfxx.h
+++ b/src/elfxx.h
@@ -53,6 +53,14 @@ extern int elf_w (get_proc_name_in_image) (unw_addr_space_t as,
                                            unw_word_t ip,
                                            char *buf, size_t buf_len, unw_word_t *offp);
 
+extern int elf_w (get_proc_ip_range) (unw_addr_space_t as,
+                                      pid_t pid, unw_word_t ip,
+                                      unw_word_t *start, unw_word_t *end);
+
+extern int elf_w (get_proc_ip_range_in_image) (unw_addr_space_t as, struct elf_image *ei,
+                                               unsigned long segbase, unw_word_t ip,
+                                               unw_word_t *start, unw_word_t *end);
+
 extern Elf_W (Shdr)* elf_w (find_section) (const struct elf_image *ei, const char* secname);
 extern int elf_w (load_debuginfo) (const char* file, struct elf_image *ei, int is_local);
 

--- a/src/nto/unw_nto_accessors.c
+++ b/src/nto/unw_nto_accessors.c
@@ -37,6 +37,7 @@ unw_accessors_t unw_nto_accessors =
   .access_reg              = unw_nto_access_reg,
   .access_fpreg            = unw_nto_access_fpreg,
   .resume                  = unw_nto_resume,
-  .get_proc_name           = unw_nto_get_proc_name
+  .get_proc_name           = unw_nto_get_proc_name,
+  .get_proc_ip_range       = unw_nto_get_proc_ip_range,
 };
 

--- a/src/nto/unw_nto_get_proc_name.c
+++ b/src/nto/unw_nto_get_proc_name.c
@@ -67,3 +67,22 @@ int unw_nto_get_proc_name (unw_addr_space_t  as,
   return ret;
 }
 
+int unw_nto_get_proc_ip_range (unw_addr_space_t  as,
+                               unw_word_t        ip,
+                               unw_word_t       *start,
+                               unw_word_t       *end,
+                               void *arg)
+{
+  unw_nto_internal_t *uni = (unw_nto_internal_t *)arg;
+  int ret = -UNW_ENOINFO;
+
+#if UNW_ELF_CLASS == UNW_ELFCLASS64
+  ret = _Uelf64_get_proc_ip_range (as, uni->pid, ip, start, end);
+#elif UNW_ELF_CLASS == UNW_ELFCLASS32
+  ret = _Uelf32_get_proc_ip_range (as, uni->pid, ip, start, end);
+#else
+# error no valid ELF class defined
+#endif
+
+  return ret;
+}


### PR DESCRIPTION
QNX aarch64 kernel call without frame pointer and cfi directives, this will fallback to use frame pointer unwinder, but the frame pointer is caller's frame pointer, causing caller frame be skipped.

Try to sniff kernel call pattern, get procedure's ip range by symtab and do the matchup from the beginning of procedure. If matched, then fallback to use link register unwinder.

This patch try to fix https://github.com/libunwind/libunwind/issues/603#issue-1865190934.