### PR TITLE
Reuse existing mmap'ed vDSO in get_elf_image

### DIFF
--- a/include/libunwind_i.h
+++ b/include/libunwind_i.h
@@ -374,6 +374,7 @@ struct elf_image
   {
     void *image;                /* pointer to mmap'd image */
     size_t size;                /* (file-) size of the image */
+    int mapped;                 /* whether image was mmap'd */
   };
 
 struct elf_dyn_info

--- a/src/elfxx.c
+++ b/src/elfxx.c
@@ -644,7 +644,8 @@ elf_w (get_proc_name) (unw_addr_space_t as, pid_t pid, unw_word_t ip,
 
   ret = elf_w (get_proc_name_in_image) (as, &ei, segbase, ip, buf, buf_len, offp);
 
-  mi_munmap (ei.image, ei.size);
+  if (ei.mapped)
+    mi_munmap (ei.image, ei.size);
   ei.image = NULL;
 
   return ret;

--- a/src/elfxx.h
+++ b/src/elfxx.h
@@ -107,5 +107,6 @@ elf_map_image (struct elf_image *ei, const char *path)
     return -1;
   }
 
+  ei->mapped = 1;
   return 0;
 }


### PR DESCRIPTION
Special-case get_elf_image when filename is the vDSO, because there is no file backing. Since vDSO is always mapped in memory, return a reference to the existing image.