### PR TITLE
Hash pin workflows and enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -36,7 +36,7 @@ jobs:
           - { CFLAGS: -O0 }
           - { CFLAGS: -O3 }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Setup
         if: ${{ matrix.target.arch }} = 'i686'
@@ -95,7 +95,7 @@ jobs:
           - {target: mips64el, host: mips64el-linux-gnuabi64, qemu: mips64el, gccver: 10 }
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Install QEMU
         # this ensure install latest qemu on ubuntu, apt get version is old
         env:

--- a/.github/workflows/CI-win.yml
+++ b/.github/workflows/CI-win.yml
@@ -30,7 +30,7 @@ jobs:
           - {toolchain: Visual Studio 17 2022, arch: x64, server: 2022, TARGET: aarch64-linux-gnu}
           - {toolchain: Visual Studio 17 2022, arch: x64, server: 2022, TARGET: x86_64-linux-gnu}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Build
         shell: cmd
         env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,16 +26,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@305f6546310b9203e892c28c1484e82977f4f63d # v2.22.10
       with:
         languages: ${{ matrix.language }}
         queries: security-extended,security-and-quality
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@305f6546310b9203e892c28c1484e82977f4f63d # v2.22.10
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@305f6546310b9203e892c28c1484e82977f4f63d # v2.22.10

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,9 @@ on:
       # Runs automatically on the twelfth of every month at 16:26
     - cron: '26 16 12 * *'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/groom-issues.yml
+++ b/.github/workflows/groom-issues.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@f7176fd3007623b69d27091f9b9d4ab7995f0a06 # v5.2.1
         with:
           stale-issue-label: "needs info"
           days-before-issue-stale: -1

--- a/.github/workflows/groom-issues.yml
+++ b/.github/workflows/groom-issues.yml
@@ -3,7 +3,8 @@ name: Close inactive issues
 on:
   schedule:
     - cron: "30 1 * * *"
-
+permissions:
+  contents: read
 jobs:
   close-issues:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #679 

As mentioned on the issue, I've hash pinned the actions used on the privileged workflows. I've also hash pinned the non-privileged ones just for consistency --- since dependabot is configured to group PRs, it won't add many maintainence effort to have it all hash pinned or only some files. 

Besides, consider also enabling Dependabot security updates on the [settings](https://github.com/joycebrum/libunwind/settings/security_analysis) to receive out of schedule updates to fix existing vulnerabilities.

Any questions, let me know!

Thanks!