### PR TITLE
Fix test-async-sig on x86-linux

### DIFF
--- a/src/x86/Gos-linux.c
+++ b/src/x86/Gos-linux.c
@@ -136,6 +136,10 @@ x86_handle_signal_frame (unw_cursor_t *cursor)
   c->dwarf.loc[EIP] = DWARF_LOC (sc_addr + LINUX_SC_EIP_OFF, 0);
   c->dwarf.loc[ESP] = DWARF_LOC (sc_addr + LINUX_SC_ESP_OFF, 0);
 
+  ret = dwarf_get (&c->dwarf, c->dwarf.loc[EIP], &c->dwarf.ip);
+  ret = dwarf_get (&c->dwarf, c->dwarf.loc[ESP], &c->dwarf.cfa);
+  c->dwarf.use_prev_instr = 0;
+
   return 0;
 }
 
@@ -287,49 +291,11 @@ x86_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
   struct cursor *c = (struct cursor *) cursor;
   ucontext_t *uc = c->uc;
 
-  /* Ensure c->pi is up-to-date.  On x86, it's relatively common to be
-     missing DWARF unwind info.  We don't want to fail in that case,
-     because the frame-chain still would let us do a backtrace at
-     least.  */
-  dwarf_make_proc_info (&c->dwarf);
-
-  if (unlikely (c->sigcontext_format != X86_SCF_NONE))
-    {
-      struct sigcontext *sc = (struct sigcontext *) c->sigcontext_addr;
-
-      Debug (8, "resuming at ip=%x via sigreturn(%p)\n", c->dwarf.ip, sc);
+  Debug (8, "resuming at ip=%x via setcontext()\n", c->dwarf.ip);
 #if !defined(__ANDROID__)
-      x86_sigreturn (sc);
+  setcontext (uc);
 #endif
-    }
-  else
-    {
-      Debug (8, "resuming at ip=%x via setcontext()\n", c->dwarf.ip);
-#if !defined(__ANDROID__)
-      setcontext (uc);
-#endif
-    }
   return -UNW_EINVAL;
 }
 
-/* sigreturn() is a no-op on x86 glibc.  */
-HIDDEN void
-x86_sigreturn (unw_cursor_t *cursor)
-{
-  struct cursor *c = (struct cursor *) cursor;
-  struct sigcontext *sc = (struct sigcontext *) c->sigcontext_addr;
-  mcontext_t *sc_mcontext = &((ucontext_t*)sc)->uc_mcontext;
-  /* Copy in saved uc - all preserved regs are at the start of sigcontext */
-  memcpy(sc_mcontext, &c->uc->uc_mcontext,
-         DWARF_NUM_PRESERVED_REGS * sizeof(unw_word_t));
-
-  Debug (8, "resuming at ip=%llx via sigreturn(%p)\n",
-             (unsigned long long) c->dwarf.ip, sc);
-  __asm__ __volatile__ ("mov %0, %%esp;"
-                        "mov %1, %%eax;"
-                        "syscall"
-                        :: "r"(sc), "i"(SYS_rt_sigreturn)
-                        : "memory");
-  abort();
-}
 #endif

--- a/src/x86/Gstep.c
+++ b/src/x86/Gstep.c
@@ -32,11 +32,21 @@ unw_step (unw_cursor_t *cursor)
   struct cursor *c = (struct cursor *) cursor;
   int ret, i;
   int validate = c->validate;
+  c->validate = 1;
 
   Debug (1, "(cursor=%p, ip=0x%08x)\n", c, (unsigned) c->dwarf.ip);
 
+  /*
+   * Special-case the signal trampoline since on many OS targets it lacks DWARF
+   * unwind info.
+   */
+  if (unw_is_signal_frame (cursor) > 0)
+    {
+      ret = x86_handle_signal_frame(cursor);
+      return 1;
+    }
+
   /* Try DWARF-based unwinding... */
-  c->validate = 1;
   ret = dwarf_step (&c->dwarf);
   c->validate = validate;
 
