### PR TITLE
Import config.h before dwarf-config.h.

### DIFF
--- a/include/dwarf.h
+++ b/include/dwarf.h
@@ -32,11 +32,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 struct dwarf_cursor;    /* forward-declaration */
 struct elf_dyn_info;
 
-#include "dwarf-config.h"
-
 #ifdef HAVE_CONFIG_H
 # include "config.h"
 #endif
+
+#include "dwarf-config.h"
 
 #ifndef UNW_REMOTE_ONLY
   #if defined(HAVE_LINK_H)


### PR DESCRIPTION
Header tdep-x86_64/dwarf-config.h depends on config.h because it uses CONFIG_MSABI_SUPPORT.

I discovered this problem because some compilation units actually import config.h before dwarf-config.h, and some others don't. So the `struct dwarf_cursor` definition was different in different compilation units, which caused segfaults.

I'm not sure if the proposed fix is the best one, or if dwarf-config.h should rather include config.h directly. Feel free to adjust accordingly.