### PR TITLE
Fixed local variable hiding a global variable

### DIFF
--- a/tests/Gperf-simple.c
+++ b/tests/Gperf-simple.c
@@ -38,7 +38,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 long dummy;
 
 static long iterations = 10000;
-static int maxlevel = 100;
 
 #define KB	1024
 #define MB	(1024*1024)
@@ -110,7 +109,7 @@ f1 (int level, int maxlevel, double *step)
 }
 
 static void
-doit (const char *label)
+doit (const char *label, int maxlevel)
 {
   double step, min_step, first_step, sum_step;
   int i;
@@ -232,10 +231,11 @@ measure_init (void)
 int
 main (int argc, char **argv)
 {
-  struct rlimit rlim;
-
-  rlim.rlim_cur = RLIM_INFINITY;
-  rlim.rlim_max = RLIM_INFINITY;
+  int maxlevel = 100;
+  struct rlimit rlim = {
+    .rlim_cur = RLIM_INFINITY,
+    .rlim_max = RLIM_INFINITY
+  };
   setrlimit (RLIMIT_STACK, &rlim);
 
   memset (big, 0xaa, sizeof (big));
@@ -244,21 +244,21 @@ main (int argc, char **argv)
     {
       maxlevel = atol (argv[1]);
       if (argc > 2)
-	iterations = atol (argv[2]);
+        iterations = atol (argv[2]);
     }
 
   measure_init ();
 
-  doit ("default         ");
+  doit ("default         ", maxlevel);
 
   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_NONE);
-  doit ("no cache        ");
+  doit ("no cache        ", maxlevel);
 
   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_GLOBAL);
-  doit ("global cache    ");
+  doit ("global cache    ", maxlevel);
 
   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_PER_THREAD);
-  doit ("per-thread cache");
+  doit ("per-thread cache", maxlevel);
 
   return 0;
 }

--- a/tests/Gperf-trace.c
+++ b/tests/Gperf-trace.c
@@ -38,7 +38,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 long dummy;
 
 static long iterations = 10000;
-static int maxlevel = 100;
 
 #define KB	1024
 #define MB	(1024*1024)
@@ -96,7 +95,7 @@ f1 (int level, int maxlevel, double *step)
 }
 
 static void
-doit (const char *label)
+doit (const char *label, int maxlevel)
 {
   double step, min_step, first_step, sum_step;
   int i;
@@ -218,10 +217,11 @@ measure_init (void)
 int
 main (int argc, char **argv)
 {
-  struct rlimit rlim;
-
-  rlim.rlim_cur = RLIM_INFINITY;
-  rlim.rlim_max = RLIM_INFINITY;
+  int maxlevel = 100;
+  struct rlimit rlim = {
+    .rlim_cur = RLIM_INFINITY,
+    .rlim_max = RLIM_INFINITY
+  };
   setrlimit (RLIMIT_STACK, &rlim);
 
   memset (big, 0xaa, sizeof (big));
@@ -230,21 +230,21 @@ main (int argc, char **argv)
     {
       maxlevel = atol (argv[1]);
       if (argc > 2)
-	iterations = atol (argv[2]);
+        iterations = atol (argv[2]);
     }
 
   measure_init ();
 
-  doit ("default         ");
+  doit ("default         ", maxlevel);
 
   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_NONE);
-  doit ("no cache        ");
+  doit ("no cache        ", maxlevel);
 
   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_GLOBAL);
-  doit ("global cache    ");
+  doit ("global cache    ", maxlevel);
 
   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_PER_THREAD);
-  doit ("per-thread cache");
+  doit ("per-thread cache", maxlevel);
 
   return 0;
 }


### PR DESCRIPTION
This issue was found by static analysis. It makes comprehending what the tests do a little more difficult. There is no functional change.

Verified on Ubuntu 20.04 x86_64.

Closes #649 