### PR TITLE
Ensure that structs are not empty

### DIFF
--- a/include/libunwind-hppa.h
+++ b/include/libunwind-hppa.h
@@ -32,6 +32,10 @@ extern "C" {
 #include <inttypes.h>
 #include <ucontext.h>
 
+#ifndef UNW_EMPTY_STRUCT
+#  define UNW_EMPTY_STRUCT uint8_t unused;
+#endif
+
 #define UNW_TARGET      hppa
 #define UNW_TARGET_HPPA 1
 
@@ -97,6 +101,7 @@ hppa_regnum_t;
 typedef struct unw_tdep_save_loc
   {
     /* Additional target-dependent info on a save location.  */
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_save_loc_t;
 
@@ -110,6 +115,7 @@ typedef ucontext_t unw_tdep_context_t;
 typedef struct
   {
     /* no PA-RISC-specific auxiliary proc-info */
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_proc_info_t;
 

--- a/include/libunwind-ia64.h
+++ b/include/libunwind-ia64.h
@@ -29,6 +29,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <inttypes.h>
 #include <ucontext.h>
 
+#ifndef UNW_EMPTY_STRUCT
+#  define UNW_EMPTY_STRUCT uint8_t unused;
+#endif
+
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {
 #endif
@@ -83,6 +87,7 @@ unw_tdep_fpreg_t;
 typedef struct
   {
     /* no ia64-specific auxiliary proc-info */
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_proc_info_t;
 

--- a/include/libunwind-loongarch64.h
+++ b/include/libunwind-loongarch64.h
@@ -34,6 +34,10 @@ extern "C" {
 #include <inttypes.h>
 #include <ucontext.h>
 
+#ifndef UNW_EMPTY_STRUCT
+#  define UNW_EMPTY_STRUCT uint8_t unused;
+#endif
+
 #define UNW_TARGET      loongarch64
 #define UNW_TARGET_LOONGARCH64 1
 
@@ -109,7 +113,7 @@ loongarch64_regnum_t;
 typedef struct unw_tdep_save_loc
   {
     /* Additional target-dependent info on a save location.  */
-    char unused;
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_save_loc_t;
 
@@ -119,7 +123,7 @@ typedef ucontext_t unw_tdep_context_t;
 typedef struct
   {
     /* no loongarch64-specific auxiliary proc-info */
-    char unused;
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_proc_info_t;
 

--- a/include/libunwind-mips.h
+++ b/include/libunwind-mips.h
@@ -36,6 +36,10 @@ extern "C" {
 # undef mips
 #endif
 
+#ifndef UNW_EMPTY_STRUCT
+#  define UNW_EMPTY_STRUCT uint8_t unused;
+#endif
+
 #define UNW_TARGET      mips
 #define UNW_TARGET_MIPS 1
 
@@ -127,6 +131,7 @@ mips_abi_t;
 typedef struct unw_tdep_save_loc
   {
     /* Additional target-dependent info on a save location.  */
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_save_loc_t;
 
@@ -139,6 +144,7 @@ typedef ucontext_t unw_tdep_context_t;
 typedef struct
   {
     /* no mips-specific auxiliary proc-info */
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_proc_info_t;
 

--- a/include/libunwind-ppc32.h
+++ b/include/libunwind-ppc32.h
@@ -39,6 +39,10 @@ extern "C" {
 #include <inttypes.h>
 #include <ucontext.h>
 
+#ifndef UNW_EMPTY_STRUCT
+#  define UNW_EMPTY_STRUCT uint8_t unused;
+#endif
+
 #define UNW_TARGET              ppc32
 #define UNW_TARGET_PPC32        1
 
@@ -175,6 +179,7 @@ ppc32_regnum_t;
 typedef struct unw_tdep_save_loc
   {
     /* Additional target-dependent info on a save location.  */
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_save_loc_t;
 
@@ -192,6 +197,7 @@ typedef ucontext_t unw_tdep_context_t;
 typedef struct
   {
     /* no ppc32-specific auxiliary proc-info */
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_proc_info_t;
 

--- a/include/libunwind-ppc64.h
+++ b/include/libunwind-ppc64.h
@@ -39,6 +39,10 @@ extern "C" {
 #include <inttypes.h>
 #include <ucontext.h>
 
+#ifndef UNW_EMPTY_STRUCT
+#  define UNW_EMPTY_STRUCT uint8_t unused;
+#endif
+
 #define UNW_TARGET              ppc64
 #define UNW_TARGET_PPC64        1
 
@@ -239,6 +243,7 @@ ppc64_abi_t;
 typedef struct unw_tdep_save_loc
   {
     /* Additional target-dependent info on a save location.  */
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_save_loc_t;
 
@@ -256,6 +261,7 @@ typedef ucontext_t unw_tdep_context_t;
 typedef struct
   {
     /* no ppc64-specific auxiliary proc-info */
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_proc_info_t;
 

--- a/include/libunwind-riscv.h
+++ b/include/libunwind-riscv.h
@@ -36,6 +36,10 @@ extern "C" {
 #include <inttypes.h>
 #include <ucontext.h>
 
+#ifndef UNW_EMPTY_STRUCT
+#  define UNW_EMPTY_STRUCT uint8_t unused;
+#endif
+
 #define UNW_TARGET              riscv
 #define UNW_TARGET_RISCV      1
 
@@ -157,7 +161,7 @@ riscv_regnum_t;
 typedef struct unw_tdep_save_loc
   {
     /* Additional target-dependent info on a save location.  */
-    char unused;
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_save_loc_t;
 
@@ -167,7 +171,7 @@ typedef ucontext_t unw_tdep_context_t;
 typedef struct
   {
     /* no riscv-specific auxiliary proc-info */
-    char unused;
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_proc_info_t;
 

--- a/include/libunwind-s390x.h
+++ b/include/libunwind-s390x.h
@@ -36,6 +36,10 @@ extern "C" {
 #include <inttypes.h>
 #include <ucontext.h>
 
+#ifndef UNW_EMPTY_STRUCT
+#  define UNW_EMPTY_STRUCT uint8_t unused;
+#endif
+
 #define UNW_TARGET              s390x
 #define UNW_TARGET_S390X        1
 
@@ -114,7 +118,7 @@ s390x_regnum_t;
 typedef struct unw_tdep_save_loc
   {
     /* Additional target-dependent info on a save location.  */
-    char unused;
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_save_loc_t;
 
@@ -124,7 +128,7 @@ typedef ucontext_t unw_tdep_context_t;
 typedef struct
   {
     /* no s390x-specific auxiliary proc-info */
-    char unused;
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_proc_info_t;
 

--- a/include/libunwind-sh.h
+++ b/include/libunwind-sh.h
@@ -34,6 +34,10 @@ extern "C" {
 #include <stddef.h>
 #include <ucontext.h>
 
+#ifndef UNW_EMPTY_STRUCT
+#  define UNW_EMPTY_STRUCT uint8_t unused;
+#endif
+
 #define UNW_TARGET      sh
 #define UNW_TARGET_SH   1
 
@@ -91,6 +95,7 @@ typedef ucontext_t unw_tdep_context_t;
 typedef struct unw_tdep_save_loc
   {
     /* Additional target-dependent info on a save location.  */
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_save_loc_t;
 
@@ -99,6 +104,7 @@ unw_tdep_save_loc_t;
 typedef struct
   {
     /* no sh-specific auxiliary proc-info */
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_proc_info_t;
 

--- a/include/libunwind-x86_64.h
+++ b/include/libunwind-x86_64.h
@@ -36,6 +36,10 @@ extern "C" {
 #include <inttypes.h>
 #include <ucontext.h>
 
+#ifndef UNW_EMPTY_STRUCT
+#  define UNW_EMPTY_STRUCT uint8_t unused;
+#endif
+
 #define UNW_TARGET              x86_64
 #define UNW_TARGET_X86_64       1
 
@@ -111,7 +115,7 @@ x86_64_regnum_t;
 typedef struct unw_tdep_save_loc
   {
     /* Additional target-dependent info on a save location.  */
-    char unused;
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_save_loc_t;
 
@@ -121,7 +125,7 @@ typedef ucontext_t unw_tdep_context_t;
 typedef struct
   {
     /* no x86-64-specific auxiliary proc-info */
-    char unused;
+    UNW_EMPTY_STRUCT
   }
 unw_tdep_proc_info_t;
 


### PR DESCRIPTION
Closes #434

Removing types from the header will only result an an API/ABI break, which we should avoid.