### PR TITLE
Fix unaligned memory accesses in */Ginit.c

### DIFF
--- a/src/aarch64/Ginit.c
+++ b/src/aarch64/Ginit.c
@@ -132,7 +132,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (unlikely (write))
     {
       Debug (16, "mem[%lx] <- %lx\n", addr, *val);
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
     }
   else
     {
@@ -143,7 +143,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
         Debug (16, "mem[%016lx] -> invalid\n", addr);
         return -1;
       }
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (16, "mem[%lx] -> %lx\n", addr, *val);
     }
   return 0;
@@ -164,12 +164,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 
   if (write)
     {
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- %lx\n", unw_regname (reg), *val);
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "%s -> %lx\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/aarch64/Ginit.c
+++ b/src/aarch64/Ginit.c
@@ -132,7 +132,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (unlikely (write))
     {
       Debug (16, "mem[%lx] <- %lx\n", addr, *val);
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
     }
   else
     {
@@ -143,7 +143,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
         Debug (16, "mem[%016lx] -> invalid\n", addr);
         return -1;
       }
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (16, "mem[%lx] -> %lx\n", addr, *val);
     }
   return 0;
@@ -164,12 +164,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 
   if (write)
     {
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- %lx\n", unw_regname (reg), *val);
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "%s -> %lx\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/arm/Ginit.c
+++ b/src/arm/Ginit.c
@@ -83,7 +83,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (write)
     {
       Debug (16, "mem[%x] <- %x\n", addr, *val);
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
     }
   else
     {
@@ -93,7 +93,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
           Debug (16, "mem[%#010lx] -> invalid\n", (long)addr);
           return -1;
         }
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (16, "mem[%#010lx] -> %#010lx\n", (long)addr, (long)*val);
     }
   return 0;
@@ -114,12 +114,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 
   if (write)
     {
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- %x\n", unw_regname (reg), *val);
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "%s -> %x\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/arm/Ginit.c
+++ b/src/arm/Ginit.c
@@ -83,7 +83,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (write)
     {
       Debug (16, "mem[%x] <- %x\n", addr, *val);
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
     }
   else
     {
@@ -93,7 +93,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
           Debug (16, "mem[%#010lx] -> invalid\n", (long)addr);
           return -1;
         }
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (16, "mem[%#010lx] -> %#010lx\n", (long)addr, (long)*val);
     }
   return 0;
@@ -114,12 +114,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 
   if (write)
     {
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- %x\n", unw_regname (reg), *val);
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "%s -> %x\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/hppa/Ginit.c
+++ b/src/hppa/Ginit.c
@@ -91,11 +91,11 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (write)
     {
       Debug (12, "mem[%x] <- %x\n", addr, *val);
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "mem[%x] -> %x\n", addr, *val);
     }
   return 0;
@@ -117,12 +117,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 
   if (write)
     {
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- %x\n", unw_regname (reg), *val);
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "%s -> %x\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/hppa/Ginit.c
+++ b/src/hppa/Ginit.c
@@ -91,11 +91,11 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (write)
     {
       Debug (12, "mem[%x] <- %x\n", addr, *val);
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "mem[%x] -> %x\n", addr, *val);
     }
   return 0;
@@ -117,12 +117,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 
   if (write)
     {
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- %x\n", unw_regname (reg), *val);
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "%s -> %x\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/ia64/Ginit.c
+++ b/src/ia64/Ginit.c
@@ -80,11 +80,11 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (write)
     {
       Debug (12, "mem[%lx] <- %lx\n", addr, *val);
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "mem[%lx] -> %lx\n", addr, *val);
     }
   return 0;
@@ -293,7 +293,7 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "%s -> %lx\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/ia64/Ginit.c
+++ b/src/ia64/Ginit.c
@@ -80,11 +80,11 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (write)
     {
       Debug (12, "mem[%lx] <- %lx\n", addr, *val);
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "mem[%lx] -> %lx\n", addr, *val);
     }
   return 0;
@@ -293,7 +293,7 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "%s -> %lx\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/ppc32/Ginit.c
+++ b/src/ppc32/Ginit.c
@@ -136,11 +136,11 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (write)
     {
       Debug (12, "mem[%lx] <- %lx\n", addr, *val);
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "mem[%lx] -> %lx\n", addr, *val);
     }
   return 0;
