### PR TITLE
Fix build on FreeBSD i386

### DIFF
--- a/src/x86/Gos-freebsd.c
+++ b/src/x86/Gos-freebsd.c
@@ -111,6 +111,7 @@ x86_handle_signal_frame (unw_cursor_t *cursor)
     struct sigframe *sf;
     uintptr_t uc_addr;
     struct dwarf_loc esp_loc;
+    int i;
 
     sf = (struct sigframe *)c->dwarf.cfa;
     uc_addr = (uintptr_t)&(sf->sf_uc);


### PR DESCRIPTION
The error message is as follows:
```
--- x86/Gos-freebsd.lo ---
x86/Gos-freebsd.c:127:10: error: use of undeclared identifier 'i'
    for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
         ^
x86/Gos-freebsd.c:127:17: error: use of undeclared identifier 'i'
    for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
                ^
x86/Gos-freebsd.c:127:49: error: use of undeclared identifier 'i'
    for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
                                                ^
x86/Gos-freebsd.c:128:20: error: use of undeclared identifier 'i'
      c->dwarf.loc[i] = DWARF_NULL_LOC;
                   ^
4 errors generated.
*** [x86/Gos-freebsd.lo] Error code 1
```