### PR TITLE
Fix clang x86_64 unit test failure

### DIFF
--- a/tests/Gtest-bt.c
+++ b/tests/Gtest-bt.c
@@ -259,6 +259,8 @@ main (int argc, char **argv UNUSED)
   act.sa_sigaction = segv_handler;
   if (sigaction (SIGSEGV, &act, NULL) < 0)
     panic ("sigaction: %s\n", strerror (errno));
+  if (sigaction (SIGILL, &act, NULL) < 0)
+    panic ("sigaction: %s\n", strerror (errno));
 
   if (sigsetjmp (env, 1) == 0)
   {


### PR DESCRIPTION
For whatever reason the clang runtime started raising a SIGILL instead of a SIGSEGV when dereferencing NULL. Fixed the test case to trap both signals.