### PR TITLE
Use header for test function prototype

### DIFF
--- a/tests/Gtest-bt.c
+++ b/tests/Gtest-bt.c
@@ -43,6 +43,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <unistd.h>
 #include <libunwind.h>
 
+#include "ident.h"
+
 #define panic(...)				\
 	{ fprintf (stderr, __VA_ARGS__); exit (-1); }
 
@@ -143,7 +145,6 @@ foo (long val UNUSED)
 void
 bar (long v)
 {
-  extern long f (long);
   int arr[v];
   arr[0] = 0;
 

--- a/tests/Gtest-trace.c
+++ b/tests/Gtest-trace.c
@@ -40,6 +40,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <unistd.h>
 #include <libunwind.h>
 
+#include "ident.h"
+
 #define panic(...)				\
 	{ fprintf (stderr, __VA_ARGS__); exit (-1); }
 
@@ -206,7 +208,6 @@ foo (long val UNUSED)
 void
 bar (long v)
 {
-  extern long f (long);
   int arr[v];
   arr[0] = 0;
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -166,6 +166,7 @@ endif
 
 noinst_PROGRAMS = $(noinst_PROGRAMS_common) $(noinst_PROGRAMS_cdep) \
 	$(noinst_PROGRAMS_arch)
+noinst_HEADERS = ident.h
 
 Lia64_test_readonly_SOURCES = Lia64-test-readonly.c ia64-test-readonly-asm.S
 Gia64_test_readonly_SOURCES = Gia64-test-readonly.c ia64-test-readonly-asm.S

--- a/tests/ident.h
+++ b/tests/ident.h
@@ -20,10 +20,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include "ident.h"
+#ifndef LIBUNWIND_TESTS_IDENT_H
+#define LIBUNWIND_TESTS_IDENT_H
 
-long
-f (long val)
-{
-  return val;
-}
+extern long f (long val);
+
+#endif /* LIBUNWIND_TESTS_IDENT_H */

--- a/tests/test-ptrace-misc.c
+++ b/tests/test-ptrace-misc.c
@@ -33,6 +33,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include <sys/types.h>
 
+#include "ident.h"
+
 pid_t self;
 int global[64];
 
@@ -68,7 +70,6 @@ func (int arg)
 int
 bar (int v)
 {
-  extern long f (long);
   int arr[1] = { v };
   uintptr_t r;
 


### PR DESCRIPTION
Some of the unit test code was bringing an extern function prototype into scope in a function body. The idiomatic and expected way to do this is by using a header file and not adhering to the idiom not only increases the cognitive load of the reader but triggers warning from static analysis tools.

This change just does it the right way instead. No functional change.

Closes #651