@@ -163,12 +163,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val,
 
   if (write)
     {
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- %lx\n", unw_regname (reg), *val);
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "%s -> %lx\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/ppc32/Ginit.c
+++ b/src/ppc32/Ginit.c
@@ -136,11 +136,11 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (write)
     {
       Debug (12, "mem[%lx] <- %lx\n", addr, *val);
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "mem[%lx] -> %lx\n", addr, *val);
     }
   return 0;
@@ -163,12 +163,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val,
 
   if (write)
     {
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- %lx\n", unw_regname (reg), *val);
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "%s -> %lx\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/ppc64/Ginit.c
+++ b/src/ppc64/Ginit.c
@@ -144,11 +144,11 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (write)
     {
       Debug (12, "mem[%lx] <- %lx\n", addr, *val);
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "mem[%lx] -> %lx\n", addr, *val);
     }
   return 0;
@@ -172,12 +172,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val,
 
   if (write)
     {
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- %lx\n", unw_regname (reg), *val);
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "%s -> %lx\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/ppc64/Ginit.c
+++ b/src/ppc64/Ginit.c
@@ -144,11 +144,11 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (write)
     {
       Debug (12, "mem[%lx] <- %lx\n", addr, *val);
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "mem[%lx] -> %lx\n", addr, *val);
     }
   return 0;
@@ -172,12 +172,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val,
 
   if (write)
     {
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- %lx\n", unw_regname (reg), *val);
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "%s -> %lx\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/riscv/Ginit.c
+++ b/src/riscv/Ginit.c
@@ -115,7 +115,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
         Debug (16, "mem[%016lx] -> invalid\n", addr);
         return -1;
       }
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (16, "mem[%lx] -> %lx\n", addr, *val);
     }
   return 0;
@@ -142,7 +142,7 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "%s -> %lx\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/riscv/Ginit.c
+++ b/src/riscv/Ginit.c
@@ -115,7 +115,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
         Debug (16, "mem[%016lx] -> invalid\n", addr);
         return -1;
       }
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (16, "mem[%lx] -> %lx\n", addr, *val);
     }
   return 0;
@@ -142,7 +142,7 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "%s -> %lx\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/s390x/Ginit.c
+++ b/src/s390x/Ginit.c
@@ -101,7 +101,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (unlikely (write))
     {
       Debug (16, "mem[%016lx] <- %lx\n", addr, *val);
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
     }
   else
     {
@@ -112,7 +112,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
         Debug (16, "mem[%016lx] -> invalid\n", addr);
         return -1;
       }
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (16, "mem[%016lx] -> %lx\n", addr, *val);
     }
   return 0;
@@ -133,12 +133,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 
   if (write)
     {
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- 0x%016lx\n", unw_regname (reg), *val);
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "%s -> 0x%016lx\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/s390x/Ginit.c
+++ b/src/s390x/Ginit.c
@@ -101,7 +101,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (unlikely (write))
     {
       Debug (16, "mem[%016lx] <- %lx\n", addr, *val);
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
     }
   else
     {
@@ -112,7 +112,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
         Debug (16, "mem[%016lx] -> invalid\n", addr);
         return -1;
       }
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (16, "mem[%016lx] -> %lx\n", addr, *val);
     }
   return 0;
