### PR TITLE
Fix maps leak if caller's pathlen is too small

### DIFF
--- a/src/os-linux.c
+++ b/src/os-linux.c
@@ -91,7 +91,10 @@ tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
   if(!path)
     full_path = (char*) malloc (_len);
   else if(_len >= pathlen) // passed buffer is too small, fail
-    return -1;
+    {
+      maps_close (&mi);
+      return -1;
+    }
 
   strcpy (full_path, root);
   strcat (full_path, mi.path);


### PR DESCRIPTION
`maps_close` should be called when passed path buffer is too small