### PR TITLE
Fix scan_hex() logic error

### DIFF
--- a/src/os-linux.h
+++ b/src/os-linux.h
@@ -119,10 +119,10 @@ scan_hex (char *cp, unsigned long *valp)
       digit = *cp;
       if ((digit - '0') <= 9)
         digit -= '0';
-      else if ((digit - 'a') < 6)
-        digit -= 'a' - 10;
       else if ((digit - 'A') < 6)
         digit -= 'A' - 10;
+      else if ((digit - 'a') < 6)
+        digit -= 'a' - 10;
       else
         break;
       val = (val << 4) | digit;


### PR DESCRIPTION
This was dertected by static analysis. The function scan_hex() had a logic error. It was unlikely to be encountered in real life but fixing it guarantees it won't have any effect.

Built and tested Ubunbtu 20.04 x86_64. No regressions.

Closes #642 