@@ -133,12 +133,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 
   if (write)
     {
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- 0x%016lx\n", unw_regname (reg), *val);
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "%s -> 0x%016lx\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/sh/Ginit.c
+++ b/src/sh/Ginit.c
@@ -85,11 +85,11 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (write)
     {
       Debug (16, "mem[%x] <- %x\n", addr, *val);
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (16, "mem[%x] -> %x\n", addr, *val);
     }
   return 0;
@@ -110,12 +110,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 
   if (write)
     {
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- %x\n", unw_regname (reg), *val);
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "%s -> %x\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/sh/Ginit.c
+++ b/src/sh/Ginit.c
@@ -85,11 +85,11 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (write)
     {
       Debug (16, "mem[%x] <- %x\n", addr, *val);
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (16, "mem[%x] -> %x\n", addr, *val);
     }
   return 0;
@@ -110,12 +110,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 
   if (write)
     {
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- %x\n", unw_regname (reg), *val);
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "%s -> %x\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/x86/Ginit.c
+++ b/src/x86/Ginit.c
@@ -82,7 +82,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (write)
     {
       Debug (16, "mem[%x] <- %x\n", addr, *val);
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
     }
   else
     {
@@ -93,7 +93,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
           Debug (16, "mem[%#010lx] -> invalid\n", (long)addr);
           return -1;
         }
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (16, "mem[%x] -> %x\n", addr, *val);
     }
   return 0;
@@ -114,12 +114,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 
   if (write)
     {
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- %x\n", unw_regname (reg), *val);
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "%s -> %x\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/x86/Ginit.c
+++ b/src/x86/Ginit.c
@@ -82,7 +82,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   if (write)
     {
       Debug (16, "mem[%x] <- %x\n", addr, *val);
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
     }
   else
     {
@@ -93,7 +93,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
           Debug (16, "mem[%#010lx] -> invalid\n", (long)addr);
           return -1;
         }
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (16, "mem[%x] -> %x\n", addr, *val);
     }
   return 0;
@@ -114,12 +114,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 
   if (write)
     {
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- %x\n", unw_regname (reg), *val);
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "%s -> %x\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/x86_64/Ginit.c
+++ b/src/x86_64/Ginit.c
@@ -81,7 +81,7 @@ access_mem (unw_addr_space_t as UNUSED, unw_word_t addr, unw_word_t *val, int wr
   if (unlikely (write))
     {
       Debug (16, "mem[%016lx] <- %lx\n", addr, *val);
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
     }
   else
     {
@@ -91,7 +91,7 @@ access_mem (unw_addr_space_t as UNUSED, unw_word_t addr, unw_word_t *val, int wr
         Debug (16, "mem[%016lx] -> invalid\n", addr);
         return -1;
       }
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (16, "mem[%016lx] -> %lx\n", addr, *val);
     }
   return 0;
@@ -112,12 +112,12 @@ access_reg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_word_t *val, int w
 
   if (write)
     {
-      *(unw_word_t *) addr = *val;
+      memcpy (addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- 0x%016lx\n", unw_regname (reg), *val);
     }
   else
     {
-      *val = *(unw_word_t *) addr;
+      memcpy (val, addr, sizeof(unw_word_t));
       Debug (12, "%s -> 0x%016lx\n", unw_regname (reg), *val);
     }
   return 0;

--- a/src/x86_64/Ginit.c
+++ b/src/x86_64/Ginit.c
@@ -81,7 +81,7 @@ access_mem (unw_addr_space_t as UNUSED, unw_word_t addr, unw_word_t *val, int wr
   if (unlikely (write))
     {
       Debug (16, "mem[%016lx] <- %lx\n", addr, *val);
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
     }
   else
     {
@@ -91,7 +91,7 @@ access_mem (unw_addr_space_t as UNUSED, unw_word_t addr, unw_word_t *val, int wr
         Debug (16, "mem[%016lx] -> invalid\n", addr);
         return -1;
       }
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (16, "mem[%016lx] -> %lx\n", addr, *val);
     }
   return 0;
@@ -112,12 +112,12 @@ access_reg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_word_t *val, int w
 
   if (write)
     {
-      memcpy (addr, val, sizeof(unw_word_t));
+      memcpy ((void *) addr, val, sizeof(unw_word_t));
       Debug (12, "%s <- 0x%016lx\n", unw_regname (reg), *val);
     }
   else
     {
-      memcpy (val, addr, sizeof(unw_word_t));
+      memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "%s -> 0x%016lx\n", unw_regname (reg), *val);
     }
   return 0;


### PR DESCRIPTION
This was detected by UBSan:
```
/worker/build/66bf5b2131e0cc44/root/external/libunwind/src/aarch64/Ginit.c:362:14: runtime error: load of misaligned address 0xffff7ffd376c for type 'unw_word_t', which requires 8 byte alignment
```

Partial stack trace in v1.7.2:
```
#5  0x000000000044ad14 in access_mem (as=0x570638 <local_addr_space>, addr=281474809427820, val=0xffffffffcf38, write=0, arg=0xffffffffd420) at /worker/build/66bf5b2131e0cc44/root/external/libunwind/src/aarch64/Ginit.c:362
#6  0x000000000044b7fc in _Uaarch64_is_signal_frame (cursor=0xffffffffd420) at /worker/build/66bf5b2131e0cc44/root/external/libunwind/src/aarch64/Gis_signal_frame.c:51
#7  0x00000000004535e0 in _Uaarch64_step (cursor=0xffffffffd420) at /worker/build/66bf5b2131e0cc44/root/external/libunwind/src/aarch64/Gstep.c:204
```

The same issue applies to other architectures as well.

Fixes #340 
Fixes #530