@@ -48,50 +58,39 @@ unw_step (unw_cursor_t *cursor)
 
   if (unlikely (ret < 0))
     {
-      /* DWARF failed, let's see if we can follow the frame-chain
-         or skip over the signal trampoline.  */
+      /* DWARF failed, let's see if we can follow the frame-chain */
       struct dwarf_loc ebp_loc, eip_loc, esp_loc;
 
 
       Debug (13, "dwarf_step() failed (ret=%d), trying frame-chain\n", ret);
 
-      if (unw_is_signal_frame (cursor) > 0)
+      ret = dwarf_get (&c->dwarf, c->dwarf.loc[EBP], &c->dwarf.cfa);
+      if (ret < 0)
         {
-          ret = x86_handle_signal_frame(cursor);
-          if (ret < 0)
-            {
-              Debug (2, "returning 0\n");
-              return 0;
-            }
+          Debug (2, "returning %d\n", ret);
+          return ret;
         }
-      else
+
+      Debug (13, "[EBP=0x%x] = 0x%x\n", DWARF_GET_LOC (c->dwarf.loc[EBP]), c->dwarf.cfa);
+
+      ebp_loc = DWARF_LOC (c->dwarf.cfa, 0);
+      esp_loc = DWARF_VAL_LOC (c, c->dwarf.cfa + 8);
+      eip_loc = DWARF_LOC (c->dwarf.cfa + 4, 0);
+      c->dwarf.cfa += 8;
+
+      /*
+       * Mark all registers unsaved, since we don't know where they are saved
+       * (if at all), except for the EBP and EIP.
+       */
+      for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
         {
-          ret = dwarf_get (&c->dwarf, c->dwarf.loc[EBP], &c->dwarf.cfa);
-          if (ret < 0)
-            {
-              Debug (2, "returning %d\n", ret);
-              return ret;
-            }
-
-          Debug (13, "[EBP=0x%x] = 0x%x\n", DWARF_GET_LOC (c->dwarf.loc[EBP]),
-                 c->dwarf.cfa);
-
-          ebp_loc = DWARF_LOC (c->dwarf.cfa, 0);
-          esp_loc = DWARF_VAL_LOC (c, c->dwarf.cfa + 8);
-          eip_loc = DWARF_LOC (c->dwarf.cfa + 4, 0);
-          c->dwarf.cfa += 8;
-
-          /* Mark all registers unsaved, since we don't know where
-             they are saved (if at all), except for the EBP and
-             EIP.  */
-          for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
-            c->dwarf.loc[i] = DWARF_NULL_LOC;
-
-          c->dwarf.loc[EBP] = ebp_loc;
-          c->dwarf.loc[ESP] = esp_loc;
-          c->dwarf.loc[EIP] = eip_loc;
-          c->dwarf.use_prev_instr = 1;
+          c->dwarf.loc[i] = DWARF_NULL_LOC;
         }
+
+      c->dwarf.loc[EBP] = ebp_loc;
+      c->dwarf.loc[ESP] = esp_loc;
+      c->dwarf.loc[EIP] = eip_loc;
+      c->dwarf.use_prev_instr = 1;
 
       if (!DWARF_IS_NULL_LOC (c->dwarf.loc[EBP]))
         {

--- a/src/x86/unwind_i.h
+++ b/src/x86/unwind_i.h
@@ -52,7 +52,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #define x86_scratch_loc                 UNW_OBJ(scratch_loc)
 #define x86_get_scratch_loc             UNW_OBJ(get_scratch_loc)
 #define x86_r_uc_addr                   UNW_OBJ(r_uc_addr)
-#define x86_sigreturn                   UNW_OBJ(sigreturn)
 
 extern void x86_local_addr_space_init (void);
 extern int x86_local_resume (unw_addr_space_t as, unw_cursor_t *cursor,
@@ -61,7 +60,6 @@ extern dwarf_loc_t x86_scratch_loc (struct cursor *c, unw_regnum_t reg);
 extern dwarf_loc_t x86_get_scratch_loc (struct cursor *c, unw_regnum_t reg);
 extern void *x86_r_uc_addr (ucontext_t *uc, int reg);
 
-extern void x86_sigreturn (unw_cursor_t *cursor);
 #define x86_handle_signal_frame UNW_OBJ(handle_signal_frame)
 extern int x86_handle_signal_frame(unw_cursor_t *cursor);
 


### PR DESCRIPTION
The x86-specific code would often mistakenly advance the cursor through the signal trampoline by misinterpreting what was on the stack, and it just happened to work most of the time. It was wrong, however, and moving the signal trampolive detection up before the DWARF stepping (like it is on other target architectures) should make it do the right thing.

This change had the cascade effect of tickling some undefined behaviour in the target architecture-specific unw_resume code, so that got fixed too.

Fixes #569