### PR TITLE
Use pkg-config to find dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -413,38 +413,32 @@ if test x$enable_msabi_support = xyes; then
 fi
 AC_MSG_RESULT([$enable_msabi_support])
 
-LIBLZMA=
 AC_MSG_CHECKING([whether to support LZMA-compressed symbol tables])
 AC_ARG_ENABLE(minidebuginfo,
 AS_HELP_STRING([--enable-minidebuginfo], [Enables support for LZMA-compressed symbol tables]),, [enable_minidebuginfo=auto])
 AC_MSG_RESULT([$enable_minidebuginfo])
-if test x$enable_minidebuginfo != xno; then
-   AC_CHECK_LIB([lzma], [lzma_mf_is_supported],
-   [LIBLZMA=-llzma
-    AC_DEFINE([HAVE_LZMA], [1], [Define if you have liblzma])
+AS_IF([test x$enable_minidebuginfo != xno], [
+   PKG_CHECK_MODULES([LIBLZMA], [liblzma],
+   [AC_DEFINE([HAVE_LZMA], [1], [Define if you have liblzma])
     enable_minidebuginfo=yes],
    [if test x$enable_minidebuginfo = xyes; then
       AC_MSG_FAILURE([liblzma not found])
     fi])
-fi
-AC_SUBST([LIBLZMA])
+])
 AM_CONDITIONAL(HAVE_LZMA, test x$enable_minidebuginfo = xyes)
 
-LIBZ=
 AC_MSG_CHECKING([whether to support ZLIB-compressed symbol tables])
 AC_ARG_ENABLE(zlibdebuginfo,
 AS_HELP_STRING([--enable-zlibdebuginfo], [Enables support for ZLIB-compressed symbol tables]),, [enable_zlibdebuginfo=auto])
 AC_MSG_RESULT([$enable_zlibdebuginfo])
-if test x$enable_zlibdebuginfo != xno; then
-   AC_CHECK_LIB([z], [uncompress],
-   [LIBZ=-lz
-    AC_DEFINE([HAVE_ZLIB], [1], [Define if you have libz])
+AS_IF([test x$enable_zlibdebuginfo != xno], [
+   PKG_CHECK_MODULES([LIBZ], [zlib],
+   [AC_DEFINE([HAVE_ZLIB], [1], [Define if you have libz])
     enable_zlibdebuginfo=yes],
    [if test x$enable_zlibdebuginfo = xyes; then
       AC_MSG_FAILURE([libz not found])
     fi])
-fi
-AC_SUBST([LIBZ])
+])
 AM_CONDITIONAL(HAVE_ZLIB, test x$enable_zlibdebuginfo = xyes)
 
 AC_MSG_CHECKING([for Intel compiler])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -151,12 +151,14 @@ libunwind_coredump_la_SOURCES =                \
 	coredump/_UPT_get_dyn_info_list_addr.c \
 	coredump/_UPT_put_unwind_info.c        \
 	coredump/_UPT_resume.c
+libunwind_coredump_la_CFLAGS =                 \
+	$(LIBLZMA_CFLAGS) $(LIBZ_CFLAGS)
 libunwind_coredump_la_LDFLAGS =                \
 	$(COMMON_SO_LDFLAGS)                   \
 	-version-info $(COREDUMP_SO_VERSION)
 libunwind_coredump_la_LIBADD =                 \
 	libunwind-$(arch).la                   \
-	$(LIBLZMA) $(LIBZ)
+	$(LIBLZMA_LIBS) $(LIBZ_LIBS)
 
 ### libunwind-nto:
 noinst_HEADERS += nto/unw_nto_internal.h
@@ -197,9 +199,11 @@ libunwind_ptrace_la_SOURCES =                  \
 	ptrace/_UPT_put_unwind_info.c          \
 	ptrace/_UPT_reg_offset.c               \
 	ptrace/_UPT_resume.c
+libunwind_ptrace_la_CFLAGS =                   \
+	$(LIBLZMA_CFLAGS) $(LIBZ_CFLAGS)
 libunwind_ptrace_la_LIBADD =                   \
 	libunwind-$(arch).la                   \
-	$(LIBLZMA) $(LIBZ)
+	$(LIBLZMA_LIBS) $(LIBZ_LIBS)
 
 ### libunwind-setjmp:
 noinst_HEADERS += setjmp/setjmp_i.h
@@ -313,7 +317,11 @@ libunwind_dwarf_local_la_SOURCES =             \
 	dwarf/Lget_proc_info_in_range.c        \
 	dwarf/Lparser.c                        \
 	dwarf/Lpe.c
-libunwind_dwarf_local_la_LIBADD = libunwind-dwarf-common.la
+libunwind_dwarf_local_la_CFLAGS =          \
+	$(LIBZ_CFLAGS)
+libunwind_dwarf_local_la_LIBADD =          \
+	libunwind-dwarf-common.la              \
+	$(LIBZ_LIBS)
 
 libunwind_dwarf_generic_la_SOURCES =           \
 	dwarf/Gexpr.c                          \
@@ -323,7 +331,11 @@ libunwind_dwarf_generic_la_SOURCES =           \
 	dwarf/Gget_proc_info_in_range.c        \
 	dwarf/Gparser.c                        \
 	dwarf/Gpe.c
-libunwind_dwarf_generic_la_LIBADD = libunwind-dwarf-common.la
+libunwind_dwarf_generic_la_CFLAGS =        \
+	$(LIBZ_CFLAGS)
+libunwind_dwarf_generic_la_LIBADD =        \
+	libunwind-dwarf-common.la              \
+	$(LIBZ_LIBS)
 
 if USE_DWARF
  noinst_LTLIBRARIES += libunwind-dwarf-common.la libunwind-dwarf-generic.la
@@ -338,9 +350,12 @@ noinst_HEADERS += elf32.h elf64.h elfxx.h
 libunwind_elf32_la_SOURCES = elf32.c
 libunwind_elf64_la_SOURCES = elf64.c
 libunwind_elfxx_la_SOURCES = elfxx.c
-libunwind_elf32_la_LIBADD  = $(LIBLZMA) $(LIBZ)
-libunwind_elf64_la_LIBADD  = $(LIBLZMA) $(LIBZ)
-libunwind_elfxx_la_LIBADD  = $(LIBLZMA) $(LIBZ)
+libunwind_elf32_la_CFLAGS  = $(LIBLZMA_CFLAGS) $(LIBZ_CFLAGS)
+libunwind_elf64_la_CFLAGS  = $(LIBLZMA_CFLAGS) $(LIBZ_CFLAGS)
+libunwind_elfxx_la_CFLAGS  = $(LIBLZMA_CFLAGS) $(LIBZ_CFLAGS)
+libunwind_elf32_la_LIBADD  = $(LIBLZMA_LIBS) $(LIBZ_LIBS)
+libunwind_elf64_la_LIBADD  = $(LIBLZMA_LIBS) $(LIBZ_LIBS)
+libunwind_elfxx_la_LIBADD  = $(LIBLZMA_LIBS) $(LIBZ_LIBS)
 
 noinst_LTLIBRARIES += $(libunwind_elf_libs)
 libunwind_la_LIBADD += $(libunwind_elf_libs)
@@ -1242,7 +1257,8 @@ endif
 libunwind_la_LDFLAGS =	$(COMMON_SO_LDFLAGS) -XCClinker -nostdlib \
 			$(LDFLAGS_STATIC_LIBCXA) -version-info $(SOVERSION)
 libunwind_la_LIBADD  += -lc $(LIBCRTS)
-libunwind_la_LIBADD += $(LIBLZMA) $(LIBZ)
+libunwind_la_CFLAGS = $(LIBLZMA_CFLAGS) $(LIBZ_CFLAGS)
+libunwind_la_LIBADD += $(LIBLZMA_LIBS) $(LIBZ_LIBS)
 
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I.
 AM_CCASFLAGS = $(AM_CPPFLAGS)

--- a/src/unwind/libunwind.pc.in
+++ b/src/unwind/libunwind.pc.in
@@ -7,5 +7,5 @@ Name: libunwind
 Description: libunwind base library
 Version: @VERSION@
 Libs: -L${libdir} -lunwind
-Libs.private: @LIBLZMA@ @LIBZ@
+Libs.private: @LIBLZMA_LIBS@ @LIBZ_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
Currently the dependencies (zlib and liblzma) are found only through compiler checks. This means users wanting to customize these dependencies need to fiddle with `CFLAGS` and `LDFLAGS` to point to the one they want. This is inconvenient and nonstandard, and isn't the main purpose for these very generic variables.

This PR converts the dependency handling to use the standard `pkg-config` method instead. This allows users to customize the dependencies via `PKG_CONFIG_PATH`, no `*FLAGS` needed.