### PR TITLE
Add use of libabigail for ABI checks

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -42,23 +42,30 @@ jobs:
         if: ${{ matrix.target.arch }} = 'i686'
         run: |
           sudo apt update
-          sudo apt install -y g++-12-multilib
+          sudo apt install -y g++-12-multilib abigail-tools
 
       - name: Configure
         run: |
           set -x
           autoreconf -i
-          ./configure --build=x86_64-pc-linux-gnu --host=${{ matrix.target.triple }}
+          mkdir build
+          cd build
+          ../configure --build=x86_64-pc-linux-gnu --host=${{ matrix.target.triple }}
         env:
           CC: ${{ matrix.toolchain.CC }}
           CXX: ${{ matrix.toolchain.CXX }}
-          CFLAGS: "${{ matrix.target.CFLAGS }} ${{ matrix.optimization.CFLAGS }} -Wall -Wextra"
-          CXXFLAGS: "${{ matrix.target.CFLAGS }} ${{ matrix.optimization.CFLAGS }} -Wall -Wextra"
+          CFLAGS: "${{ matrix.target.CFLAGS }} ${{ matrix.optimization.CFLAGS }} -g -Wall -Wextra"
+          CXXFLAGS: "${{ matrix.target.CFLAGS }} ${{ matrix.optimization.CFLAGS }} -g -Wall -Wextra"
           LDFLAGS: ${{ matrix.target.CFLAGS }}
 
       - name: Build
         run: |
-          make -j8
+          make -C build -j
+
+      - name: Check ABI
+        if: ${{ success() }}
+        run:
+          make -C build/src abi-check
 
       - name: Test (native)
         if: ${{ success() }}
@@ -66,12 +73,12 @@ jobs:
           set -x
           sudo bash -c 'echo core.%p.%p > /proc/sys/kernel/core_pattern'
           ulimit -c unlimited
-          make check -j8
+          make -C build check -j8
 
       - name: Show Logs
         if: ${{ failure() }}
         run: |
-          cat tests/test-suite.log 2>/dev/null
+          cat build/tests/test-suite.log 2>/dev/null
 
   build-gnu-cross:
     runs-on: ubuntu-22.04
@@ -109,42 +116,58 @@ jobs:
       - name: Install ${{ matrix.config.host }} Toolchain
         run: |
           sudo apt update
-          sudo apt install g++-${{ matrix.config.gccver }}-${{ matrix.config.host }} -y
+          sudo apt install -y g++-${{ matrix.config.gccver }}-${{ matrix.config.host }} abigail-tools
 
       - name: Configure with ${{ matrix.config.cc }}
         run: |
           set -x
           autoreconf -i
-          BUILD=x86_64-linux-gnu
-          ./configure --build=$BUILD --host=${{ matrix.config.host }} --with-testdriver="$(pwd)/libtool execute $(pwd)/scripts/qemu-test-driver" --enable-debug
+          mkdir build
+          cd build
+          ../configure --build=$(config/config.guess) \
+                       --host=${{ matrix.config.host }} \
+                       --with-testdriver="$(pwd)/libtool execute $(pwd)/../scripts/qemu-test-driver" \
+                       --enable-debug
         env:
           CC: ${{ matrix.config.host }}-gcc-${{ matrix.config.gccver }}
           CXX: ${{ matrix.config.host }}-g++-${{ matrix.config.gccver }}
 
       - name: Build
         run: |
-          make -j8
+          make -C build -j
         env:
-          CFLAGS: "-Wall -Wextra"
+          CFLAGS: "-Wall -Wextra -g -Og"
 
       - name: ABI Check
         run: |
-            cd tests && ./check-namespace.sh
+            case ${{ matrix.config.target }} in
+            aarch64|riscv*|s390x|x86*)
+                make -C build/src abi-check
+                ;;
+            *)
+                srcdir=$(pwd)
+                cd build/tests
+                ${srcdir}/tests/run-check-namespace
+                ;;
+            esac
 
       - name: Test
         run: |
           set -x
           sudo bash -c 'echo core.%p.%p > /proc/sys/kernel/core_pattern'
           ulimit -c unlimited
-          CROSS_LIB="/usr/${{ matrix.config.host }}"
-          make check LOG_DRIVER_FLAGS="--qemu-arch ${{ matrix.config.qemu }}" QEMU_LD_PREFIX="$CROSS_LIB"
+          cd build
+          make check LOG_DRIVER_FLAGS="--qemu-arch ${{ matrix.config.qemu }}" \
+                     QEMU_LD_PREFIX="$CROSS_LIB" \
+                     LDFLAGS="-L$CROSS_LIB/lib"
         env:
           UNW_DEBUG_LEVEL: 4
+          CROSS_LIB: "/usr/${{ matrix.config.host }}"
 
       - name: Show Logs
         if: ${{ failure() }}
         run: |
-          cat tests/test-suite.log 2>/dev/null
+          cat build/tests/test-suite.log 2>/dev/null
 
   build-musl-native:
     runs-on: ubuntu-latest

--- a/Makefile.am
+++ b/Makefile.am
@@ -121,3 +121,6 @@ MAINTAINERCLEANFILES = \
 	include/config.h.in \
 	include/config.h.in~
 
+abi-check:
+	cd src && $(MAKE) $(AM_MAKEFLAGS) $@
+

--- a/configure.ac
+++ b/configure.ac
@@ -541,6 +541,20 @@ if test x$have__builtin_unreachable = xyes; then
 fi
 AC_MSG_RESULT([$have__builtin_unreachable])
 
+AC_CHECK_TOOL([ABICHECK], [abidw])
+AS_IF([test "$ABICHECK" = ":"],, [
+    abicheck_version=$($ABICHECK --version | sed -n 's/[[^ ]]* \([[0-9]]\).*/\1/p')
+    AC_MSG_WARN([$ABICHECK version $abicheck_version])
+    AS_IF([test $abicheck_version -ge 2],
+          [ABIDIFF=abidiff],
+          [AC_MSG_WARN([$ABICHECK is version $abicheck_version, need at least 2.0])
+           ABICHECK=":"
+           ABIDIFF=":"]
+    )
+])
+AC_SUBST(ABICHECK)
+AC_SUBST(ABIDIFF)
+
 arch="$target_arch"
 ARCH=`echo $target_arch | tr [a-z] [A-Z]`
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1251,9 +1251,45 @@ libunwind_la_LIBADD += $(LIBLZMA) $(LIBZ)
 
 noinst_HEADERS += unwind/unwind-internal.h
 
-EXTRA_DIST = $(libunwind_la_EXTRAS_ia64)
+EXTRA_DIST = $(libunwind_la_EXTRAS_ia64) abi
 
 MAINTAINERCLEANFILES = Makefile.in
+
+#
+# ABI checks
+#
+# Running the ABI checks require configuring with CFLAGS="-g -Og".
+# The result is output in a file with the `.abidiff` extension which is also
+# printed to stdout if there is an ABI mismatch detected.
+#
+# This also requires libabigail tools of at least version 2.0 to be installed.
+#
+.la.abi:
+	$(AM_V_GEN)soname=$$(sed -n -e "s#dlname='\(.*\)\.[0-9]*'#\1#p" $<); \
+	if test -n "$$soname"; then \
+		$(ABICHECK) .libs/$${soname} \
+		            --no-show-locs \
+		            --no-comp-dir-path \
+		            --no-corpus-path \
+		            --drop-undefined-syms \
+		            --drop-private-types \
+		            --out-file $@; \
+	else \
+		printf "(no SONAME found in %s)\n" "$<"; \
+	fi
+
+abi_srcdir = "$(top_srcdir)/src/abi"
+abi_targetdir = "$(abi_srcdir)/$(arch)/$(target_os)"
+.abi.abidiff:
+	$(AM_V_GEN)if test -f "$<"; then \
+		$(ABIDIFF) --suppressions "$(abi_srcdir)/libunwind.supp" \
+		           -l "$(abi_targetdir)/$<" "$<" >$@ \
+			|| cat $@; \
+	fi
+
+abi-check: $(lib_LTLIBRARIES:.la=.abidiff) 
+
+.PHONY: abi-check
 
 # The -version-info flag accepts an argument of the form
 # `current[:revision[:age]]'. So, passing `-version-info 3:12:1' sets

--- a/src/abi/README.md
+++ b/src/abi/README.md
@@ -1,0 +1,33 @@
+ABI Baseline Files
+==================
+
+This source directory contains the ABI baseline files used to detect
+incompatible ABI (application binary interface) changes in libunwind.
+
+These files are generated using the **libabigail** ABI generic analysis and
+instrumentation library tools https://sourceware.org/libabigail/
+
+Checking the ABI
+----------------
+
+1. Install the **libabigail** tools, at least version 2.0.
+   On Ubuntu you can use the following command
+    ```
+    $ sudo apt install abigail-tools
+    ```
+    and a similar command with other package managers or you can clone the project
+    from upstream and build it yourself.
+
+2. Configure and build libunwind
+    ```
+    $ mkdir build; cd build
+    $ ../configure CFLAGS="-g -Og"
+    $ make -j
+    ```
+
+3. Run the ABI checks
+    ```
+    $ make -C src abi-check
+    ```
+    A report for each .so file will be generated into the corresponding .abidiff
+    file in the build-tree's src directory.

--- a/src/abi/aarch64/linux-gnu/libunwind-aarch64.abi
+++ b/src/abi/aarch64/linux-gnu/libunwind-aarch64.abi
@@ -1,0 +1,1126 @@
+<abi-corpus version='2.2' architecture='elf-arm-aarch64' soname='libunwind-aarch64.so.8'>
+  <elf-needed>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-aarch64.so.1'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_Uaarch64_apply_reg_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_create_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_destroy_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_dwarf_find_debug_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_dwarf_find_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_dwarf_search_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_flush_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_accessors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_elf_filename_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_elf_image' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_exe_image_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_proc_info_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_proc_info_in_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_proc_name_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_save_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_init_local' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_init_local2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_init_remote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_is_signal_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_reg_states_iterate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_set_cache_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_set_caching_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_set_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_set_iterate_phdr_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_set_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_Uaarch64_local_addr_space' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/aarch64/Gapply_reg_state.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_apply_reg_state' mangled-name='_Uaarch64_apply_reg_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_apply_reg_state'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-2' name='reg_states_data'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Gcreate_addr_space.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_create_addr_space' mangled-name='_Uaarch64_create_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_create_addr_space'>
+      <parameter type-id='type-id-4' name='a'/>
+      <parameter type-id='type-id-3' name='byte_order'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Gget_proc_info.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_get_proc_info' mangled-name='_Uaarch64_get_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_proc_info'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Gget_save_loc.c' language='LANG_C99'>
+    <enum-decl name='unw_save_loc_type' id='type-id-7'>
+      <underlying-type type-id='type-id-8'/>
+      <enumerator name='UNW_SLT_NONE' value='0'/>
+      <enumerator name='UNW_SLT_MEMORY' value='1'/>
+      <enumerator name='UNW_SLT_REG' value='2'/>
+    </enum-decl>
+    <class-decl name='unw_save_loc' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-9'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='u' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='extra' type-id='type-id-12' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_save_loc' size-in-bits='8' is-struct='yes' visibility='default' id='type-id-13'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-14' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_save_loc_t' type-id='type-id-9' id='type-id-15'/>
+    <typedef-decl name='unw_save_loc_type_t' type-id='type-id-7' id='type-id-10'/>
+    <typedef-decl name='unw_tdep_save_loc_t' type-id='type-id-13' id='type-id-12'/>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-11'>
+      <data-member access='public'>
+        <var-decl name='addr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='regnum' type-id='type-id-17' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-18'/>
+    <function-decl name='_Uaarch64_get_save_loc' mangled-name='_Uaarch64_get_save_loc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_save_loc'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='reg'/>
+      <parameter type-id='type-id-18' name='sloc'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Gglobal.c' language='LANG_C99'>
+    <type-decl name='atomic_bool' size-in-bits='8' id='type-id-19'/>
+    <var-decl name='_Uaarch64_init_done' type-id='type-id-19' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Ginit.c' language='LANG_C99'>
+    <var-decl name='_Uaarch64_local_addr_space' type-id='type-id-5' mangled-name='_Uaarch64_local_addr_space' visibility='default' elf-symbol-id='_Uaarch64_local_addr_space'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Ginit_local.c' language='LANG_C99'>
+    <class-decl name='stack_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-20' visibility='default' id='type-id-21'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ss_sp' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ss_flags' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ss_size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_sigcontext' size-in-bits='6528' is-struct='yes' visibility='default' id='type-id-23'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fault_address' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='regs' type-id='type-id-25' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='sp' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2112'>
+        <var-decl name='pc' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='pstate' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='__reserved' type-id='type-id-26' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_context_t' size-in-bits='7936' is-struct='yes' naming-typedef-id='type-id-27' visibility='default' id='type-id-28'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uc_flags' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uc_link' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uc_stack' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='uc_sigmask' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='uc_mcontext' type-id='type-id-23' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='stack_t' type-id='type-id-21' id='type-id-20'/>
+    <typedef-decl name='unw_context_t' type-id='type-id-27' id='type-id-32'/>
+    <typedef-decl name='unw_tdep_context_t' type-id='type-id-28' id='type-id-27'/>
+    <array-type-def dimensions='1' type-id='type-id-24' size-in-bits='1984' id='type-id-25'>
+      <subrange length='31' lower-bound='0' upper-bound='30' type-id='type-id-29' id='type-id-33'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-14' size-in-bits='4224' id='type-id-26'>
+      <subrange length='528' lower-bound='0' upper-bound='527' type-id='type-id-29' id='type-id-34'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-35'/>
+    <class-decl name='ucontext' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-36'/>
+    <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-30'/>
+    <function-decl name='_Uaarch64_init_local' mangled-name='_Uaarch64_init_local' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_init_local'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-35' name='uc'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_Uaarch64_init_local2' mangled-name='_Uaarch64_init_local2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_init_local2'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-35' name='uc'/>
+      <parameter type-id='type-id-3' name='flag'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Ginit_remote.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_init_remote' mangled-name='_Uaarch64_init_remote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_init_remote'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-2' name='as_arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Gis_signal_frame.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_is_signal_frame' mangled-name='_Uaarch64_is_signal_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_is_signal_frame'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Greg_states_iterate.c' language='LANG_C99'>
+    <typedef-decl name='unw_reg_states_callback' type-id='type-id-37' id='type-id-38'/>
+    <pointer-type-def type-id='type-id-39' size-in-bits='64' id='type-id-37'/>
+    <function-decl name='_Uaarch64_reg_states_iterate' mangled-name='_Uaarch64_reg_states_iterate' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_reg_states_iterate'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-38' name='cb'/>
+      <parameter type-id='type-id-2' name='token'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-39'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Gresume.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_resume' mangled-name='_Uaarch64_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_resume'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Gstep.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_step' mangled-name='_Uaarch64_step' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_step'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/is_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_is_fpreg' mangled-name='_Uaarch64_is_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_is_fpreg'>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/regname.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_regname' mangled-name='_Uaarch64_regname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_regname'>
+      <parameter type-id='type-id-17' name='reg'/>
+      <return type-id='type-id-40'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Gfind_proc_info-lsb.c' language='LANG_C99'>
+    <type-decl name='short int' size-in-bits='16' id='type-id-41'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-42'/>
+    <class-decl name='table_entry' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip_offset' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fde_offset' type-id='type-id-44' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-45'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-47' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-48'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-51'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-53' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-54'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-56' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-57'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-58'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-59' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int16_t' type-id='type-id-41' id='type-id-60'/>
+    <typedef-decl name='__int32_t' type-id='type-id-3' id='type-id-61'/>
+    <typedef-decl name='__int8_t' type-id='type-id-42' id='type-id-62'/>
+    <typedef-decl name='int16_t' type-id='type-id-60' id='type-id-50'/>
+    <typedef-decl name='int32_t' type-id='type-id-61' id='type-id-44'/>
+    <typedef-decl name='int8_t' type-id='type-id-62' id='type-id-49'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-45' id='type-id-63'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-48' id='type-id-64'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-51' id='type-id-65'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-54' id='type-id-66'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-57' id='type-id-67'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-58' id='type-id-68'/>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-47'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-67' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-64' size-in-bits='128' id='type-id-56'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-29' id='type-id-69'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-45' size-in-bits='64' id='type-id-46'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='64' id='type-id-70'/>
+    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-53'/>
+    <function-decl name='_Uaarch64_dwarf_find_debug_frame' mangled-name='_Uaarch64_dwarf_find_debug_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_dwarf_find_debug_frame'>
+      <parameter type-id='type-id-3' name='found'/>
+      <parameter type-id='type-id-70' name='di_debug'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-16' name='segbase'/>
+      <parameter type-id='type-id-40' name='obj_name'/>
+      <parameter type-id='type-id-16' name='start'/>
+      <parameter type-id='type-id-16' name='end'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_Uaarch64_dwarf_search_unwind_table' mangled-name='_Uaarch64_dwarf_search_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_dwarf_search_unwind_table'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-70' name='di'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-3' name='need_unwind_info'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-71'>
+      <parameter type-id='type-id-72'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-73'>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Gfind_unwind_table.c' language='LANG_C99'>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-75'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-63' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-77'/>
+    <function-decl name='_Uaarch64_dwarf_find_unwind_table' mangled-name='_Uaarch64_dwarf_find_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_dwarf_find_unwind_table'>
+      <parameter type-id='type-id-77' name='edi'/>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-40' name='path'/>
+      <parameter type-id='type-id-16' name='segbase'/>
+      <parameter type-id='type-id-16' name='mapoff'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Gget_proc_info_in_range.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_get_proc_info_in_range' mangled-name='_Uaarch64_get_proc_info_in_range' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_proc_info_in_range'>
+      <parameter type-id='type-id-16' name='start_ip'/>
+      <parameter type-id='type-id-16' name='end_ip'/>
+      <parameter type-id='type-id-16' name='eh_frame_table'/>
+      <parameter type-id='type-id-16' name='eh_frame_table_len'/>
+      <parameter type-id='type-id-16' name='exidx_frame_table'/>
+      <parameter type-id='type-id-16' name='exidx_frame_table_len'/>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-3' name='need_unwind_info'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/global.c' language='LANG_C99'>
+    <class-decl name='mempool' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-78'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-79' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='obj_size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='chunk_size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='reserve' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='num_free' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='free_list' type-id='type-id-80' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='object' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-81'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-80' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-81' size-in-bits='64' id='type-id-80'/>
+    <var-decl name='dwarf_reg_state_pool' type-id='type-id-78' visibility='default'/>
+    <var-decl name='dwarf_cie_info_pool' type-id='type-id-78' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gdestroy_addr_space.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_destroy_addr_space' mangled-name='_Uaarch64_destroy_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_destroy_addr_space'>
+      <parameter type-id='type-id-5' name='as'/>
+      <return type-id='type-id-82'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-83' id='type-id-84'/>
+    <pointer-type-def type-id='type-id-84' size-in-bits='64' id='type-id-4'/>
+    <function-decl name='_Uaarch64_get_accessors' mangled-name='_Uaarch64_get_accessors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_accessors'>
+      <parameter type-id='type-id-5' name='as'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_get_elf_filename_by_ip' mangled-name='_Uaarch64_get_elf_filename_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_elf_filename_by_ip'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-85' name='buf'/>
+      <parameter type-id='type-id-22' name='buf_len'/>
+      <parameter type-id='type-id-59' name='offp'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_Uaarch64_get_elf_filename' mangled-name='_Uaarch64_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_elf_filename'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-85' name='buf'/>
+      <parameter type-id='type-id-22' name='buf_len'/>
+      <parameter type-id='type-id-59' name='offp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_get_fpreg' mangled-name='_Uaarch64_get_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_fpreg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-86' name='valp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_proc_info_by_ip.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_get_proc_info_by_ip' mangled-name='_Uaarch64_get_proc_info_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_proc_info_by_ip'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-2' name='as_arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_proc_name.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_get_proc_name_by_ip' mangled-name='_Uaarch64_get_proc_name_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_proc_name_by_ip'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-85' name='buf'/>
+      <parameter type-id='type-id-22' name='buf_len'/>
+      <parameter type-id='type-id-59' name='offp'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_Uaarch64_get_proc_name' mangled-name='_Uaarch64_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_proc_name'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-85' name='buf'/>
+      <parameter type-id='type-id-22' name='buf_len'/>
+      <parameter type-id='type-id-59' name='offp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_reg.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_get_reg' mangled-name='_Uaarch64_get_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_reg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-59' name='valp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_cache_size.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_set_cache_size' mangled-name='_Uaarch64_set_cache_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_set_cache_size'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-22' name='size'/>
+      <parameter type-id='type-id-3' name='flag'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_caching_policy.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_set_caching_policy' mangled-name='_Uaarch64_set_caching_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_set_caching_policy'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-87' name='policy'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_set_fpreg' mangled-name='_Uaarch64_set_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_set_fpreg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-88' name='val'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_iterate_phdr_function.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_set_iterate_phdr_function' mangled-name='_Uaarch64_set_iterate_phdr_function' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_set_iterate_phdr_function'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-89' name='function'/>
+      <return type-id='type-id-82'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_reg.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_set_reg' mangled-name='_Uaarch64_set_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_set_reg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-16' name='valp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/flush_cache.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-90' size-in-bits='384' id='type-id-91'>
+      <subrange length='48' lower-bound='0' upper-bound='47' type-id='type-id-29' id='type-id-92'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-90' size-in-bits='792' id='type-id-93'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-29' id='type-id-94'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-95' size-in-bits='16384' id='type-id-96'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-29' id='type-id-97'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-98' size-in-bits='925696' id='type-id-99'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-29' id='type-id-97'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-87' id='type-id-100'>
+      <underlying-type type-id='type-id-8'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='long double' size-in-bits='128' id='type-id-101'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-102' visibility='default' id='type-id-103'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-105' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-106' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-106' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-107' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-107' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-107' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-108'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-109' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-109' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-110'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-111' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-111' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-112' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-113'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-106' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-114' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-115' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-116' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-116' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-2' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-117'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-118' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='7168' is-struct='yes' visibility='default' id='type-id-119'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-93' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='val' type-id='type-id-120' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='7232' is-struct='yes' visibility='default' id='type-id-121'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-122' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='946880' is-struct='yes' visibility='default' id='type-id-123'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-79' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='rr_head' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='400'>
+        <var-decl name='log_size' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='prev_log_size' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='hash' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='generation' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='buckets' type-id='type-id-125' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='links' type-id='type-id-126' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='default_hash' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4800'>
+        <var-decl name='default_buckets' type-id='type-id-99' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='930496'>
+        <var-decl name='default_links' type-id='type-id-96' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-83'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-128' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-129' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-130' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-132' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-133' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-135' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-135' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-136' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-137' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='947968' is-struct='yes' visibility='default' id='type-id-138'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='big_endian' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='caching_policy' type-id='type-id-87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='cache_generation' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_generation' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='global_cache' type-id='type-id-123' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='947904'>
+        <var-decl name='debug_frames' type-id='type-id-139' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='16000' is-struct='yes' visibility='default' id='type-id-140'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-141' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-142'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-85' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-139' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-144'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-145' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-145' visibility='default' id='type-id-146'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-14' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-24' id='type-id-106'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-147' id='type-id-115'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-24' id='type-id-105'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-103' id='type-id-102'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-52' id='type-id-104'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-24' id='type-id-107'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-108' id='type-id-112'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-118' id='type-id-148'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-111' id='type-id-149'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-150' id='type-id-151'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-117' id='type-id-95'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-119' id='type-id-122'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-121' id='type-id-98'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-152' id='type-id-79'/>
+    <typedef-decl name='uint16_t' type-id='type-id-148' id='type-id-147'/>
+    <typedef-decl name='uint32_t' type-id='type-id-149' id='type-id-52'/>
+    <typedef-decl name='uint8_t' type-id='type-id-151' id='type-id-14'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-153' id='type-id-5'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-100' id='type-id-87'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-140' id='type-id-154'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-155' id='type-id-88'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-156' id='type-id-74'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-157' id='type-id-89'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-144' id='type-id-158'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-3' id='type-id-17'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-101' id='type-id-155'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-146' id='type-id-145'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='384' naming-typedef-id='type-id-79' visibility='default' id='type-id-152'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-110' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-91' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-159' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-8'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-150'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-111'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-116'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-118'/>
+    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='4096' id='type-id-127'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-29' id='type-id-160'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-16' size-in-bits='16000' id='type-id-141'>
+      <subrange length='250' lower-bound='0' upper-bound='249' type-id='type-id-29' id='type-id-161'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-16' size-in-bits='6336' id='type-id-120'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-29' id='type-id-94'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-109'/>
+    <qualified-type-def type-id='type-id-102' const='yes' id='type-id-162'/>
+    <pointer-type-def type-id='type-id-162' size-in-bits='64' id='type-id-114'/>
+    <qualified-type-def type-id='type-id-90' const='yes' id='type-id-163'/>
+    <pointer-type-def type-id='type-id-163' size-in-bits='64' id='type-id-40'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-72'/>
+    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-126'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-125'/>
+    <pointer-type-def type-id='type-id-71' size-in-bits='64' id='type-id-156'/>
+    <pointer-type-def type-id='type-id-164' size-in-bits='64' id='type-id-133'/>
+    <pointer-type-def type-id='type-id-165' size-in-bits='64' id='type-id-132'/>
+    <pointer-type-def type-id='type-id-166' size-in-bits='64' id='type-id-135'/>
+    <pointer-type-def type-id='type-id-167' size-in-bits='64' id='type-id-128'/>
+    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-131'/>
+    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-136'/>
+    <pointer-type-def type-id='type-id-170' size-in-bits='64' id='type-id-134'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-130'/>
+    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-157'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-143'/>
+    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-137'/>
+    <pointer-type-def type-id='type-id-118' size-in-bits='64' id='type-id-124'/>
+    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-153'/>
+    <pointer-type-def type-id='type-id-154' size-in-bits='64' id='type-id-1'/>
+    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-139'/>
+    <pointer-type-def type-id='type-id-88' size-in-bits='64' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-158' size-in-bits='64' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-59'/>
+    <pointer-type-def type-id='type-id-173' size-in-bits='64' id='type-id-129'/>
+    <function-decl name='_Uaarch64_flush_cache' mangled-name='_Uaarch64_flush_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_flush_cache'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='lo'/>
+      <parameter type-id='type-id-16' name='hi'/>
+      <return type-id='type-id-82'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-164'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-165'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-59'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-166'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-59'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-167'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-168'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-59'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-169'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-59'/>
+      <parameter type-id='type-id-59'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-170'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-171'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-59'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-172'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-173'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-82'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-159'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-174' visibility='default' id='type-id-175'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-176' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-175' id='type-id-174'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-31' id='type-id-177'/>
+    <typedef-decl name='sigset_t' type-id='type-id-174' id='type-id-31'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1024' id='type-id-176'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-29' id='type-id-178'/>
+    </array-type-def>
+    <var-decl name='_UIaarch64_full_mask' type-id='type-id-177' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-159' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/strerror.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_strerror' mangled-name='_Uaarch64_strerror' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_strerror'>
+      <parameter type-id='type-id-3' name='err_code'/>
+      <return type-id='type-id-40'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/os-linux.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-90'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-3'/>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-76'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pid_t' type-id='type-id-3' id='type-id-179'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-29' id='type-id-180'/>
+    <typedef-decl name='pid_t' type-id='type-id-179' id='type-id-181'/>
+    <typedef-decl name='size_t' type-id='type-id-29' id='type-id-22'/>
+    <typedef-decl name='uint64_t' type-id='type-id-180' id='type-id-24'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-24' id='type-id-16'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-29'/>
+    <pointer-type-def type-id='type-id-90' size-in-bits='64' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-76' size-in-bits='64' id='type-id-182'/>
+    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-183'/>
+    <function-decl name='_Uaarch64_get_elf_image' mangled-name='_Uaarch64_get_elf_image' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_elf_image'>
+      <parameter type-id='type-id-182' name='ei'/>
+      <parameter type-id='type-id-181' name='pid'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-183' name='segbase'/>
+      <parameter type-id='type-id-183' name='mapoff'/>
+      <parameter type-id='type-id-85' name='path'/>
+      <parameter type-id='type-id-22' name='pathlen'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_Uaarch64_get_exe_image_path' mangled-name='_Uaarch64_get_exe_image_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_exe_image_path'>
+      <parameter type-id='type-id-85' name='path'/>
+      <return type-id='type-id-82'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-82'/>
+    <pointer-type-def type-id='type-id-82' id='type-id-2'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/aarch64/linux-gnu/libunwind-coredump.abi
+++ b/src/abi/aarch64/linux-gnu/libunwind-coredump.abi
@@ -1,0 +1,1011 @@
+<abi-corpus version='2.2' architecture='elf-arm-aarch64' soname='libunwind-coredump.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-aarch64.so.8'/>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-aarch64.so.1'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_UCD_access_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_access_mem' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_access_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_find_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_cursig' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_mapinfo' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_num_threads' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_pid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_threadinfo' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_put_unwind_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_select_thread' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_UCD_accessors' size='88' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_access_mem.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-1'/>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='384' id='type-id-2'>
+      <subrange length='48' lower-bound='0' upper-bound='47' type-id='type-id-3' id='type-id-4'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='792' id='type-id-5'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-3' id='type-id-6'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='16384' id='type-id-8'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-9'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-10' size-in-bits='925696' id='type-id-11'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-9'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-12' id='type-id-13'>
+      <underlying-type type-id='type-id-14'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-15'/>
+    <type-decl name='long double' size-in-bits='128' id='type-id-16'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-17'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-18' visibility='default' id='type-id-19'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-21' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-23' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-24'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-25' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-25' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-26'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-28' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-29'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-32' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-35' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-36'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-38' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='7168' is-struct='yes' visibility='default' id='type-id-39'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-5' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='val' type-id='type-id-40' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='7232' is-struct='yes' visibility='default' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-42' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='946880' is-struct='yes' visibility='default' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='rr_head' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='400'>
+        <var-decl name='log_size' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='prev_log_size' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='hash' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='generation' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='buckets' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='links' type-id='type-id-48' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='default_hash' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4800'>
+        <var-decl name='default_buckets' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='930496'>
+        <var-decl name='default_links' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-50'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-60' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='947968' is-struct='yes' visibility='default' id='type-id-61'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='big_endian' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='caching_policy' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='cache_generation' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_generation' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='global_cache' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='947904'>
+        <var-decl name='debug_frames' type-id='type-id-63' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='16000' is-struct='yes' visibility='default' id='type-id-64'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-65' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-66'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-67' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-63' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-69'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-70' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-70' visibility='default' id='type-id-71'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-72' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-73' id='type-id-22'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-74' id='type-id-32'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-73' id='type-id-21'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-19' id='type-id-18'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-46' id='type-id-20'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-73' id='type-id-23'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-24' id='type-id-28'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-38' id='type-id-75'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-27' id='type-id-76'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-3' id='type-id-77'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-78' id='type-id-79'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-36' id='type-id-7'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-39' id='type-id-42'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-41' id='type-id-10'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-80' id='type-id-44'/>
+    <typedef-decl name='size_t' type-id='type-id-3' id='type-id-34'/>
+    <typedef-decl name='uint16_t' type-id='type-id-75' id='type-id-74'/>
+    <typedef-decl name='uint32_t' type-id='type-id-76' id='type-id-46'/>
+    <typedef-decl name='uint64_t' type-id='type-id-77' id='type-id-73'/>
+    <typedef-decl name='uint8_t' type-id='type-id-79' id='type-id-72'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-81' id='type-id-82'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-13' id='type-id-12'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-64' id='type-id-83'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-84' id='type-id-85'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-86' id='type-id-87'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-88' id='type-id-62'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-69' id='type-id-89'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-15' id='type-id-90'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-16' id='type-id-84'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-71' id='type-id-70'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-73' id='type-id-37'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='384' naming-typedef-id='type-id-44' visibility='default' id='type-id-80'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-17' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-14'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-78'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-27'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-3'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-33'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-38'/>
+    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='4096' id='type-id-49'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-3' id='type-id-91'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-37' size-in-bits='16000' id='type-id-65'>
+      <subrange length='250' lower-bound='0' upper-bound='249' type-id='type-id-3' id='type-id-92'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-37' size-in-bits='6336' id='type-id-40'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-3' id='type-id-6'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-25'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-67'/>
+    <qualified-type-def type-id='type-id-18' const='yes' id='type-id-93'/>
+    <pointer-type-def type-id='type-id-93' size-in-bits='64' id='type-id-31'/>
+    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-94'/>
+    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-95'/>
+    <pointer-type-def type-id='type-id-7' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-47'/>
+    <pointer-type-def type-id='type-id-96' size-in-bits='64' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-97' size-in-bits='64' id='type-id-56'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-59'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-57'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-88'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-61' size-in-bits='64' id='type-id-81'/>
+    <pointer-type-def type-id='type-id-83' size-in-bits='64' id='type-id-107'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-63'/>
+    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-109'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-52'/>
+    <class-decl name='table_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-68'/>
+    <function-decl name='_UCD_access_mem' mangled-name='_UCD_access_mem' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_mem'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-37' name='addr'/>
+      <parameter type-id='type-id-110' name='val'/>
+      <parameter type-id='type-id-15' name='write'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-113' id='type-id-35'/>
+    <function-type size-in-bits='64' id='type-id-96'>
+      <parameter type-id='type-id-95'/>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-105'>
+      <parameter type-id='type-id-87'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-97'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-90'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-98'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-90'/>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-99'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-67'/>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-100'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-109'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-101'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-102'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-103'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-107'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-104'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-106'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-37'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-111'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-109'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-113'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_access_reg_linux.c' language='LANG_C99'>
+    <function-decl name='_UCD_access_reg' mangled-name='_UCD_access_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_reg'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-90' name='regnum'/>
+      <parameter type-id='type-id-110' name='valp'/>
+      <parameter type-id='type-id-15' name='write'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-50' id='type-id-114'/>
+    <var-decl name='_UCD_accessors' type-id='type-id-114' mangled-name='_UCD_accessors' visibility='default' elf-symbol-id='_UCD_accessors'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_create.c' language='LANG_C99'>
+    <type-decl name='__int128 unsigned' size-in-bits='128' id='type-id-115'/>
+    <array-type-def dimensions='1' type-id='type-id-115' size-in-bits='4096' id='type-id-116'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-3' id='type-id-117'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='2176' id='type-id-119'>
+      <subrange length='34' lower-bound='0' upper-bound='33' type-id='type-id-3' id='type-id-120'/>
+    </array-type-def>
+    <type-decl name='short int' size-in-bits='16' id='type-id-121'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-122'/>
+    <class-decl name='UCD_info' size-in-bits='2304' is-struct='yes' visibility='default' id='type-id-123'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='big_endian' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='coredump_fd' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coredump_filename' type-id='type-id-67' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='phdrs' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='phdrs_count' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ucd_file_table' type-id='type-id-125' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='note_phdr' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='prstatus' type-id='type-id-126' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='fpregset' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='n_threads' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='threads' type-id='type-id-128' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='edi' type-id='type-id-129' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='UCD_thread_info' size-in-bits='7424' is-struct='yes' visibility='default' id='type-id-130'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='prstatus' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3200'>
+        <var-decl name='fpregset' type-id='type-id-132' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='coredump_phdr' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-133'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_filesz' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_memsz' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_align' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_backing_file_index' type-id='type-id-135' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-129'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-136' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-137' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-136'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-34' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_prstatus' size-in-bits='3136' is-struct='yes' visibility='default' id='type-id-138'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pr_info' type-id='type-id-139' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='pr_cursig' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pr_sigpend' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pr_sighold' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pr_pid' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='pr_ppid' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pr_pgrp' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pr_sid' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='pr_utime' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='pr_stime' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='pr_cutime' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='pr_cstime' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='pr_reg' type-id='type-id-142' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3072'>
+        <var-decl name='pr_fpvalid' type-id='type-id-15' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_siginfo' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-139'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='si_signo' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='si_code' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='si_errno' type-id='type-id-15' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='timeval' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-141'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tv_sec' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tv_usec' type-id='type-id-144' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucd_file_s' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-145'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='filename' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fd' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='size' type-id='type-id-146' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='image' type-id='type-id-147' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucd_file_table_s' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-148'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uft_count' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uft_size' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uft_files' type-id='type-id-149' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-150'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-151' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-151' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-152' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-152' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-153' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-154'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-155' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-155' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-156' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-152' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-37' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-157'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-152' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-158' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-159'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-160' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-152' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-161' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-162'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-37' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-163'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-110' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='user_fpsimd_struct' size-in-bits='4224' is-struct='yes' visibility='default' id='type-id-164'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='vregs' type-id='type-id-116' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4096'>
+        <var-decl name='fpsr' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4128'>
+        <var-decl name='fpcr' type-id='type-id-27' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='UCD_proc_status_t' type-id='type-id-138' id='type-id-131'/>
+    <typedef-decl name='__int16_t' type-id='type-id-121' id='type-id-165'/>
+    <typedef-decl name='__int32_t' type-id='type-id-15' id='type-id-166'/>
+    <typedef-decl name='__int8_t' type-id='type-id-122' id='type-id-167'/>
+    <typedef-decl name='__off_t' type-id='type-id-17' id='type-id-168'/>
+    <typedef-decl name='__pid_t' type-id='type-id-15' id='type-id-140'/>
+    <typedef-decl name='__suseconds_t' type-id='type-id-17' id='type-id-144'/>
+    <typedef-decl name='__time_t' type-id='type-id-17' id='type-id-143'/>
+    <typedef-decl name='coredump_phdr_t' type-id='type-id-133' id='type-id-169'/>
+    <typedef-decl name='elf_fpregset_t' type-id='type-id-164' id='type-id-132'/>
+    <typedef-decl name='elf_greg_t' type-id='type-id-77' id='type-id-118'/>
+    <typedef-decl name='elf_gregset_t' type-id='type-id-119' id='type-id-142'/>
+    <typedef-decl name='int16_t' type-id='type-id-165' id='type-id-156'/>
+    <typedef-decl name='int32_t' type-id='type-id-166' id='type-id-152'/>
+    <typedef-decl name='int8_t' type-id='type-id-167' id='type-id-155'/>
+    <typedef-decl name='off_t' type-id='type-id-168' id='type-id-146'/>
+    <typedef-decl name='pid_t' type-id='type-id-140' id='type-id-170'/>
+    <typedef-decl name='ucd_file_index_t' type-id='type-id-15' id='type-id-135'/>
+    <typedef-decl name='ucd_file_t' type-id='type-id-145' id='type-id-171'/>
+    <typedef-decl name='ucd_file_table_t' type-id='type-id-148' id='type-id-125'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-150' id='type-id-137'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-154' id='type-id-172'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-157' id='type-id-173'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-159' id='type-id-174'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-162' id='type-id-175'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-163' id='type-id-176'/>
+    <typedef-decl name='uoff_t' type-id='type-id-73' id='type-id-134'/>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-153'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-173' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-176' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-175' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-172' size-in-bits='128' id='type-id-161'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-3' id='type-id-177'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-123' size-in-bits='64' id='type-id-178'/>
+    <pointer-type-def type-id='type-id-131' size-in-bits='64' id='type-id-126'/>
+    <pointer-type-def type-id='type-id-130' size-in-bits='64' id='type-id-128'/>
+    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-124'/>
+    <pointer-type-def type-id='type-id-132' size-in-bits='64' id='type-id-127'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-149'/>
+    <pointer-type-def type-id='type-id-72' size-in-bits='64' id='type-id-147'/>
+    <pointer-type-def type-id='type-id-150' size-in-bits='64' id='type-id-151'/>
+    <pointer-type-def type-id='type-id-159' size-in-bits='64' id='type-id-160'/>
+    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-158'/>
+    <function-decl name='_UCD_create' mangled-name='_UCD_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_create'>
+      <parameter type-id='type-id-30' name='filename'/>
+      <return type-id='type-id-178'/>
+    </function-decl>
+    <function-decl name='_UCD_get_num_threads' mangled-name='_UCD_get_num_threads' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_num_threads'>
+      <parameter type-id='type-id-178' name='ui'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='_UCD_select_thread' mangled-name='_UCD_select_thread' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_select_thread'>
+      <parameter type-id='type-id-178' name='ui'/>
+      <parameter type-id='type-id-15' name='n'/>
+      <return type-id='type-id-113'/>
+    </function-decl>
+    <function-decl name='_UCD_get_pid' mangled-name='_UCD_get_pid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_pid'>
+      <parameter type-id='type-id-178' name='ui'/>
+      <return type-id='type-id-170'/>
+    </function-decl>
+    <function-decl name='_UCD_get_cursig' mangled-name='_UCD_get_cursig' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_cursig'>
+      <parameter type-id='type-id-178' name='ui'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_destroy.c' language='LANG_C99'>
+    <function-decl name='_UCD_destroy' mangled-name='_UCD_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_destroy'>
+      <parameter type-id='type-id-178' name='ui'/>
+      <return type-id='type-id-113'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_find_proc_info.c' language='LANG_C99'>
+    <function-decl name='_UCD_find_proc_info' mangled-name='_UCD_find_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_find_proc_info'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-37' name='ip'/>
+      <parameter type-id='type-id-109' name='pi'/>
+      <parameter type-id='type-id-15' name='need_unwind_info'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_elf_filename' mangled-name='_UCD_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_elf_filename'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-37' name='ip'/>
+      <parameter type-id='type-id-67' name='buf'/>
+      <parameter type-id='type-id-34' name='buf_len'/>
+      <parameter type-id='type-id-110' name='offp'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_mapinfo_linux.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_mapinfo' mangled-name='_UCD_get_mapinfo' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_mapinfo'>
+      <parameter type-id='type-id-178' name='ui'/>
+      <parameter type-id='type-id-124' name='phdrs'/>
+      <parameter type-id='type-id-27' name='phdr_size'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_proc_name.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_proc_name' mangled-name='_UCD_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_proc_name'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-37' name='ip'/>
+      <parameter type-id='type-id-67' name='buf'/>
+      <parameter type-id='type-id-34' name='buf_len'/>
+      <parameter type-id='type-id-110' name='offp'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_threadinfo_prstatus.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_threadinfo' mangled-name='_UCD_get_threadinfo' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_threadinfo'>
+      <parameter type-id='type-id-178' name='ui'/>
+      <parameter type-id='type-id-124' name='phdrs'/>
+      <parameter type-id='type-id-27' name='phdr_size'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_access_fpreg.c' language='LANG_C99'>
+    <function-decl name='_UCD_access_fpreg' mangled-name='_UCD_access_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_fpreg'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-90' name='reg'/>
+      <parameter type-id='type-id-108' name='val'/>
+      <parameter type-id='type-id-15' name='write'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_get_dyn_info_list_addr.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_dyn_info_list_addr' mangled-name='_UCD_get_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_dyn_info_list_addr'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-110' name='dil_addr'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_put_unwind_info.c' language='LANG_C99'>
+    <function-decl name='_UCD_put_unwind_info' mangled-name='_UCD_put_unwind_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_put_unwind_info'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-109' name='pi'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-113'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_resume.c' language='LANG_C99'>
+    <function-decl name='_UCD_resume' mangled-name='_UCD_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_resume'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-107' name='c'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-179' visibility='default' id='type-id-180'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-181' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-180' id='type-id-179'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-182' id='type-id-183'/>
+    <typedef-decl name='sigset_t' type-id='type-id-179' id='type-id-182'/>
+    <array-type-def dimensions='1' type-id='type-id-3' size-in-bits='1024' id='type-id-181'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-3' id='type-id-184'/>
+    </array-type-def>
+    <var-decl name='_UIaarch64_full_mask' type-id='type-id-183' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-17' visibility='default'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/aarch64/linux-gnu/libunwind-ptrace.abi
+++ b/src/abi/aarch64/linux-gnu/libunwind-ptrace.abi
@@ -1,0 +1,627 @@
+<abi-corpus version='2.2' architecture='elf-arm-aarch64' soname='libunwind-ptrace.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-aarch64.so.8'/>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-aarch64.so.1'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_UPT_access_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_access_mem' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_access_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_find_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_put_unwind_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_UPT_accessors' size='88' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_reg_offset' size='392' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-2' visibility='default' id='type-id-3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-3' id='type-id-2'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-5' id='type-id-6'/>
+    <typedef-decl name='sigset_t' type-id='type-id-2' id='type-id-5'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-7'/>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='1024' id='type-id-4'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-7' id='type-id-8'/>
+    </array-type-def>
+    <var-decl name='_UIaarch64_full_mask' type-id='type-id-6' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-1' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_access_fpreg.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-9'/>
+    <array-type-def dimensions='1' type-id='type-id-9' size-in-bits='384' id='type-id-10'>
+      <subrange length='48' lower-bound='0' upper-bound='47' type-id='type-id-7' id='type-id-11'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-9' size-in-bits='792' id='type-id-12'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-7' id='type-id-13'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-14' size-in-bits='16384' id='type-id-15'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-7' id='type-id-16'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-17' size-in-bits='925696' id='type-id-18'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-7' id='type-id-16'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-19' id='type-id-20'>
+      <underlying-type type-id='type-id-21'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
+    <type-decl name='long double' size-in-bits='128' id='type-id-23'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-24' visibility='default' id='type-id-25'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-29' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-30'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-31' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-32'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-34' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-35'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-41' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-44' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='7168' is-struct='yes' visibility='default' id='type-id-45'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='val' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='7232' is-struct='yes' visibility='default' id='type-id-47'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-48' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='946880' is-struct='yes' visibility='default' id='type-id-49'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='rr_head' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='400'>
+        <var-decl name='log_size' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='prev_log_size' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='hash' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='generation' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='buckets' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='links' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='default_hash' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4800'>
+        <var-decl name='default_buckets' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='930496'>
+        <var-decl name='default_links' type-id='type-id-15' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-56'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-66' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='947968' is-struct='yes' visibility='default' id='type-id-67'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='big_endian' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='caching_policy' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='cache_generation' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_generation' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='global_cache' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='947904'>
+        <var-decl name='debug_frames' type-id='type-id-69' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='16000' is-struct='yes' visibility='default' id='type-id-70'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-71' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-72'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-73' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-69' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-75'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-76' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-76' visibility='default' id='type-id-77'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-78' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-79' id='type-id-28'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-80' id='type-id-38'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-79' id='type-id-27'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-25' id='type-id-24'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-52' id='type-id-26'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-79' id='type-id-29'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-30' id='type-id-34'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-44' id='type-id-81'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-33' id='type-id-82'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-7' id='type-id-83'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-84' id='type-id-85'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-42' id='type-id-14'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-45' id='type-id-48'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-47' id='type-id-17'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-86' id='type-id-50'/>
+    <typedef-decl name='size_t' type-id='type-id-7' id='type-id-40'/>
+    <typedef-decl name='uint16_t' type-id='type-id-81' id='type-id-80'/>
+    <typedef-decl name='uint32_t' type-id='type-id-82' id='type-id-52'/>
+    <typedef-decl name='uint64_t' type-id='type-id-83' id='type-id-79'/>
+    <typedef-decl name='uint8_t' type-id='type-id-85' id='type-id-78'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-87' id='type-id-88'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-20' id='type-id-19'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-70' id='type-id-89'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-90' id='type-id-91'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-92' id='type-id-93'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-94' id='type-id-68'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-75' id='type-id-95'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-22' id='type-id-96'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-23' id='type-id-90'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-77' id='type-id-76'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-79' id='type-id-43'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='384' naming-typedef-id='type-id-50' visibility='default' id='type-id-86'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-32' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-1' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-21'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-84'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-33'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-39'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-44'/>
+    <array-type-def dimensions='1' type-id='type-id-44' size-in-bits='4096' id='type-id-55'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-7' id='type-id-97'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-43' size-in-bits='16000' id='type-id-71'>
+      <subrange length='250' lower-bound='0' upper-bound='249' type-id='type-id-7' id='type-id-98'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-43' size-in-bits='6336' id='type-id-46'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-7' id='type-id-13'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-31'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-73'/>
+    <qualified-type-def type-id='type-id-24' const='yes' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-37'/>
+    <qualified-type-def type-id='type-id-9' const='yes' id='type-id-100'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-36'/>
+    <pointer-type-def type-id='type-id-35' size-in-bits='64' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-92'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-62'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-61'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-64'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-57'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-65'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-63'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-59'/>
+    <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-94'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-66'/>
+    <pointer-type-def type-id='type-id-44' size-in-bits='64' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-67' size-in-bits='64' id='type-id-87'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-72' size-in-bits='64' id='type-id-69'/>
+    <pointer-type-def type-id='type-id-91' size-in-bits='64' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-115'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-116'/>
+    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-58'/>
+    <class-decl name='table_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-118'/>
+    <pointer-type-def type-id='type-id-118' size-in-bits='64' id='type-id-74'/>
+    <function-decl name='_UPT_access_fpreg' mangled-name='_UPT_access_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_access_fpreg'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-96' name='reg'/>
+      <parameter type-id='type-id-114' name='val'/>
+      <parameter type-id='type-id-22' name='write'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-119'/>
+    <pointer-type-def type-id='type-id-119' id='type-id-41'/>
+    <function-type size-in-bits='64' id='type-id-102'>
+      <parameter type-id='type-id-101'/>
+      <parameter type-id='type-id-40'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-111'>
+      <parameter type-id='type-id-93'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-103'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-96'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-104'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-96'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-105'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-43'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-40'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-106'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-43'/>
+      <parameter type-id='type-id-115'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-107'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-43'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-108'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-43'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-109'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-113'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-110'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-112'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-43'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-117'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-115'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-119'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_access_mem.c' language='LANG_C99'>
+    <function-decl name='_UPT_access_mem' mangled-name='_UPT_access_mem' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_access_mem'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-43' name='addr'/>
+      <parameter type-id='type-id-116' name='val'/>
+      <parameter type-id='type-id-22' name='write'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_access_reg.c' language='LANG_C99'>
+    <function-decl name='_UPT_access_reg' mangled-name='_UPT_access_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_access_reg'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-96' name='reg'/>
+      <parameter type-id='type-id-116' name='val'/>
+      <parameter type-id='type-id-22' name='write'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-56' id='type-id-120'/>
+    <var-decl name='_UPT_accessors' type-id='type-id-120' mangled-name='_UPT_accessors' visibility='default' elf-symbol-id='_UPT_accessors'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_create.c' language='LANG_C99'>
+    <typedef-decl name='__pid_t' type-id='type-id-22' id='type-id-121'/>
+    <typedef-decl name='pid_t' type-id='type-id-121' id='type-id-122'/>
+    <function-decl name='_UPT_create' mangled-name='_UPT_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_create'>
+      <parameter type-id='type-id-122' name='pid'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_destroy.c' language='LANG_C99'>
+    <function-decl name='_UPT_destroy' mangled-name='_UPT_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_destroy'>
+      <parameter type-id='type-id-41' name='ptr'/>
+      <return type-id='type-id-119'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_find_proc_info.c' language='LANG_C99'>
+    <function-decl name='_UPT_find_proc_info' mangled-name='_UPT_find_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_find_proc_info'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-43' name='ip'/>
+      <parameter type-id='type-id-115' name='pi'/>
+      <parameter type-id='type-id-22' name='need_unwind_info'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_get_dyn_info_list_addr.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_dyn_info_list_addr' mangled-name='_UPT_get_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_get_dyn_info_list_addr'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-116' name='dil_addr'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_get_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_elf_filename' mangled-name='_UPT_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_get_elf_filename'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-43' name='ip'/>
+      <parameter type-id='type-id-73' name='buf'/>
+      <parameter type-id='type-id-40' name='buf_len'/>
+      <parameter type-id='type-id-116' name='offp'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_get_proc_name.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_proc_name' mangled-name='_UPT_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_get_proc_name'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-43' name='ip'/>
+      <parameter type-id='type-id-73' name='buf'/>
+      <parameter type-id='type-id-40' name='buf_len'/>
+      <parameter type-id='type-id-116' name='offp'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_put_unwind_info.c' language='LANG_C99'>
+    <function-decl name='_UPT_put_unwind_info' mangled-name='_UPT_put_unwind_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_put_unwind_info'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-115' name='pi'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-119'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_reg_offset.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-123' size-in-bits='3136' id='type-id-124'>
+      <subrange length='98' lower-bound='0' upper-bound='97' type-id='type-id-7' id='type-id-125'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-22' const='yes' id='type-id-123'/>
+    <var-decl name='_UPT_reg_offset' type-id='type-id-124' mangled-name='_UPT_reg_offset' visibility='default' elf-symbol-id='_UPT_reg_offset'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_resume.c' language='LANG_C99'>
+    <function-decl name='_UPT_resume' mangled-name='_UPT_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_resume'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-113' name='c'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/aarch64/linux-gnu/libunwind-setjmp.abi
+++ b/src/abi/aarch64/linux-gnu/libunwind-setjmp.abi
@@ -1,0 +1,28 @@
+<abi-corpus version='2.2' architecture='elf-arm-aarch64' soname='libunwind-setjmp.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-aarch64.so.8'/>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-aarch64.so.1'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_UI_longjmp_cont' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UI_siglongjmp_cont' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-2' visibility='default' id='type-id-3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-3' id='type-id-2'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-5' id='type-id-6'/>
+    <typedef-decl name='sigset_t' type-id='type-id-2' id='type-id-5'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-7'/>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='1024' id='type-id-4'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-7' id='type-id-8'/>
+    </array-type-def>
+    <var-decl name='_UIaarch64_full_mask' type-id='type-id-6' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-1' visibility='default'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/aarch64/linux-gnu/libunwind.abi
+++ b/src/abi/aarch64/linux-gnu/libunwind.abi
@@ -1,0 +1,1180 @@
+<abi-corpus version='2.2' architecture='elf-arm-aarch64' soname='libunwind.so.8'>
+  <elf-needed>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-aarch64.so.1'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_ULaarch64_apply_reg_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_create_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_destroy_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_dwarf_find_debug_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_dwarf_find_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_dwarf_search_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_elf_filename_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_proc_info_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_proc_info_in_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_proc_name_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_save_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_init_local' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_init_local2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_init_remote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_is_signal_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_reg_states_iterate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_set_cache_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_set_caching_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_set_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_set_iterate_phdr_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_set_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_cancel' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_register' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_flush_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_accessors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_elf_image' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_exe_image_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='backtrace' type='func-type' binding='weak-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_backtrace' type='func-type' binding='global-binding' visibility='default-visibility' alias='backtrace' is-defined='yes'/>
+    <elf-symbol name='unw_backtrace2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_ULaarch64_local_addr_space' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/aarch64/Lapply_reg_state.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_apply_reg_state' mangled-name='_ULaarch64_apply_reg_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_apply_reg_state'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-2' name='reg_states_data'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lcreate_addr_space.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_create_addr_space' mangled-name='_ULaarch64_create_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_create_addr_space'>
+      <parameter type-id='type-id-4' name='a'/>
+      <parameter type-id='type-id-3' name='byte_order'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lget_proc_info.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_get_proc_info' mangled-name='_ULaarch64_get_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_proc_info'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lget_save_loc.c' language='LANG_C99'>
+    <enum-decl name='unw_save_loc_type' id='type-id-7'>
+      <underlying-type type-id='type-id-8'/>
+      <enumerator name='UNW_SLT_NONE' value='0'/>
+      <enumerator name='UNW_SLT_MEMORY' value='1'/>
+      <enumerator name='UNW_SLT_REG' value='2'/>
+    </enum-decl>
+    <class-decl name='unw_save_loc' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-9'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='u' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='extra' type-id='type-id-12' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_save_loc' size-in-bits='8' is-struct='yes' visibility='default' id='type-id-13'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-14' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_save_loc_t' type-id='type-id-9' id='type-id-15'/>
+    <typedef-decl name='unw_save_loc_type_t' type-id='type-id-7' id='type-id-10'/>
+    <typedef-decl name='unw_tdep_save_loc_t' type-id='type-id-13' id='type-id-12'/>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-11'>
+      <data-member access='public'>
+        <var-decl name='addr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='regnum' type-id='type-id-17' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-18'/>
+    <function-decl name='_ULaarch64_get_save_loc' mangled-name='_ULaarch64_get_save_loc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_save_loc'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='reg'/>
+      <parameter type-id='type-id-18' name='sloc'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lglobal.c' language='LANG_C99'>
+    <type-decl name='atomic_bool' size-in-bits='8' id='type-id-19'/>
+    <var-decl name='_ULaarch64_init_done' type-id='type-id-19' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Linit.c' language='LANG_C99'>
+    <var-decl name='_ULaarch64_local_addr_space' type-id='type-id-5' mangled-name='_ULaarch64_local_addr_space' visibility='default' elf-symbol-id='_ULaarch64_local_addr_space'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Linit_local.c' language='LANG_C99'>
+    <class-decl name='ucontext' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-20'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-21'/>
+    <function-decl name='_ULaarch64_init_local' mangled-name='_ULaarch64_init_local' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_init_local'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-22' name='uc'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_ULaarch64_init_local2' mangled-name='_ULaarch64_init_local2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_init_local2'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-22' name='uc'/>
+      <parameter type-id='type-id-3' name='flag'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Linit_remote.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_init_remote' mangled-name='_ULaarch64_init_remote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_init_remote'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-2' name='as_arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lis_signal_frame.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_is_signal_frame' mangled-name='_ULaarch64_is_signal_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_is_signal_frame'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lreg_states_iterate.c' language='LANG_C99'>
+    <typedef-decl name='unw_reg_states_callback' type-id='type-id-23' id='type-id-24'/>
+    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-23'/>
+    <function-decl name='_ULaarch64_reg_states_iterate' mangled-name='_ULaarch64_reg_states_iterate' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_reg_states_iterate'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-24' name='cb'/>
+      <parameter type-id='type-id-2' name='token'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-25'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-26'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lresume.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_resume' mangled-name='_ULaarch64_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_resume'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lstep.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_step' mangled-name='_ULaarch64_step' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_step'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/is_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_is_fpreg' mangled-name='_Uaarch64_is_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_is_fpreg'>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/regname.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_regname' mangled-name='_Uaarch64_regname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_regname'>
+      <parameter type-id='type-id-17' name='reg'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Lfind_proc_info-lsb.c' language='LANG_C99'>
+    <class-decl name='table_entry' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-28'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip_offset' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fde_offset' type-id='type-id-29' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <function-decl name='_ULaarch64_dwarf_find_debug_frame' mangled-name='_ULaarch64_dwarf_find_debug_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_dwarf_find_debug_frame'>
+      <parameter type-id='type-id-3' name='found'/>
+      <parameter type-id='type-id-30' name='di_debug'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-16' name='segbase'/>
+      <parameter type-id='type-id-27' name='obj_name'/>
+      <parameter type-id='type-id-16' name='start'/>
+      <parameter type-id='type-id-16' name='end'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_ULaarch64_dwarf_search_unwind_table' mangled-name='_ULaarch64_dwarf_search_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_dwarf_search_unwind_table'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-30' name='di'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-3' name='need_unwind_info'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-31'>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-26'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-33'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Lfind_unwind_table.c' language='LANG_C99'>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-35'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-37' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-35' size-in-bits='64' id='type-id-38'/>
+    <function-decl name='_ULaarch64_dwarf_find_unwind_table' mangled-name='_ULaarch64_dwarf_find_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_dwarf_find_unwind_table'>
+      <parameter type-id='type-id-38' name='edi'/>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-27' name='path'/>
+      <parameter type-id='type-id-16' name='segbase'/>
+      <parameter type-id='type-id-16' name='mapoff'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Lget_proc_info_in_range.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_get_proc_info_in_range' mangled-name='_ULaarch64_get_proc_info_in_range' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_proc_info_in_range'>
+      <parameter type-id='type-id-16' name='start_ip'/>
+      <parameter type-id='type-id-16' name='end_ip'/>
+      <parameter type-id='type-id-16' name='eh_frame_table'/>
+      <parameter type-id='type-id-16' name='eh_frame_table_len'/>
+      <parameter type-id='type-id-16' name='exidx_frame_table'/>
+      <parameter type-id='type-id-16' name='exidx_frame_table_len'/>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-3' name='need_unwind_info'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/global.c' language='LANG_C99'>
+    <class-decl name='mempool' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-39'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='obj_size' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='chunk_size' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='reserve' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='num_free' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='free_list' type-id='type-id-41' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='object' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-41' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-42' size-in-bits='64' id='type-id-41'/>
+    <var-decl name='dwarf_reg_state_pool' type-id='type-id-39' visibility='default'/>
+    <var-decl name='dwarf_cie_info_pool' type-id='type-id-39' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Ldestroy_addr_space.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_destroy_addr_space' mangled-name='_ULaarch64_destroy_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_destroy_addr_space'>
+      <parameter type-id='type-id-5' name='as'/>
+      <return type-id='type-id-43'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-44' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-45' size-in-bits='64' id='type-id-4'/>
+    <function-decl name='_Uaarch64_get_accessors' mangled-name='_Uaarch64_get_accessors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_accessors'>
+      <parameter type-id='type-id-5' name='as'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_get_elf_filename_by_ip' mangled-name='_ULaarch64_get_elf_filename_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_elf_filename_by_ip'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-46' name='buf'/>
+      <parameter type-id='type-id-26' name='buf_len'/>
+      <parameter type-id='type-id-47' name='offp'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_ULaarch64_get_elf_filename' mangled-name='_ULaarch64_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_elf_filename'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-46' name='buf'/>
+      <parameter type-id='type-id-26' name='buf_len'/>
+      <parameter type-id='type-id-47' name='offp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_fpreg.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_get_fpreg' mangled-name='_ULaarch64_get_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_fpreg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-48' name='valp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_proc_info_by_ip.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_get_proc_info_by_ip' mangled-name='_ULaarch64_get_proc_info_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_proc_info_by_ip'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-2' name='as_arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_proc_name.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_get_proc_name_by_ip' mangled-name='_ULaarch64_get_proc_name_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_proc_name_by_ip'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-46' name='buf'/>
+      <parameter type-id='type-id-26' name='buf_len'/>
+      <parameter type-id='type-id-47' name='offp'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_ULaarch64_get_proc_name' mangled-name='_ULaarch64_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_proc_name'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-46' name='buf'/>
+      <parameter type-id='type-id-26' name='buf_len'/>
+      <parameter type-id='type-id-47' name='offp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_reg.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_get_reg' mangled-name='_ULaarch64_get_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_reg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-47' name='valp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_cache_size.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_set_cache_size' mangled-name='_ULaarch64_set_cache_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_set_cache_size'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-26' name='size'/>
+      <parameter type-id='type-id-3' name='flag'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_caching_policy.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_set_caching_policy' mangled-name='_ULaarch64_set_caching_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_set_caching_policy'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-49' name='policy'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_fpreg.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_set_fpreg' mangled-name='_ULaarch64_set_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_set_fpreg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-50' name='val'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_iterate_phdr_function.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_set_iterate_phdr_function' mangled-name='_ULaarch64_set_iterate_phdr_function' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_set_iterate_phdr_function'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-51' name='function'/>
+      <return type-id='type-id-43'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_reg.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_set_reg' mangled-name='_ULaarch64_set_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_set_reg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-16' name='valp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/backtrace.c' language='LANG_C99'>
+    <class-decl name='stack_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-52' visibility='default' id='type-id-53'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ss_sp' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ss_flags' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ss_size' type-id='type-id-26' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_sigcontext' size-in-bits='6528' is-struct='yes' visibility='default' id='type-id-54'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fault_address' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='regs' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='sp' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2112'>
+        <var-decl name='pc' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='pstate' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='__reserved' type-id='type-id-57' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_context_t' size-in-bits='7936' is-struct='yes' naming-typedef-id='type-id-58' visibility='default' id='type-id-59'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uc_flags' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uc_link' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uc_stack' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='uc_sigmask' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='uc_mcontext' type-id='type-id-54' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='stack_t' type-id='type-id-53' id='type-id-52'/>
+    <typedef-decl name='unw_context_t' type-id='type-id-58' id='type-id-63'/>
+    <typedef-decl name='unw_tdep_context_t' type-id='type-id-59' id='type-id-58'/>
+    <array-type-def dimensions='1' type-id='type-id-55' size-in-bits='1984' id='type-id-56'>
+      <subrange length='31' lower-bound='0' upper-bound='30' type-id='type-id-60' id='type-id-64'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-14' size-in-bits='4224' id='type-id-57'>
+      <subrange length='528' lower-bound='0' upper-bound='527' type-id='type-id-60' id='type-id-65'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-63' size-in-bits='64' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-66'/>
+    <class-decl name='ucontext' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-67' size-in-bits='64' id='type-id-61'/>
+    <function-decl name='unw_backtrace' mangled-name='unw_backtrace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_backtrace'>
+      <parameter type-id='type-id-66' name='buffer'/>
+      <parameter type-id='type-id-3' name='size'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='unw_backtrace2' mangled-name='unw_backtrace2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_backtrace2'>
+      <parameter type-id='type-id-66' name='buffer'/>
+      <parameter type-id='type-id-3' name='size'/>
+      <parameter type-id='type-id-22' name='uc2'/>
+      <parameter type-id='type-id-3' name='flag'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-cancel.c' language='LANG_C99'>
+    <type-decl name='short int' size-in-bits='16' id='type-id-68'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-69'/>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-70'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-71' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-71' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-72' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-73'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-76'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-78' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-79'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-80' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-81' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-82'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-83'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-47' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int16_t' type-id='type-id-68' id='type-id-84'/>
+    <typedef-decl name='__int32_t' type-id='type-id-3' id='type-id-85'/>
+    <typedef-decl name='__int8_t' type-id='type-id-69' id='type-id-86'/>
+    <typedef-decl name='int16_t' type-id='type-id-84' id='type-id-75'/>
+    <typedef-decl name='int32_t' type-id='type-id-85' id='type-id-29'/>
+    <typedef-decl name='int8_t' type-id='type-id-86' id='type-id-74'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-70' id='type-id-37'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-73' id='type-id-87'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-76' id='type-id-88'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-79' id='type-id-89'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-82' id='type-id-90'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-83' id='type-id-91'/>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-72'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-88' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-91' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-90' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-87' size-in-bits='128' id='type-id-81'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-60' id='type-id-92'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-70' size-in-bits='64' id='type-id-71'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-78'/>
+    <function-decl name='_U_dyn_cancel' mangled-name='_U_dyn_cancel' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_cancel'>
+      <parameter type-id='type-id-30' name='di'/>
+      <return type-id='type-id-43'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-info-list.c' language='LANG_C99'>
+    <class-decl name='unw_dyn_info_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-93'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='version' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='generation' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='first' type-id='type-id-30' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_dyn_info_list_t' type-id='type-id-93' id='type-id-94'/>
+    <var-decl name='_U_dyn_info_list' type-id='type-id-94' visibility='default'/>
+    <function-decl name='_U_dyn_info_list_addr' mangled-name='_U_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_info_list_addr'>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-register.c' language='LANG_C99'>
+    <var-decl name='_U_dyn_info_list_lock' type-id='type-id-40' visibility='default'/>
+    <function-decl name='_U_dyn_register' mangled-name='_U_dyn_register' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_register'>
+      <parameter type-id='type-id-30' name='di'/>
+      <return type-id='type-id-43'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/flush_cache.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-95' size-in-bits='384' id='type-id-96'>
+      <subrange length='48' lower-bound='0' upper-bound='47' type-id='type-id-60' id='type-id-97'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-95' size-in-bits='792' id='type-id-98'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-60' id='type-id-99'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-100' size-in-bits='16384' id='type-id-101'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-60' id='type-id-102'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-103' size-in-bits='925696' id='type-id-104'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-60' id='type-id-102'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-49' id='type-id-105'>
+      <underlying-type type-id='type-id-8'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='long double' size-in-bits='128' id='type-id-106'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-107' visibility='default' id='type-id-108'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-109' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-109' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-110' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-111' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-111' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-112' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-112' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-112' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-113'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-114' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-114' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-115'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-116' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-116' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-117' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-118'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-111' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-120' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-2' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-122'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-123' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-123' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-123' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-123' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='7168' is-struct='yes' visibility='default' id='type-id-124'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-98' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='val' type-id='type-id-125' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='7232' is-struct='yes' visibility='default' id='type-id-126'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-127' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='946880' is-struct='yes' visibility='default' id='type-id-128'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='rr_head' type-id='type-id-123' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='400'>
+        <var-decl name='log_size' type-id='type-id-123' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='prev_log_size' type-id='type-id-123' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='hash' type-id='type-id-129' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='generation' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='buckets' type-id='type-id-130' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='links' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='default_hash' type-id='type-id-132' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4800'>
+        <var-decl name='default_buckets' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='930496'>
+        <var-decl name='default_links' type-id='type-id-101' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-44'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-133' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-135' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-136' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-139' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-142' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='947968' is-struct='yes' visibility='default' id='type-id-143'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='big_endian' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='caching_policy' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='cache_generation' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_generation' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='global_cache' type-id='type-id-128' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='947904'>
+        <var-decl name='debug_frames' type-id='type-id-144' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='16000' is-struct='yes' visibility='default' id='type-id-145'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-146' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-147'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-144' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-149'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-150' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-150' visibility='default' id='type-id-151'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-14' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-55' id='type-id-111'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-152' id='type-id-120'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-55' id='type-id-110'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-108' id='type-id-107'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-77' id='type-id-109'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-55' id='type-id-112'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-113' id='type-id-117'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-123' id='type-id-153'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-116' id='type-id-154'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-155' id='type-id-156'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-122' id='type-id-100'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-124' id='type-id-127'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-126' id='type-id-103'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-157' id='type-id-40'/>
+    <typedef-decl name='uint16_t' type-id='type-id-153' id='type-id-152'/>
+    <typedef-decl name='uint32_t' type-id='type-id-154' id='type-id-77'/>
+    <typedef-decl name='uint8_t' type-id='type-id-156' id='type-id-14'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-158' id='type-id-5'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-105' id='type-id-49'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-145' id='type-id-159'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-160' id='type-id-50'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-161' id='type-id-34'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-162' id='type-id-51'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-149' id='type-id-163'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-3' id='type-id-17'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-106' id='type-id-160'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-151' id='type-id-150'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='384' naming-typedef-id='type-id-40' visibility='default' id='type-id-157'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-115' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-96' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-164' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-8'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-155'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-116'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-121'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-123'/>
+    <array-type-def dimensions='1' type-id='type-id-123' size-in-bits='4096' id='type-id-132'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-60' id='type-id-165'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-16' size-in-bits='16000' id='type-id-146'>
+      <subrange length='250' lower-bound='0' upper-bound='249' type-id='type-id-60' id='type-id-166'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-16' size-in-bits='6336' id='type-id-125'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-60' id='type-id-99'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-114'/>
+    <qualified-type-def type-id='type-id-107' const='yes' id='type-id-167'/>
+    <pointer-type-def type-id='type-id-167' size-in-bits='64' id='type-id-119'/>
+    <qualified-type-def type-id='type-id-95' const='yes' id='type-id-168'/>
+    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-27'/>
+    <pointer-type-def type-id='type-id-118' size-in-bits='64' id='type-id-32'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-131'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-130'/>
+    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-161'/>
+    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-138'/>
+    <pointer-type-def type-id='type-id-170' size-in-bits='64' id='type-id-137'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-140'/>
+    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-133'/>
+    <pointer-type-def type-id='type-id-173' size-in-bits='64' id='type-id-136'/>
+    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-141'/>
+    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-139'/>
+    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-135'/>
+    <pointer-type-def type-id='type-id-33' size-in-bits='64' id='type-id-162'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-148'/>
+    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-142'/>
+    <pointer-type-def type-id='type-id-123' size-in-bits='64' id='type-id-129'/>
+    <pointer-type-def type-id='type-id-143' size-in-bits='64' id='type-id-158'/>
+    <pointer-type-def type-id='type-id-159' size-in-bits='64' id='type-id-1'/>
+    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-144'/>
+    <pointer-type-def type-id='type-id-50' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-163' size-in-bits='64' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-47'/>
+    <pointer-type-def type-id='type-id-178' size-in-bits='64' id='type-id-134'/>
+    <function-decl name='_Uaarch64_flush_cache' mangled-name='_Uaarch64_flush_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_flush_cache'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='lo'/>
+      <parameter type-id='type-id-16' name='hi'/>
+      <return type-id='type-id-43'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-169'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-48'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-170'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-47'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-171'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-26'/>
+      <parameter type-id='type-id-47'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-172'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-173'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-47'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-174'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-47'/>
+      <parameter type-id='type-id-47'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-175'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-176'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-47'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-177'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-178'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-43'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-164'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-179' visibility='default' id='type-id-180'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-181' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-180' id='type-id-179'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-62' id='type-id-182'/>
+    <typedef-decl name='sigset_t' type-id='type-id-179' id='type-id-62'/>
+    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='1024' id='type-id-181'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-60' id='type-id-183'/>
+    </array-type-def>
+    <var-decl name='_UIaarch64_full_mask' type-id='type-id-182' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-164' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/strerror.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_strerror' mangled-name='_Uaarch64_strerror' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_strerror'>
+      <parameter type-id='type-id-3' name='err_code'/>
+      <return type-id='type-id-27'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/os-linux.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-95'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-3'/>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-36'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-26' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pid_t' type-id='type-id-3' id='type-id-184'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-60' id='type-id-185'/>
+    <typedef-decl name='pid_t' type-id='type-id-184' id='type-id-186'/>
+    <typedef-decl name='size_t' type-id='type-id-60' id='type-id-26'/>
+    <typedef-decl name='uint64_t' type-id='type-id-185' id='type-id-55'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-55' id='type-id-16'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-46'/>
+    <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-187'/>
+    <pointer-type-def type-id='type-id-60' size-in-bits='64' id='type-id-188'/>
+    <function-decl name='_Uaarch64_get_elf_image' mangled-name='_Uaarch64_get_elf_image' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_elf_image'>
+      <parameter type-id='type-id-187' name='ei'/>
+      <parameter type-id='type-id-186' name='pid'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-188' name='segbase'/>
+      <parameter type-id='type-id-188' name='mapoff'/>
+      <parameter type-id='type-id-46' name='path'/>
+      <parameter type-id='type-id-26' name='pathlen'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_Uaarch64_get_exe_image_path' mangled-name='_Uaarch64_get_exe_image_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_exe_image_path'>
+      <parameter type-id='type-id-46' name='path'/>
+      <return type-id='type-id-43'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-43'/>
+    <pointer-type-def type-id='type-id-43' id='type-id-2'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/aarch64/nto-qnx7.1.0/libunwind-aarch64.abi
+++ b/src/abi/aarch64/nto-qnx7.1.0/libunwind-aarch64.abi
@@ -1,0 +1,1113 @@
+<abi-corpus version='2.2' architecture='elf-arm-aarch64' soname='libunwind-aarch64.so.9'>
+  <elf-needed>
+    <dependency name='liblzma.so.5'/>
+    <dependency name='libz.so.2'/>
+    <dependency name='libunwind.so.9'/>
+    <dependency name='libc.so.5'/>
+    <dependency name='libgcc_s.so.1'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_Uaarch64_apply_reg_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_create_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_destroy_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_dwarf_find_debug_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_dwarf_find_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_dwarf_search_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_flush_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_accessors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_elf_filename_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_elf_image' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_exe_image_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_proc_info_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_proc_info_in_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_proc_name_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_save_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_init_local' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_init_local2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_init_remote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_is_signal_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_reg_states_iterate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_set_cache_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_set_caching_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_set_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_set_iterate_phdr_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_set_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_Uaarch64_local_addr_space' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/aarch64/Gapply_reg_state.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_apply_reg_state' mangled-name='_Uaarch64_apply_reg_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_apply_reg_state'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-2' name='reg_states_data'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Gcreate_addr_space.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_create_addr_space' mangled-name='_Uaarch64_create_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_create_addr_space'>
+      <parameter type-id='type-id-4' name='a'/>
+      <parameter type-id='type-id-3' name='byte_order'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Gget_proc_info.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_get_proc_info' mangled-name='_Uaarch64_get_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_proc_info'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Gget_save_loc.c' language='LANG_C99'>
+    <enum-decl name='unw_save_loc_type' id='type-id-7'>
+      <underlying-type type-id='type-id-8'/>
+      <enumerator name='UNW_SLT_NONE' value='0'/>
+      <enumerator name='UNW_SLT_MEMORY' value='1'/>
+      <enumerator name='UNW_SLT_REG' value='2'/>
+    </enum-decl>
+    <class-decl name='unw_save_loc' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-9'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='u' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='extra' type-id='type-id-12' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_save_loc' size-in-bits='8' is-struct='yes' visibility='default' id='type-id-13'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-14' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_save_loc_t' type-id='type-id-9' id='type-id-15'/>
+    <typedef-decl name='unw_save_loc_type_t' type-id='type-id-7' id='type-id-10'/>
+    <typedef-decl name='unw_tdep_save_loc_t' type-id='type-id-13' id='type-id-12'/>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-11'>
+      <data-member access='public'>
+        <var-decl name='addr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='regnum' type-id='type-id-17' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-18'/>
+    <function-decl name='_Uaarch64_get_save_loc' mangled-name='_Uaarch64_get_save_loc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_save_loc'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='reg'/>
+      <parameter type-id='type-id-18' name='sloc'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Gglobal.c' language='LANG_C99'>
+    <type-decl name='atomic_bool' size-in-bits='8' id='type-id-19'/>
+    <var-decl name='_Uaarch64_init_done' type-id='type-id-19' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Ginit.c' language='LANG_C99'>
+    <var-decl name='_Uaarch64_local_addr_space' type-id='type-id-5' mangled-name='_Uaarch64_local_addr_space' visibility='default' elf-symbol-id='_Uaarch64_local_addr_space'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Ginit_local.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='2048' id='type-id-21'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-22' id='type-id-23'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-24' size-in-bits='4096' id='type-id-25'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-22' id='type-id-23'/>
+    </array-type-def>
+    <class-decl name='__aarch64_mcontext' size-in-bits='6400' is-struct='yes' visibility='default' id='type-id-26'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cpu' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='fpu' type-id='type-id-28' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__ucontext_t' size-in-bits='6784' is-struct='yes' visibility='default' id='type-id-29'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uc_link' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uc_sigmask' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uc_stack' type-id='type-id-32' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='uc_mcontext' type-id='type-id-33' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='aarch64_cpu_registers' size-in-bits='2176' is-struct='yes' visibility='default' id='type-id-34'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gpr' type-id='type-id-21' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='elr' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2112'>
+        <var-decl name='pstate' type-id='type-id-20' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='aarch64_fpu_registers' size-in-bits='4160' is-struct='yes' visibility='default' id='type-id-35'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='reg' type-id='type-id-25' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4096'>
+        <var-decl name='fpsr' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4128'>
+        <var-decl name='fpcr' type-id='type-id-36' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='aarch64_qreg_t' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-24' visibility='default' id='type-id-37'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='qlo' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='qhi' type-id='type-id-20' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='stack_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-32' visibility='default' id='type-id-38'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ss_sp' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ss_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ss_flags' type-id='type-id-3' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='AARCH64_CPU_REGISTERS' type-id='type-id-34' id='type-id-27'/>
+    <typedef-decl name='AARCH64_FPU_REGISTERS' type-id='type-id-35' id='type-id-28'/>
+    <typedef-decl name='aarch64_qreg_t' type-id='type-id-37' id='type-id-24'/>
+    <typedef-decl name='mcontext_t' type-id='type-id-26' id='type-id-33'/>
+    <typedef-decl name='stack_t' type-id='type-id-38' id='type-id-32'/>
+    <typedef-decl name='ucontext_t' type-id='type-id-29' id='type-id-40'/>
+    <typedef-decl name='unw_context_t' type-id='type-id-41' id='type-id-42'/>
+    <typedef-decl name='unw_tdep_context_t' type-id='type-id-40' id='type-id-41'/>
+    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-42' size-in-bits='64' id='type-id-43'/>
+    <function-decl name='_Uaarch64_init_local' mangled-name='_Uaarch64_init_local' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_init_local'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-43' name='uc'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_Uaarch64_init_local2' mangled-name='_Uaarch64_init_local2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_init_local2'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-43' name='uc'/>
+      <parameter type-id='type-id-3' name='flag'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Ginit_remote.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_init_remote' mangled-name='_Uaarch64_init_remote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_init_remote'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-2' name='as_arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Gis_signal_frame.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_is_signal_frame' mangled-name='_Uaarch64_is_signal_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_is_signal_frame'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Greg_states_iterate.c' language='LANG_C99'>
+    <typedef-decl name='unw_reg_states_callback' type-id='type-id-44' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-46' size-in-bits='64' id='type-id-44'/>
+    <function-decl name='_Uaarch64_reg_states_iterate' mangled-name='_Uaarch64_reg_states_iterate' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_reg_states_iterate'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-45' name='cb'/>
+      <parameter type-id='type-id-2' name='token'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-46'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-47'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Gresume.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_resume' mangled-name='_Uaarch64_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_resume'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Gstep.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_step' mangled-name='_Uaarch64_step' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_step'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/is_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_is_fpreg' mangled-name='_Uaarch64_is_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_is_fpreg'>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/regname.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_regname' mangled-name='_Uaarch64_regname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_regname'>
+      <parameter type-id='type-id-17' name='reg'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Gfind_proc_info-lsb.c' language='LANG_C99'>
+    <type-decl name='short int' size-in-bits='16' id='type-id-49'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-50'/>
+    <class-decl name='table_entry' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-51'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip_offset' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fde_offset' type-id='type-id-52' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-53'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-55' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-56'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-59'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-61' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-62'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-64' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-65'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-66'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-67' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_GCC_ATTR_ALIGN_16t' type-id='type-id-49' id='type-id-68'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_32t' type-id='type-id-3' id='type-id-69'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_8t' type-id='type-id-50' id='type-id-70'/>
+    <typedef-decl name='_Int16t' type-id='type-id-68' id='type-id-71'/>
+    <typedef-decl name='_Int32t' type-id='type-id-69' id='type-id-72'/>
+    <typedef-decl name='_Int8t' type-id='type-id-70' id='type-id-73'/>
+    <typedef-decl name='int16_t' type-id='type-id-71' id='type-id-58'/>
+    <typedef-decl name='int32_t' type-id='type-id-72' id='type-id-52'/>
+    <typedef-decl name='int8_t' type-id='type-id-73' id='type-id-57'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-53' id='type-id-74'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-56' id='type-id-75'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-59' id='type-id-76'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-62' id='type-id-77'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-65' id='type-id-78'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-66' id='type-id-79'/>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-55'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-79' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-78' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-75' size-in-bits='128' id='type-id-64'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-22' id='type-id-80'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-53' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-81'/>
+    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-63'/>
+    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-61'/>
+    <function-decl name='_Uaarch64_dwarf_find_debug_frame' mangled-name='_Uaarch64_dwarf_find_debug_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_dwarf_find_debug_frame'>
+      <parameter type-id='type-id-3' name='found'/>
+      <parameter type-id='type-id-81' name='di_debug'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-16' name='segbase'/>
+      <parameter type-id='type-id-48' name='obj_name'/>
+      <parameter type-id='type-id-16' name='start'/>
+      <parameter type-id='type-id-16' name='end'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_Uaarch64_dwarf_search_unwind_table' mangled-name='_Uaarch64_dwarf_search_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_dwarf_search_unwind_table'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-81' name='di'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-3' name='need_unwind_info'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-82'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-47'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-84'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Gfind_unwind_table.c' language='LANG_C99'>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-86'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-74' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-86' size-in-bits='64' id='type-id-88'/>
+    <function-decl name='_Uaarch64_dwarf_find_unwind_table' mangled-name='_Uaarch64_dwarf_find_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_dwarf_find_unwind_table'>
+      <parameter type-id='type-id-88' name='edi'/>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-48' name='path'/>
+      <parameter type-id='type-id-16' name='segbase'/>
+      <parameter type-id='type-id-16' name='mapoff'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Gget_proc_info_in_range.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_get_proc_info_in_range' mangled-name='_Uaarch64_get_proc_info_in_range' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_proc_info_in_range'>
+      <parameter type-id='type-id-16' name='start_ip'/>
+      <parameter type-id='type-id-16' name='end_ip'/>
+      <parameter type-id='type-id-16' name='eh_frame_table'/>
+      <parameter type-id='type-id-16' name='eh_frame_table_len'/>
+      <parameter type-id='type-id-16' name='exidx_frame_table'/>
+      <parameter type-id='type-id-16' name='exidx_frame_table_len'/>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-3' name='need_unwind_info'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/global.c' language='LANG_C99'>
+    <class-decl name='mempool' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-89'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-90' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='obj_size' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='chunk_size' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='reserve' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='num_free' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='free_list' type-id='type-id-91' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='object' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-92'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-91' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-91'/>
+    <var-decl name='dwarf_reg_state_pool' type-id='type-id-89' visibility='default'/>
+    <var-decl name='dwarf_cie_info_pool' type-id='type-id-89' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gdestroy_addr_space.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_destroy_addr_space' mangled-name='_Uaarch64_destroy_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_destroy_addr_space'>
+      <parameter type-id='type-id-5' name='as'/>
+      <return type-id='type-id-93'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-94' id='type-id-95'/>
+    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-4'/>
+    <function-decl name='_Uaarch64_get_accessors' mangled-name='_Uaarch64_get_accessors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_accessors'>
+      <parameter type-id='type-id-5' name='as'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_get_elf_filename_by_ip' mangled-name='_Uaarch64_get_elf_filename_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_elf_filename_by_ip'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-96' name='buf'/>
+      <parameter type-id='type-id-47' name='buf_len'/>
+      <parameter type-id='type-id-67' name='offp'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_Uaarch64_get_elf_filename' mangled-name='_Uaarch64_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_elf_filename'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-96' name='buf'/>
+      <parameter type-id='type-id-47' name='buf_len'/>
+      <parameter type-id='type-id-67' name='offp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_get_fpreg' mangled-name='_Uaarch64_get_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_fpreg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-97' name='valp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_proc_info_by_ip.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_get_proc_info_by_ip' mangled-name='_Uaarch64_get_proc_info_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_proc_info_by_ip'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-2' name='as_arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_proc_name.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_get_proc_name_by_ip' mangled-name='_Uaarch64_get_proc_name_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_proc_name_by_ip'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-96' name='buf'/>
+      <parameter type-id='type-id-47' name='buf_len'/>
+      <parameter type-id='type-id-67' name='offp'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_Uaarch64_get_proc_name' mangled-name='_Uaarch64_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_proc_name'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-96' name='buf'/>
+      <parameter type-id='type-id-47' name='buf_len'/>
+      <parameter type-id='type-id-67' name='offp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_reg.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_get_reg' mangled-name='_Uaarch64_get_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_reg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-67' name='valp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_cache_size.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_set_cache_size' mangled-name='_Uaarch64_set_cache_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_set_cache_size'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-47' name='size'/>
+      <parameter type-id='type-id-3' name='flag'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_caching_policy.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_set_caching_policy' mangled-name='_Uaarch64_set_caching_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_set_caching_policy'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-98' name='policy'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_set_fpreg' mangled-name='_Uaarch64_set_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_set_fpreg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-99' name='val'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_iterate_phdr_function.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_set_iterate_phdr_function' mangled-name='_Uaarch64_set_iterate_phdr_function' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_set_iterate_phdr_function'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-100' name='function'/>
+      <return type-id='type-id-93'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_reg.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_set_reg' mangled-name='_Uaarch64_set_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_set_reg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-16' name='valp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/flush_cache.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-101' size-in-bits='792' id='type-id-102'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-22' id='type-id-103'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-104' size-in-bits='16384' id='type-id-105'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-22' id='type-id-106'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-107' size-in-bits='925696' id='type-id-108'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-22' id='type-id-106'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-98' id='type-id-109'>
+      <underlying-type type-id='type-id-8'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='long double' size-in-bits='128' id='type-id-110'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-111' visibility='default' id='type-id-112'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-113' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-113' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-114' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-115' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-115' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-116' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-116' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-116' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_sync' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-117'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__u' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__owner' type-id='type-id-119' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-120'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-115' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-48' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-122' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-123'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-124' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='7168' is-struct='yes' visibility='default' id='type-id-125'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-102' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='val' type-id='type-id-126' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='7232' is-struct='yes' visibility='default' id='type-id-127'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-128' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='946560' is-struct='yes' visibility='default' id='type-id-129'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-90' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='rr_head' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='log_size' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='prev_log_size' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='hash' type-id='type-id-130' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='generation' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='buckets' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='links' type-id='type-id-132' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='default_hash' type-id='type-id-133' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4480'>
+        <var-decl name='default_buckets' type-id='type-id-108' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='930176'>
+        <var-decl name='default_links' type-id='type-id-105' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-94'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-135' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-136' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-139' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-142' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-143' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='947648' is-struct='yes' visibility='default' id='type-id-144'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-94' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='big_endian' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-100' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='caching_policy' type-id='type-id-98' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='cache_generation' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_generation' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='global_cache' type-id='type-id-129' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='947584'>
+        <var-decl name='debug_frames' type-id='type-id-145' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='16000' is-struct='yes' visibility='default' id='type-id-146'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-147' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-148'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-96' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-149' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-145' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-150'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-151' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-151' visibility='default' id='type-id-152'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-14' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-153' id='type-id-115'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-154' id='type-id-122'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-153' id='type-id-114'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-112' id='type-id-111'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-60' id='type-id-113'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-153' id='type-id-116'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u16t' type-id='type-id-124' id='type-id-155'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u8t' type-id='type-id-156' id='type-id-157'/>
+    <typedef-decl name='_Uint16t' type-id='type-id-155' id='type-id-158'/>
+    <typedef-decl name='_Uint8t' type-id='type-id-157' id='type-id-159'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-123' id='type-id-104'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-125' id='type-id-128'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-127' id='type-id-107'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-117' id='type-id-90'/>
+    <typedef-decl name='uint16_t' type-id='type-id-158' id='type-id-154'/>
+    <typedef-decl name='uint32_t' type-id='type-id-36' id='type-id-60'/>
+    <typedef-decl name='uint8_t' type-id='type-id-159' id='type-id-14'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-160' id='type-id-5'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-109' id='type-id-98'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-146' id='type-id-161'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-162' id='type-id-99'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-163' id='type-id-85'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-164' id='type-id-100'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-150' id='type-id-165'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-3' id='type-id-17'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-110' id='type-id-162'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-152' id='type-id-151'/>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-118'>
+      <data-member access='public'>
+        <var-decl name='__count' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__fd' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__clockid' type-id='type-id-3' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-8'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-156'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-124'/>
+    <array-type-def dimensions='1' type-id='type-id-124' size-in-bits='4096' id='type-id-133'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-22' id='type-id-166'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-16' size-in-bits='16000' id='type-id-147'>
+      <subrange length='250' lower-bound='0' upper-bound='249' type-id='type-id-22' id='type-id-167'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-16' size-in-bits='6336' id='type-id-126'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-22' id='type-id-103'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-111' const='yes' id='type-id-168'/>
+    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-121'/>
+    <qualified-type-def type-id='type-id-101' const='yes' id='type-id-169'/>
+    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-120' size-in-bits='64' id='type-id-83'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-132'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-131'/>
+    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-163'/>
+    <pointer-type-def type-id='type-id-170' size-in-bits='64' id='type-id-139'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-138'/>
+    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-141'/>
+    <pointer-type-def type-id='type-id-173' size-in-bits='64' id='type-id-134'/>
+    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-137'/>
+    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-142'/>
+    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-140'/>
+    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-136'/>
+    <pointer-type-def type-id='type-id-84' size-in-bits='64' id='type-id-164'/>
+    <pointer-type-def type-id='type-id-51' size-in-bits='64' id='type-id-149'/>
+    <pointer-type-def type-id='type-id-178' size-in-bits='64' id='type-id-143'/>
+    <pointer-type-def type-id='type-id-124' size-in-bits='64' id='type-id-130'/>
+    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-160'/>
+    <pointer-type-def type-id='type-id-161' size-in-bits='64' id='type-id-1'/>
+    <pointer-type-def type-id='type-id-148' size-in-bits='64' id='type-id-145'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-165' size-in-bits='64' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-179' size-in-bits='64' id='type-id-135'/>
+    <function-decl name='_Uaarch64_flush_cache' mangled-name='_Uaarch64_flush_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_flush_cache'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='lo'/>
+      <parameter type-id='type-id-16' name='hi'/>
+      <return type-id='type-id-93'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-170'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-97'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-171'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-67'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-172'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-96'/>
+      <parameter type-id='type-id-47'/>
+      <parameter type-id='type-id-67'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-173'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-174'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-67'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-175'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-67'/>
+      <parameter type-id='type-id-67'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-176'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-177'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-67'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-178'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-179'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-93'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-36' size-in-bits='64' id='type-id-180'>
+      <subrange length='2' lower-bound='0' upper-bound='1' type-id='type-id-22' id='type-id-181'/>
+    </array-type-def>
+    <type-decl name='long int' size-in-bits='64' id='type-id-182'/>
+    <class-decl name='sigset_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-31' visibility='default' id='type-id-183'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__bits' type-id='type-id-180' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u32t' type-id='type-id-119' id='type-id-184'/>
+    <typedef-decl name='_Uint32t' type-id='type-id-184' id='type-id-36'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-31' id='type-id-185'/>
+    <typedef-decl name='sigset_t' type-id='type-id-183' id='type-id-31'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-119'/>
+    <var-decl name='_UIaarch64_full_mask' type-id='type-id-185' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-182' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/strerror.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_strerror' mangled-name='_Uaarch64_strerror' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_strerror'>
+      <parameter type-id='type-id-3' name='err_code'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/os-qnx.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-101'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-3'/>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-87'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-47' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u64t' type-id='type-id-22' id='type-id-186'/>
+    <typedef-decl name='_Sizet' type-id='type-id-20' id='type-id-39'/>
+    <typedef-decl name='_Uint64t' type-id='type-id-186' id='type-id-20'/>
+    <typedef-decl name='pid_t' type-id='type-id-3' id='type-id-187'/>
+    <typedef-decl name='size_t' type-id='type-id-39' id='type-id-47'/>
+    <typedef-decl name='uint64_t' type-id='type-id-20' id='type-id-153'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-153' id='type-id-16'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-96'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-188'/>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-189'/>
+    <function-decl name='_Uaarch64_get_elf_image' mangled-name='_Uaarch64_get_elf_image' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_elf_image'>
+      <parameter type-id='type-id-188' name='ei'/>
+      <parameter type-id='type-id-187' name='pid'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-189' name='segbase'/>
+      <parameter type-id='type-id-189' name='mapoff'/>
+      <parameter type-id='type-id-96' name='path'/>
+      <parameter type-id='type-id-47' name='pathlen'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_Uaarch64_get_exe_image_path' mangled-name='_Uaarch64_get_exe_image_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_exe_image_path'>
+      <parameter type-id='type-id-96' name='path'/>
+      <return type-id='type-id-93'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-93'/>
+    <pointer-type-def type-id='type-id-93' id='type-id-2'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/aarch64/nto-qnx7.1.0/libunwind-coredump.abi
+++ b/src/abi/aarch64/nto-qnx7.1.0/libunwind-coredump.abi
@@ -1,0 +1,1393 @@
+<abi-corpus version='2.2' architecture='elf-arm-aarch64' soname='libunwind-coredump.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-aarch64.so.9'/>
+    <dependency name='liblzma.so.5'/>
+    <dependency name='libz.so.2'/>
+    <dependency name='libc.so.5'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_UCD_access_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_access_mem' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_access_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_find_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_cursig' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_mapinfo' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_num_threads' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_pid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_threadinfo' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_put_unwind_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_select_thread' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_UCD_accessors' size='88' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_access_mem.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-1'/>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='792' id='type-id-2'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-3' id='type-id-4'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='16384' id='type-id-6'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-7'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='925696' id='type-id-9'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-7'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-10' id='type-id-11'>
+      <underlying-type type-id='type-id-12'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-13'/>
+    <type-decl name='long double' size-in-bits='128' id='type-id-14'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-15' visibility='default' id='type-id-16'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-17' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-17' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-20' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_sync' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-21'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__u' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__owner' type-id='type-id-23' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-24'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-25' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-27' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-28'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-30' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='7168' is-struct='yes' visibility='default' id='type-id-31'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='val' type-id='type-id-32' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='7232' is-struct='yes' visibility='default' id='type-id-33'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-34' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='946560' is-struct='yes' visibility='default' id='type-id-35'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='rr_head' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='log_size' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='prev_log_size' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='hash' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='generation' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='buckets' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='links' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='default_hash' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4480'>
+        <var-decl name='default_buckets' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='930176'>
+        <var-decl name='default_links' type-id='type-id-6' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-48' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-52' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='947648' is-struct='yes' visibility='default' id='type-id-53'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='big_endian' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='caching_policy' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='cache_generation' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_generation' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='global_cache' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='947584'>
+        <var-decl name='debug_frames' type-id='type-id-55' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='16000' is-struct='yes' visibility='default' id='type-id-56'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-57' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-58'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-55' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-62'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-64' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-64' visibility='default' id='type-id-65'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-66' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-67' id='type-id-19'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-68' id='type-id-27'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-67' id='type-id-18'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-16' id='type-id-15'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-38' id='type-id-17'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-67' id='type-id-20'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u16t' type-id='type-id-30' id='type-id-69'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u32t' type-id='type-id-23' id='type-id-70'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u64t' type-id='type-id-3' id='type-id-71'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u8t' type-id='type-id-72' id='type-id-73'/>
+    <typedef-decl name='_Sizet' type-id='type-id-74' id='type-id-75'/>
+    <typedef-decl name='_Uint16t' type-id='type-id-69' id='type-id-76'/>
+    <typedef-decl name='_Uint32t' type-id='type-id-70' id='type-id-77'/>
+    <typedef-decl name='_Uint64t' type-id='type-id-71' id='type-id-74'/>
+    <typedef-decl name='_Uint8t' type-id='type-id-73' id='type-id-78'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-28' id='type-id-5'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-31' id='type-id-34'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-33' id='type-id-8'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-21' id='type-id-36'/>
+    <typedef-decl name='size_t' type-id='type-id-75' id='type-id-60'/>
+    <typedef-decl name='uint16_t' type-id='type-id-76' id='type-id-68'/>
+    <typedef-decl name='uint32_t' type-id='type-id-77' id='type-id-38'/>
+    <typedef-decl name='uint64_t' type-id='type-id-74' id='type-id-67'/>
+    <typedef-decl name='uint8_t' type-id='type-id-78' id='type-id-66'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-79' id='type-id-80'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-11' id='type-id-10'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-56' id='type-id-81'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-82' id='type-id-83'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-84' id='type-id-85'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-86' id='type-id-54'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-62' id='type-id-87'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-13' id='type-id-88'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-14' id='type-id-82'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-65' id='type-id-64'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-67' id='type-id-29'/>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-22'>
+      <data-member access='public'>
+        <var-decl name='__count' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__fd' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__clockid' type-id='type-id-13' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-12'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-72'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-23'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-3'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-30'/>
+    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='4096' id='type-id-41'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-3' id='type-id-89'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='16000' id='type-id-57'>
+      <subrange length='250' lower-bound='0' upper-bound='249' type-id='type-id-3' id='type-id-90'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='6336' id='type-id-32'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-3' id='type-id-4'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-59'/>
+    <qualified-type-def type-id='type-id-15' const='yes' id='type-id-91'/>
+    <pointer-type-def type-id='type-id-91' size-in-bits='64' id='type-id-26'/>
+    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-92'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-25'/>
+    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-93'/>
+    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-40'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-39'/>
+    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-84'/>
+    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-96' size-in-bits='64' id='type-id-47'/>
+    <pointer-type-def type-id='type-id-97' size-in-bits='64' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-43'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-46'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-49'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-37'/>
+    <pointer-type-def type-id='type-id-53' size-in-bits='64' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-81' size-in-bits='64' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-58' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-83' size-in-bits='64' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-107'/>
+    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-44'/>
+    <class-decl name='table_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-61'/>
+    <function-decl name='_UCD_access_mem' mangled-name='_UCD_access_mem' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_mem'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-29' name='addr'/>
+      <parameter type-id='type-id-108' name='val'/>
+      <parameter type-id='type-id-13' name='write'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-111'/>
+    <pointer-type-def type-id='type-id-111' id='type-id-63'/>
+    <function-type size-in-bits='64' id='type-id-94'>
+      <parameter type-id='type-id-93'/>
+      <parameter type-id='type-id-60'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-103'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-95'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-106'/>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-96'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-97'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-59'/>
+      <parameter type-id='type-id-60'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-98'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-107'/>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-99'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-100'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-101'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-105'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-102'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-104'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-29'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-109'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-107'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-111'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_access_reg_qnx.c' language='LANG_C99'>
+    <function-decl name='_UCD_access_reg' mangled-name='_UCD_access_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_reg'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-88' name='regnum'/>
+      <parameter type-id='type-id-108' name='valp'/>
+      <parameter type-id='type-id-13' name='write'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-42' id='type-id-112'/>
+    <var-decl name='_UCD_accessors' type-id='type-id-112' mangled-name='_UCD_accessors' visibility='default' elf-symbol-id='_UCD_accessors'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_create.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-77' size-in-bits='64' id='type-id-113'>
+      <subrange length='2' lower-bound='0' upper-bound='1' type-id='type-id-3' id='type-id-114'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-74' size-in-bits='65536' id='type-id-115'>
+      <subrange length='1024' lower-bound='0' upper-bound='1023' type-id='type-id-3' id='type-id-116'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-74' size-in-bits='2048' id='type-id-117'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-3' id='type-id-118'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-74' size-in-bits='256' id='type-id-119'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-3' id='type-id-120'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-78' size-in-bits='64' id='type-id-121'>
+      <subrange length='8' lower-bound='0' upper-bound='7' type-id='type-id-3' id='type-id-122'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-123' size-in-bits='4096' id='type-id-124'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-3' id='type-id-118'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-13' size-in-bits='224' id='type-id-125'>
+      <subrange length='7' lower-bound='0' upper-bound='6' type-id='type-id-3' id='type-id-126'/>
+    </array-type-def>
+    <type-decl name='long int' size-in-bits='64' id='type-id-127'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-128'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-129'/>
+    <class-decl name='UCD_info' size-in-bits='2240' is-struct='yes' visibility='default' id='type-id-130'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='big_endian' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='coredump_fd' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coredump_filename' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='phdrs' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='phdrs_count' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ucd_file_table' type-id='type-id-132' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='note_phdr' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='prstatus' type-id='type-id-133' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='n_threads' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='threads' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='edi' type-id='type-id-135' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='UCD_proc_status_t' size-in-bits='133248' is-struct='yes' naming-typedef-id='type-id-136' visibility='default' id='type-id-137'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='thread' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='greg' type-id='type-id-139' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='67712'>
+        <var-decl name='fpreg' type-id='type-id-140' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='UCD_thread_info' size-in-bits='133248' is-struct='yes' visibility='default' id='type-id-141'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='prstatus' type-id='type-id-136' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_debug_thread_info64' size-in-bits='2176' is-struct='yes' visibility='default' id='type-id-142'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pid' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='tid' type-id='type-id-144' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='flags' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='why' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='112'>
+        <var-decl name='what' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ip' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='sp' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='stkbase' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='tls' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='stksize' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='tid_flags' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='priority' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='456'>
+        <var-decl name='real_priority' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='464'>
+        <var-decl name='policy' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='472'>
+        <var-decl name='state' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='syscall' type-id='type-id-145' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='496'>
+        <var-decl name='last_cpu' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='timeout' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='last_chid' type-id='type-id-146' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='sig_blocked' type-id='type-id-147' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='sig_pending' type-id='type-id-147' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='__info32' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='blocked' type-id='type-id-149' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='start_time' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='sutime' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='extsched' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='nsec_since_block' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='' type-id='type-id-150' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1920'>
+        <var-decl name='reserved2' type-id='type-id-119' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_siginfo' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-151'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='si_signo' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='si_code' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='si_errno' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__data' type-id='type-id-152' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_siginfo32' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-153'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='si_signo' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='si_code' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='si_errno' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__data' type-id='type-id-154' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_siginfo64' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-155'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='si_signo' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='si_code' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='si_errno' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__data' type-id='type-id-156' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='aarch64_cpu_registers' size-in-bits='2176' is-struct='yes' visibility='default' id='type-id-157'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gpr' type-id='type-id-117' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='elr' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2112'>
+        <var-decl name='pstate' type-id='type-id-74' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='aarch64_fpu_registers' size-in-bits='4160' is-struct='yes' visibility='default' id='type-id-158'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='reg' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4096'>
+        <var-decl name='fpsr' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4128'>
+        <var-decl name='fpcr' type-id='type-id-77' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='aarch64_qreg_t' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-123' visibility='default' id='type-id-159'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='qlo' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='qhi' type-id='type-id-74' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='coredump_phdr' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-160'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-161' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-161' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_filesz' type-id='type-id-161' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_memsz' type-id='type-id-161' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_align' type-id='type-id-161' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_backing_file_index' type-id='type-id-162' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-135'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-163' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-164' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-164' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-163'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-60' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='sigset_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-147' visibility='default' id='type-id-165'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__bits' type-id='type-id-113' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucd_file_s' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-166'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='filename' type-id='type-id-25' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fd' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='size' type-id='type-id-167' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='image' type-id='type-id-168' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucd_file_table_s' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-169'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uft_count' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uft_size' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uft_files' type-id='type-id-170' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-171'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-172' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-172' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-173' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-173' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-174' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-175'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-176' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-176' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-177' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-173' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-29' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-178'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-173' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-179' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-180'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-181' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-173' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-182' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-183'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-29' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-184'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-108' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__8' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-185'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='chid' type-id='type-id-146' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__6' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-186'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='id' type-id='type-id-187' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='sync' type-id='type-id-188' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__10' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-189'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='size' type-id='type-id-190' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__7' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-191'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nd' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='pid' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coid' type-id='type-id-146' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='chid' type-id='type-id-146' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='scoid' type-id='type-id-146' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='flags' type-id='type-id-77' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__3' size-in-bits='96' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-192'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__utime' type-id='type-id-193' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__status' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__stime' type-id='type-id-193' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__4' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-194'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__fltno' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__fltip' type-id='type-id-195' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__addr' type-id='type-id-195' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__bdslot' type-id='type-id-13' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__16' size-in-bits='256' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-196'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__fltno' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__fltip' type-id='type-id-188' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__addr' type-id='type-id-188' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__bdslot' type-id='type-id-13' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__20' size-in-bits='256' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-197'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__fltno' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__fltip' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__addr' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__bdslot' type-id='type-id-13' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__1' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-198'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__pid' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__pdata' type-id='type-id-199' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__13' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-200'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__pid' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__pdata' type-id='type-id-201' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__17' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-202'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__pid' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__pdata' type-id='type-id-203' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__12' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-204'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='child' type-id='type-id-143' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__9' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-205'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pid' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='flags' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='vaddr' type-id='type-id-188' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__5' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-206'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tid' type-id='type-id-144' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__2' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-207'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__uid' type-id='type-id-208' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__value' type-id='type-id-209' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__14' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-210'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__uid' type-id='type-id-208' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__value' type-id='type-id-211' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__18' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-212'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__uid' type-id='type-id-208' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__value' type-id='type-id-213' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='AARCH64_CPU_REGISTERS' type-id='type-id-157' id='type-id-214'/>
+    <typedef-decl name='AARCH64_FPU_REGISTERS' type-id='type-id-158' id='type-id-215'/>
+    <typedef-decl name='UCD_proc_status_t' type-id='type-id-137' id='type-id-136'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_16t' type-id='type-id-128' id='type-id-216'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_32t' type-id='type-id-13' id='type-id-217'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_64t' type-id='type-id-127' id='type-id-218'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_8t' type-id='type-id-129' id='type-id-219'/>
+    <typedef-decl name='_Int16t' type-id='type-id-216' id='type-id-145'/>
+    <typedef-decl name='_Int32t' type-id='type-id-217' id='type-id-146'/>
+    <typedef-decl name='_Int64t' type-id='type-id-218' id='type-id-220'/>
+    <typedef-decl name='_Int8t' type-id='type-id-219' id='type-id-221'/>
+    <typedef-decl name='_Intptr64t' type-id='type-id-220' id='type-id-187'/>
+    <typedef-decl name='_Offt' type-id='type-id-220' id='type-id-222'/>
+    <typedef-decl name='_Size64t' type-id='type-id-74' id='type-id-190'/>
+    <typedef-decl name='_Uintptr32t' type-id='type-id-77' id='type-id-195'/>
+    <typedef-decl name='_Uintptr64t' type-id='type-id-74' id='type-id-188'/>
+    <typedef-decl name='__siginfo32_t' type-id='type-id-153' id='type-id-148'/>
+    <typedef-decl name='__siginfo64_t' type-id='type-id-155' id='type-id-223'/>
+    <typedef-decl name='aarch64_qreg_t' type-id='type-id-159' id='type-id-123'/>
+    <typedef-decl name='clock_t' type-id='type-id-77' id='type-id-193'/>
+    <typedef-decl name='coredump_phdr_t' type-id='type-id-160' id='type-id-224'/>
+    <typedef-decl name='debug_fpreg_t' type-id='type-id-225' id='type-id-226'/>
+    <typedef-decl name='debug_greg_t' type-id='type-id-227' id='type-id-228'/>
+    <typedef-decl name='debug_thread64_t' type-id='type-id-142' id='type-id-229'/>
+    <typedef-decl name='debug_thread_t' type-id='type-id-229' id='type-id-230'/>
+    <typedef-decl name='int16_t' type-id='type-id-145' id='type-id-177'/>
+    <typedef-decl name='int32_t' type-id='type-id-146' id='type-id-173'/>
+    <typedef-decl name='int8_t' type-id='type-id-221' id='type-id-176'/>
+    <typedef-decl name='off_t' type-id='type-id-222' id='type-id-167'/>
+    <typedef-decl name='pid_t' type-id='type-id-13' id='type-id-143'/>
+    <typedef-decl name='procfs_fpreg' type-id='type-id-226' id='type-id-140'/>
+    <typedef-decl name='procfs_greg' type-id='type-id-228' id='type-id-139'/>
+    <typedef-decl name='procfs_status' type-id='type-id-230' id='type-id-138'/>
+    <typedef-decl name='pthread_t' type-id='type-id-146' id='type-id-144'/>
+    <typedef-decl name='siginfo_t' type-id='type-id-151' id='type-id-231'/>
+    <typedef-decl name='sigset_t' type-id='type-id-165' id='type-id-147'/>
+    <typedef-decl name='ucd_file_index_t' type-id='type-id-13' id='type-id-162'/>
+    <typedef-decl name='ucd_file_t' type-id='type-id-166' id='type-id-232'/>
+    <typedef-decl name='ucd_file_table_t' type-id='type-id-169' id='type-id-132'/>
+    <typedef-decl name='uid_t' type-id='type-id-13' id='type-id-208'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-171' id='type-id-164'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-175' id='type-id-233'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-178' id='type-id-234'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-180' id='type-id-235'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-183' id='type-id-236'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-184' id='type-id-237'/>
+    <typedef-decl name='uoff_t' type-id='type-id-67' id='type-id-161'/>
+    <union-decl name='__sigval32' size-in-bits='32' visibility='default' id='type-id-209'>
+      <data-member access='public'>
+        <var-decl name='sival_int' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='sival_ptr' type-id='type-id-195' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__sigval64' size-in-bits='64' visibility='default' id='type-id-211'>
+      <data-member access='public'>
+        <var-decl name='sival_int' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='sival_ptr' type-id='type-id-188' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='_debug_fpregs' size-in-bits='65536' visibility='default' id='type-id-225'>
+      <data-member access='public'>
+        <var-decl name='aarch64' type-id='type-id-215' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='padding' type-id='type-id-115' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='_debug_gregs' size-in-bits='65536' visibility='default' id='type-id-227'>
+      <data-member access='public'>
+        <var-decl name='aarch64' type-id='type-id-214' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='padding' type-id='type-id-115' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='sigval' size-in-bits='64' visibility='default' id='type-id-213'>
+      <data-member access='public'>
+        <var-decl name='sival_int' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='sival_ptr' type-id='type-id-63' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__3' size-in-bits='384' is-anonymous='yes' visibility='default' id='type-id-150'>
+      <data-member access='public'>
+        <var-decl name='info32' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='info64' type-id='type-id-223' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='info' type-id='type-id-231' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='224' is-anonymous='yes' visibility='default' id='type-id-154'>
+      <data-member access='public'>
+        <var-decl name='__pad' type-id='type-id-125' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__proc' type-id='type-id-198' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__fault' type-id='type-id-194' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__4' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-156'>
+      <data-member access='public'>
+        <var-decl name='__pad' type-id='type-id-125' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__proc' type-id='type-id-200' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__fault' type-id='type-id-196' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__6' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-152'>
+      <data-member access='public'>
+        <var-decl name='__pad' type-id='type-id-125' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__proc' type-id='type-id-202' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__fault' type-id='type-id-197' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__2' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-149'>
+      <data-member access='public'>
+        <var-decl name='join' type-id='type-id-206' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='sync' type-id='type-id-186' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='connect' type-id='type-id-191' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='channel' type-id='type-id-185' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='waitpage' type-id='type-id-205' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='stack' type-id='type-id-189' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='thread_event' type-id='type-id-206' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='fork_event' type-id='type-id-204' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='filler' type-id='type-id-119' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__1' size-in-bits='96' is-anonymous='yes' visibility='default' id='type-id-199'>
+      <data-member access='public'>
+        <var-decl name='__kill' type-id='type-id-207' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__chld' type-id='type-id-192' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__5' size-in-bits='128' is-anonymous='yes' visibility='default' id='type-id-201'>
+      <data-member access='public'>
+        <var-decl name='__kill' type-id='type-id-210' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__chld' type-id='type-id-192' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__7' size-in-bits='128' is-anonymous='yes' visibility='default' id='type-id-203'>
+      <data-member access='public'>
+        <var-decl name='__kill' type-id='type-id-212' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__chld' type-id='type-id-192' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__8' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-174'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-234' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-237' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-236' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-233' size-in-bits='128' id='type-id-182'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-3' id='type-id-238'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-130' size-in-bits='64' id='type-id-239'/>
+    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-133'/>
+    <pointer-type-def type-id='type-id-141' size-in-bits='64' id='type-id-134'/>
+    <pointer-type-def type-id='type-id-224' size-in-bits='64' id='type-id-131'/>
+    <pointer-type-def type-id='type-id-232' size-in-bits='64' id='type-id-170'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-168'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-172'/>
+    <pointer-type-def type-id='type-id-180' size-in-bits='64' id='type-id-181'/>
+    <pointer-type-def type-id='type-id-235' size-in-bits='64' id='type-id-179'/>
+    <function-decl name='_UCD_create' mangled-name='_UCD_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_create'>
+      <parameter type-id='type-id-25' name='filename'/>
+      <return type-id='type-id-239'/>
+    </function-decl>
+    <function-decl name='_UCD_get_num_threads' mangled-name='_UCD_get_num_threads' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_num_threads'>
+      <parameter type-id='type-id-239' name='ui'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='_UCD_select_thread' mangled-name='_UCD_select_thread' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_select_thread'>
+      <parameter type-id='type-id-239' name='ui'/>
+      <parameter type-id='type-id-13' name='n'/>
+      <return type-id='type-id-111'/>
+    </function-decl>
+    <function-decl name='_UCD_get_pid' mangled-name='_UCD_get_pid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_pid'>
+      <parameter type-id='type-id-239' name='ui'/>
+      <return type-id='type-id-143'/>
+    </function-decl>
+    <function-decl name='_UCD_get_cursig' mangled-name='_UCD_get_cursig' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_cursig'>
+      <parameter type-id='type-id-239' name='ui'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_destroy.c' language='LANG_C99'>
+    <function-decl name='_UCD_destroy' mangled-name='_UCD_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_destroy'>
+      <parameter type-id='type-id-239' name='ui'/>
+      <return type-id='type-id-111'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_find_proc_info.c' language='LANG_C99'>
+    <function-decl name='_UCD_find_proc_info' mangled-name='_UCD_find_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_find_proc_info'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-29' name='ip'/>
+      <parameter type-id='type-id-107' name='pi'/>
+      <parameter type-id='type-id-13' name='need_unwind_info'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_elf_filename' mangled-name='_UCD_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_elf_filename'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-29' name='ip'/>
+      <parameter type-id='type-id-59' name='buf'/>
+      <parameter type-id='type-id-60' name='buf_len'/>
+      <parameter type-id='type-id-108' name='offp'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_mapinfo_qnx.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_mapinfo' mangled-name='_UCD_get_mapinfo' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_mapinfo'>
+      <parameter type-id='type-id-239' name='ui'/>
+      <parameter type-id='type-id-131' name='phdrs'/>
+      <parameter type-id='type-id-23' name='phdr_size'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_proc_name.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_proc_name' mangled-name='_UCD_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_proc_name'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-29' name='ip'/>
+      <parameter type-id='type-id-59' name='buf'/>
+      <parameter type-id='type-id-60' name='buf_len'/>
+      <parameter type-id='type-id-108' name='offp'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_threadinfo_prstatus.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_threadinfo' mangled-name='_UCD_get_threadinfo' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_threadinfo'>
+      <parameter type-id='type-id-239' name='ui'/>
+      <parameter type-id='type-id-131' name='phdrs'/>
+      <parameter type-id='type-id-23' name='phdr_size'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_access_fpreg.c' language='LANG_C99'>
+    <function-decl name='_UCD_access_fpreg' mangled-name='_UCD_access_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_fpreg'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-88' name='reg'/>
+      <parameter type-id='type-id-106' name='val'/>
+      <parameter type-id='type-id-13' name='write'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_get_dyn_info_list_addr.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_dyn_info_list_addr' mangled-name='_UCD_get_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_dyn_info_list_addr'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-108' name='dil_addr'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_put_unwind_info.c' language='LANG_C99'>
+    <function-decl name='_UCD_put_unwind_info' mangled-name='_UCD_put_unwind_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_put_unwind_info'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-107' name='pi'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-111'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_resume.c' language='LANG_C99'>
+    <function-decl name='_UCD_resume' mangled-name='_UCD_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_resume'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-105' name='c'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <typedef-decl name='intrmask_t' type-id='type-id-147' id='type-id-240'/>
+    <var-decl name='_UIaarch64_full_mask' type-id='type-id-240' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-127' visibility='default'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/aarch64/nto-qnx7.1.0/libunwind-nto.abi
+++ b/src/abi/aarch64/nto-qnx7.1.0/libunwind-nto.abi
@@ -1,0 +1,594 @@
+<abi-corpus version='2.2' architecture='elf-arm-aarch64' soname='libunwind-nto.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-aarch64.so.9'/>
+    <dependency name='libunwind.so.9'/>
+    <dependency name='libc.so.5'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='unw_nto_access_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_access_mem' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_access_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_find_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_get_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_get_proc_ip_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_put_unwind_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='unw_nto_accessors' size='88' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='64' id='type-id-2'>
+      <subrange length='2' lower-bound='0' upper-bound='1' type-id='type-id-3' id='type-id-4'/>
+    </array-type-def>
+    <type-decl name='long int' size-in-bits='64' id='type-id-5'/>
+    <class-decl name='sigset_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-6' visibility='default' id='type-id-7'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__bits' type-id='type-id-2' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u32t' type-id='type-id-8' id='type-id-9'/>
+    <typedef-decl name='_Uint32t' type-id='type-id-9' id='type-id-1'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-6' id='type-id-10'/>
+    <typedef-decl name='sigset_t' type-id='type-id-7' id='type-id-6'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-8'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-3'/>
+    <var-decl name='_UIaarch64_full_mask' type-id='type-id-10' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-5' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_access_fpreg.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-11'/>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='792' id='type-id-12'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-3' id='type-id-13'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-14' size-in-bits='16384' id='type-id-15'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-16'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-17' size-in-bits='925696' id='type-id-18'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-16'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-19' id='type-id-20'>
+      <underlying-type type-id='type-id-21'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
+    <type-decl name='long double' size-in-bits='128' id='type-id-23'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-24' visibility='default' id='type-id-25'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-29' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_sync' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-30'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__u' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__owner' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-32'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-35' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-36'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-38' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='7168' is-struct='yes' visibility='default' id='type-id-39'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='val' type-id='type-id-40' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='7232' is-struct='yes' visibility='default' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-42' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='946560' is-struct='yes' visibility='default' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='rr_head' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='log_size' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='prev_log_size' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='hash' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='generation' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='buckets' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='links' type-id='type-id-48' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='default_hash' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4480'>
+        <var-decl name='default_buckets' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='930176'>
+        <var-decl name='default_links' type-id='type-id-15' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-50'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-60' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='947648' is-struct='yes' visibility='default' id='type-id-61'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='big_endian' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='caching_policy' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='cache_generation' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_generation' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='global_cache' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='947584'>
+        <var-decl name='debug_frames' type-id='type-id-63' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='16000' is-struct='yes' visibility='default' id='type-id-64'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-65' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-66'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-67' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-69' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-63' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-70'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-71' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-72' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-72' visibility='default' id='type-id-73'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-74' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-75' id='type-id-28'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-76' id='type-id-35'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-75' id='type-id-27'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-25' id='type-id-24'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-46' id='type-id-26'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-75' id='type-id-29'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u16t' type-id='type-id-38' id='type-id-77'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u64t' type-id='type-id-3' id='type-id-78'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u8t' type-id='type-id-79' id='type-id-80'/>
+    <typedef-decl name='_Sizet' type-id='type-id-81' id='type-id-82'/>
+    <typedef-decl name='_Uint16t' type-id='type-id-77' id='type-id-83'/>
+    <typedef-decl name='_Uint64t' type-id='type-id-78' id='type-id-81'/>
+    <typedef-decl name='_Uint8t' type-id='type-id-80' id='type-id-84'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-36' id='type-id-14'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-39' id='type-id-42'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-41' id='type-id-17'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-30' id='type-id-44'/>
+    <typedef-decl name='size_t' type-id='type-id-82' id='type-id-68'/>
+    <typedef-decl name='uint16_t' type-id='type-id-83' id='type-id-76'/>
+    <typedef-decl name='uint32_t' type-id='type-id-1' id='type-id-46'/>
+    <typedef-decl name='uint64_t' type-id='type-id-81' id='type-id-75'/>
+    <typedef-decl name='uint8_t' type-id='type-id-84' id='type-id-74'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-85' id='type-id-86'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-20' id='type-id-19'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-64' id='type-id-87'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-88' id='type-id-89'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-90' id='type-id-91'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-92' id='type-id-62'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-70' id='type-id-93'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-22' id='type-id-94'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-23' id='type-id-88'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-73' id='type-id-72'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-75' id='type-id-37'/>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-31'>
+      <data-member access='public'>
+        <var-decl name='__count' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__fd' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__clockid' type-id='type-id-22' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-21'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-79'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-38'/>
+    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='4096' id='type-id-49'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-3' id='type-id-95'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-37' size-in-bits='16000' id='type-id-65'>
+      <subrange length='250' lower-bound='0' upper-bound='249' type-id='type-id-3' id='type-id-96'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-37' size-in-bits='6336' id='type-id-40'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-3' id='type-id-13'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-67'/>
+    <qualified-type-def type-id='type-id-24' const='yes' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-97' size-in-bits='64' id='type-id-34'/>
+    <qualified-type-def type-id='type-id-11' const='yes' id='type-id-98'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-33'/>
+    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-47'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-90'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-56'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-59'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-57'/>
+    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-92'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-61' size-in-bits='64' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-111'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-63'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-93' size-in-bits='64' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-115' size-in-bits='64' id='type-id-52'/>
+    <class-decl name='table_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-116'/>
+    <pointer-type-def type-id='type-id-116' size-in-bits='64' id='type-id-69'/>
+    <function-decl name='unw_nto_access_fpreg' mangled-name='unw_nto_access_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_access_fpreg'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-94' name='regnum'/>
+      <parameter type-id='type-id-112' name='valp'/>
+      <parameter type-id='type-id-22' name='write'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-117'/>
+    <pointer-type-def type-id='type-id-117' id='type-id-71'/>
+    <function-type size-in-bits='64' id='type-id-100'>
+      <parameter type-id='type-id-99'/>
+      <parameter type-id='type-id-68'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-109'>
+      <parameter type-id='type-id-91'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-101'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-94'/>
+      <parameter type-id='type-id-112'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-102'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-94'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-103'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-67'/>
+      <parameter type-id='type-id-68'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-104'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-113'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-105'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-106'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-107'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-111'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-108'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-110'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-37'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-115'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-113'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-117'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_access_mem.c' language='LANG_C99'>
+    <function-decl name='unw_nto_access_mem' mangled-name='unw_nto_access_mem' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_access_mem'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-37' name='addr'/>
+      <parameter type-id='type-id-114' name='valp'/>
+      <parameter type-id='type-id-22' name='write'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_access_reg.c' language='LANG_C99'>
+    <function-decl name='unw_nto_access_reg' mangled-name='unw_nto_access_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_access_reg'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-94' name='regnum'/>
+      <parameter type-id='type-id-114' name='valp'/>
+      <parameter type-id='type-id-22' name='write'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-50' id='type-id-118'/>
+    <var-decl name='unw_nto_accessors' type-id='type-id-118' mangled-name='unw_nto_accessors' visibility='default' elf-symbol-id='unw_nto_accessors'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_create.c' language='LANG_C99'>
+    <typedef-decl name='_GCC_ATTR_ALIGN_32t' type-id='type-id-22' id='type-id-119'/>
+    <typedef-decl name='_Int32t' type-id='type-id-119' id='type-id-120'/>
+    <typedef-decl name='pid_t' type-id='type-id-22' id='type-id-121'/>
+    <typedef-decl name='pthread_t' type-id='type-id-120' id='type-id-122'/>
+    <function-decl name='unw_nto_create' mangled-name='unw_nto_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_create'>
+      <parameter type-id='type-id-121' name='pid'/>
+      <parameter type-id='type-id-122' name='tid'/>
+      <return type-id='type-id-71'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_destroy.c' language='LANG_C99'>
+    <function-decl name='unw_nto_destroy' mangled-name='unw_nto_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_destroy'>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-117'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_find_proc_info.c' language='LANG_C99'>
+    <function-decl name='unw_nto_find_proc_info' mangled-name='unw_nto_find_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_find_proc_info'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-37' name='ip'/>
+      <parameter type-id='type-id-113' name='pi'/>
+      <parameter type-id='type-id-22' name='need_unwind_info'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_get_dyn_info_list_addr.c' language='LANG_C99'>
+    <function-decl name='unw_nto_get_dyn_info_list_addr' mangled-name='unw_nto_get_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_get_dyn_info_list_addr'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-114' name='dilap'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_get_elf_filename.c' language='LANG_C99'>
+    <function-decl name='unw_nto_get_elf_filename' mangled-name='unw_nto_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_get_elf_filename'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-37' name='ip'/>
+      <parameter type-id='type-id-67' name='buf'/>
+      <parameter type-id='type-id-68' name='buf_len'/>
+      <parameter type-id='type-id-114' name='offp'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_get_proc_name.c' language='LANG_C99'>
+    <function-decl name='unw_nto_get_proc_name' mangled-name='unw_nto_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_get_proc_name'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-37' name='ip'/>
+      <parameter type-id='type-id-67' name='buf'/>
+      <parameter type-id='type-id-68' name='buf_len'/>
+      <parameter type-id='type-id-114' name='offp'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='unw_nto_get_proc_ip_range' mangled-name='unw_nto_get_proc_ip_range' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_get_proc_ip_range'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-37' name='ip'/>
+      <parameter type-id='type-id-114' name='start'/>
+      <parameter type-id='type-id-114' name='end'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_put_unwind_info.c' language='LANG_C99'>
+    <function-decl name='unw_nto_put_unwind_info' mangled-name='unw_nto_put_unwind_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_put_unwind_info'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-113' name='pi'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-117'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_resume.c' language='LANG_C99'>
+    <function-decl name='unw_nto_resume' mangled-name='unw_nto_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_resume'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-111' name='reg'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/aarch64/nto-qnx7.1.0/libunwind.abi
+++ b/src/abi/aarch64/nto-qnx7.1.0/libunwind.abi
@@ -1,0 +1,1164 @@
+<abi-corpus version='2.2' architecture='elf-arm-aarch64' soname='libunwind.so.9'>
+  <elf-needed>
+    <dependency name='libc.so.5'/>
+    <dependency name='libgcc_s.so.1'/>
+    <dependency name='liblzma.so.5'/>
+    <dependency name='libz.so.2'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_ULaarch64_apply_reg_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_create_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_destroy_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_dwarf_find_debug_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_dwarf_find_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_dwarf_search_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_elf_filename_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_proc_info_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_proc_info_in_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_proc_name_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_get_save_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_init_local' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_init_local2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_init_remote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_is_signal_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_reg_states_iterate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_set_cache_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_set_caching_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_set_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_set_iterate_phdr_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_set_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULaarch64_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_cancel' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_register' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_flush_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_accessors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_elf_image' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_get_exe_image_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uaarch64_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='backtrace' type='func-type' binding='weak-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_backtrace' type='func-type' binding='global-binding' visibility='default-visibility' alias='backtrace' is-defined='yes'/>
+    <elf-symbol name='unw_backtrace2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_ULaarch64_local_addr_space' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/aarch64/Lapply_reg_state.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_apply_reg_state' mangled-name='_ULaarch64_apply_reg_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_apply_reg_state'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-2' name='reg_states_data'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lcreate_addr_space.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_create_addr_space' mangled-name='_ULaarch64_create_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_create_addr_space'>
+      <parameter type-id='type-id-4' name='a'/>
+      <parameter type-id='type-id-3' name='byte_order'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lget_proc_info.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_get_proc_info' mangled-name='_ULaarch64_get_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_proc_info'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lget_save_loc.c' language='LANG_C99'>
+    <enum-decl name='unw_save_loc_type' id='type-id-7'>
+      <underlying-type type-id='type-id-8'/>
+      <enumerator name='UNW_SLT_NONE' value='0'/>
+      <enumerator name='UNW_SLT_MEMORY' value='1'/>
+      <enumerator name='UNW_SLT_REG' value='2'/>
+    </enum-decl>
+    <class-decl name='unw_save_loc' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-9'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='u' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='extra' type-id='type-id-12' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_save_loc' size-in-bits='8' is-struct='yes' visibility='default' id='type-id-13'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-14' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_save_loc_t' type-id='type-id-9' id='type-id-15'/>
+    <typedef-decl name='unw_save_loc_type_t' type-id='type-id-7' id='type-id-10'/>
+    <typedef-decl name='unw_tdep_save_loc_t' type-id='type-id-13' id='type-id-12'/>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-11'>
+      <data-member access='public'>
+        <var-decl name='addr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='regnum' type-id='type-id-17' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-18'/>
+    <function-decl name='_ULaarch64_get_save_loc' mangled-name='_ULaarch64_get_save_loc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_save_loc'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='reg'/>
+      <parameter type-id='type-id-18' name='sloc'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lglobal.c' language='LANG_C99'>
+    <type-decl name='atomic_bool' size-in-bits='8' id='type-id-19'/>
+    <var-decl name='_ULaarch64_init_done' type-id='type-id-19' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Linit.c' language='LANG_C99'>
+    <var-decl name='_ULaarch64_local_addr_space' type-id='type-id-5' mangled-name='_ULaarch64_local_addr_space' visibility='default' elf-symbol-id='_ULaarch64_local_addr_space'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Linit_local.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_init_local' mangled-name='_ULaarch64_init_local' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_init_local'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-20' name='uc'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_ULaarch64_init_local2' mangled-name='_ULaarch64_init_local2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_init_local2'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-20' name='uc'/>
+      <parameter type-id='type-id-3' name='flag'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Linit_remote.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_init_remote' mangled-name='_ULaarch64_init_remote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_init_remote'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-2' name='as_arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lis_signal_frame.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_is_signal_frame' mangled-name='_ULaarch64_is_signal_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_is_signal_frame'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lreg_states_iterate.c' language='LANG_C99'>
+    <typedef-decl name='unw_reg_states_callback' type-id='type-id-21' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-21'/>
+    <function-decl name='_ULaarch64_reg_states_iterate' mangled-name='_ULaarch64_reg_states_iterate' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_reg_states_iterate'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-22' name='cb'/>
+      <parameter type-id='type-id-2' name='token'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-23'>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-2'/>
+      <parameter type-id='type-id-24'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lresume.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_resume' mangled-name='_ULaarch64_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_resume'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/Lstep.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_step' mangled-name='_ULaarch64_step' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_step'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/is_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_is_fpreg' mangled-name='_Uaarch64_is_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_is_fpreg'>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/aarch64/regname.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_regname' mangled-name='_Uaarch64_regname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_regname'>
+      <parameter type-id='type-id-17' name='reg'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Lfind_proc_info-lsb.c' language='LANG_C99'>
+    <class-decl name='table_entry' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-26'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip_offset' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fde_offset' type-id='type-id-27' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <function-decl name='_ULaarch64_dwarf_find_debug_frame' mangled-name='_ULaarch64_dwarf_find_debug_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_dwarf_find_debug_frame'>
+      <parameter type-id='type-id-3' name='found'/>
+      <parameter type-id='type-id-28' name='di_debug'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-16' name='segbase'/>
+      <parameter type-id='type-id-25' name='obj_name'/>
+      <parameter type-id='type-id-16' name='start'/>
+      <parameter type-id='type-id-16' name='end'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_ULaarch64_dwarf_search_unwind_table' mangled-name='_ULaarch64_dwarf_search_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_dwarf_search_unwind_table'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-28' name='di'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-3' name='need_unwind_info'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-29'>
+      <parameter type-id='type-id-30'/>
+      <parameter type-id='type-id-24'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-31'>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Lfind_unwind_table.c' language='LANG_C99'>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-33'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-35' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-33' size-in-bits='64' id='type-id-36'/>
+    <function-decl name='_ULaarch64_dwarf_find_unwind_table' mangled-name='_ULaarch64_dwarf_find_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_dwarf_find_unwind_table'>
+      <parameter type-id='type-id-36' name='edi'/>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-25' name='path'/>
+      <parameter type-id='type-id-16' name='segbase'/>
+      <parameter type-id='type-id-16' name='mapoff'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Lget_proc_info_in_range.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_get_proc_info_in_range' mangled-name='_ULaarch64_get_proc_info_in_range' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_proc_info_in_range'>
+      <parameter type-id='type-id-16' name='start_ip'/>
+      <parameter type-id='type-id-16' name='end_ip'/>
+      <parameter type-id='type-id-16' name='eh_frame_table'/>
+      <parameter type-id='type-id-16' name='eh_frame_table_len'/>
+      <parameter type-id='type-id-16' name='exidx_frame_table'/>
+      <parameter type-id='type-id-16' name='exidx_frame_table_len'/>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-3' name='need_unwind_info'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/global.c' language='LANG_C99'>
+    <class-decl name='mempool' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-37'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='obj_size' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='chunk_size' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='reserve' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='num_free' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='free_list' type-id='type-id-39' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='object' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-40'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-39' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-40' size-in-bits='64' id='type-id-39'/>
+    <var-decl name='dwarf_reg_state_pool' type-id='type-id-37' visibility='default'/>
+    <var-decl name='dwarf_cie_info_pool' type-id='type-id-37' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Ldestroy_addr_space.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_destroy_addr_space' mangled-name='_ULaarch64_destroy_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_destroy_addr_space'>
+      <parameter type-id='type-id-5' name='as'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-42' id='type-id-43'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-4'/>
+    <function-decl name='_Uaarch64_get_accessors' mangled-name='_Uaarch64_get_accessors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_accessors'>
+      <parameter type-id='type-id-5' name='as'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_get_elf_filename_by_ip' mangled-name='_ULaarch64_get_elf_filename_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_elf_filename_by_ip'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-44' name='buf'/>
+      <parameter type-id='type-id-24' name='buf_len'/>
+      <parameter type-id='type-id-45' name='offp'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_ULaarch64_get_elf_filename' mangled-name='_ULaarch64_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_elf_filename'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-44' name='buf'/>
+      <parameter type-id='type-id-24' name='buf_len'/>
+      <parameter type-id='type-id-45' name='offp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_fpreg.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_get_fpreg' mangled-name='_ULaarch64_get_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_fpreg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-46' name='valp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_proc_info_by_ip.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_get_proc_info_by_ip' mangled-name='_ULaarch64_get_proc_info_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_proc_info_by_ip'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-2' name='as_arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_proc_name.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_get_proc_name_by_ip' mangled-name='_ULaarch64_get_proc_name_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_proc_name_by_ip'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-44' name='buf'/>
+      <parameter type-id='type-id-24' name='buf_len'/>
+      <parameter type-id='type-id-45' name='offp'/>
+      <parameter type-id='type-id-2' name='arg'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_ULaarch64_get_proc_name' mangled-name='_ULaarch64_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_proc_name'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-44' name='buf'/>
+      <parameter type-id='type-id-24' name='buf_len'/>
+      <parameter type-id='type-id-45' name='offp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_reg.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_get_reg' mangled-name='_ULaarch64_get_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_get_reg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-45' name='valp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_cache_size.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_set_cache_size' mangled-name='_ULaarch64_set_cache_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_set_cache_size'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-24' name='size'/>
+      <parameter type-id='type-id-3' name='flag'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_caching_policy.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_set_caching_policy' mangled-name='_ULaarch64_set_caching_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_set_caching_policy'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-47' name='policy'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_fpreg.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_set_fpreg' mangled-name='_ULaarch64_set_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_set_fpreg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-48' name='val'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_iterate_phdr_function.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_set_iterate_phdr_function' mangled-name='_ULaarch64_set_iterate_phdr_function' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_set_iterate_phdr_function'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-49' name='function'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_reg.c' language='LANG_C99'>
+    <function-decl name='_ULaarch64_set_reg' mangled-name='_ULaarch64_set_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULaarch64_set_reg'>
+      <parameter type-id='type-id-1' name='cursor'/>
+      <parameter type-id='type-id-3' name='regnum'/>
+      <parameter type-id='type-id-16' name='valp'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/backtrace.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-50' size-in-bits='2048' id='type-id-51'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-52' id='type-id-53'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-54' size-in-bits='4096' id='type-id-55'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-52' id='type-id-53'/>
+    </array-type-def>
+    <class-decl name='__aarch64_mcontext' size-in-bits='6400' is-struct='yes' visibility='default' id='type-id-56'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cpu' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='fpu' type-id='type-id-58' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__ucontext_t' size-in-bits='6784' is-struct='yes' visibility='default' id='type-id-59'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uc_link' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uc_sigmask' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uc_stack' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='uc_mcontext' type-id='type-id-63' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='aarch64_cpu_registers' size-in-bits='2176' is-struct='yes' visibility='default' id='type-id-64'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gpr' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='elr' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2112'>
+        <var-decl name='pstate' type-id='type-id-50' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='aarch64_fpu_registers' size-in-bits='4160' is-struct='yes' visibility='default' id='type-id-65'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='reg' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4096'>
+        <var-decl name='fpsr' type-id='type-id-66' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4128'>
+        <var-decl name='fpcr' type-id='type-id-66' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='aarch64_qreg_t' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-54' visibility='default' id='type-id-67'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='qlo' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='qhi' type-id='type-id-50' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='stack_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-62' visibility='default' id='type-id-68'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ss_sp' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ss_size' type-id='type-id-69' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ss_flags' type-id='type-id-3' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='AARCH64_CPU_REGISTERS' type-id='type-id-64' id='type-id-57'/>
+    <typedef-decl name='AARCH64_FPU_REGISTERS' type-id='type-id-65' id='type-id-58'/>
+    <typedef-decl name='aarch64_qreg_t' type-id='type-id-67' id='type-id-54'/>
+    <typedef-decl name='mcontext_t' type-id='type-id-56' id='type-id-63'/>
+    <typedef-decl name='stack_t' type-id='type-id-68' id='type-id-62'/>
+    <typedef-decl name='ucontext_t' type-id='type-id-59' id='type-id-70'/>
+    <typedef-decl name='unw_context_t' type-id='type-id-71' id='type-id-72'/>
+    <typedef-decl name='unw_tdep_context_t' type-id='type-id-70' id='type-id-71'/>
+    <pointer-type-def type-id='type-id-59' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-72' size-in-bits='64' id='type-id-20'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-73'/>
+    <function-decl name='unw_backtrace' mangled-name='unw_backtrace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_backtrace'>
+      <parameter type-id='type-id-73' name='buffer'/>
+      <parameter type-id='type-id-3' name='size'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='unw_backtrace2' mangled-name='unw_backtrace2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_backtrace2'>
+      <parameter type-id='type-id-73' name='buffer'/>
+      <parameter type-id='type-id-3' name='size'/>
+      <parameter type-id='type-id-20' name='uc2'/>
+      <parameter type-id='type-id-3' name='flag'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-cancel.c' language='LANG_C99'>
+    <type-decl name='short int' size-in-bits='16' id='type-id-74'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-75'/>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-76'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-78' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-79'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-80' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-80' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-81' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-82'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-84' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-85'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-86' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-87' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-88'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-89'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-45' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_GCC_ATTR_ALIGN_16t' type-id='type-id-74' id='type-id-90'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_32t' type-id='type-id-3' id='type-id-91'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_8t' type-id='type-id-75' id='type-id-92'/>
+    <typedef-decl name='_Int16t' type-id='type-id-90' id='type-id-93'/>
+    <typedef-decl name='_Int32t' type-id='type-id-91' id='type-id-94'/>
+    <typedef-decl name='_Int8t' type-id='type-id-92' id='type-id-95'/>
+    <typedef-decl name='int16_t' type-id='type-id-93' id='type-id-81'/>
+    <typedef-decl name='int32_t' type-id='type-id-94' id='type-id-27'/>
+    <typedef-decl name='int8_t' type-id='type-id-95' id='type-id-80'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-76' id='type-id-35'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-79' id='type-id-96'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-82' id='type-id-97'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-85' id='type-id-98'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-88' id='type-id-99'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-89' id='type-id-100'/>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-78'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-97' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-100' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-99' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-96' size-in-bits='128' id='type-id-87'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-52' id='type-id-101'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-76' size-in-bits='64' id='type-id-77'/>
+    <pointer-type-def type-id='type-id-35' size-in-bits='64' id='type-id-28'/>
+    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-84'/>
+    <function-decl name='_U_dyn_cancel' mangled-name='_U_dyn_cancel' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_cancel'>
+      <parameter type-id='type-id-28' name='di'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-info-list.c' language='LANG_C99'>
+    <class-decl name='unw_dyn_info_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-102'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='version' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='generation' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='first' type-id='type-id-28' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_dyn_info_list_t' type-id='type-id-102' id='type-id-103'/>
+    <var-decl name='_U_dyn_info_list' type-id='type-id-103' visibility='default'/>
+    <function-decl name='_U_dyn_info_list_addr' mangled-name='_U_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_info_list_addr'>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-register.c' language='LANG_C99'>
+    <var-decl name='_U_dyn_info_list_lock' type-id='type-id-38' visibility='default'/>
+    <function-decl name='_U_dyn_register' mangled-name='_U_dyn_register' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_register'>
+      <parameter type-id='type-id-28' name='di'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/flush_cache.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-104' size-in-bits='792' id='type-id-105'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-52' id='type-id-106'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-107' size-in-bits='16384' id='type-id-108'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-52' id='type-id-109'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-110' size-in-bits='925696' id='type-id-111'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-52' id='type-id-109'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-47' id='type-id-112'>
+      <underlying-type type-id='type-id-8'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='long double' size-in-bits='128' id='type-id-113'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-114' visibility='default' id='type-id-115'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-116' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-116' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-117' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-119' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_sync' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-120'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__u' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__owner' type-id='type-id-122' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-123'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-25' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-125' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-126'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-127' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='7168' is-struct='yes' visibility='default' id='type-id-128'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-105' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='val' type-id='type-id-129' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='7232' is-struct='yes' visibility='default' id='type-id-130'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-131' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='946560' is-struct='yes' visibility='default' id='type-id-132'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='rr_head' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='log_size' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='prev_log_size' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='hash' type-id='type-id-133' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='generation' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='buckets' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='links' type-id='type-id-135' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='default_hash' type-id='type-id-136' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4480'>
+        <var-decl name='default_buckets' type-id='type-id-111' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='930176'>
+        <var-decl name='default_links' type-id='type-id-108' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-139' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-142' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-144' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-144' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-145' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-146' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='947648' is-struct='yes' visibility='default' id='type-id-147'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='big_endian' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='caching_policy' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='cache_generation' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_generation' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='global_cache' type-id='type-id-132' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='947584'>
+        <var-decl name='debug_frames' type-id='type-id-148' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='16000' is-struct='yes' visibility='default' id='type-id-149'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-150' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-151'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-152' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-148' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-153'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-154' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-154' visibility='default' id='type-id-155'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-14' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-156' id='type-id-118'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-157' id='type-id-125'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-156' id='type-id-117'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-115' id='type-id-114'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-83' id='type-id-116'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-156' id='type-id-119'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u16t' type-id='type-id-127' id='type-id-158'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u8t' type-id='type-id-159' id='type-id-160'/>
+    <typedef-decl name='_Uint16t' type-id='type-id-158' id='type-id-161'/>
+    <typedef-decl name='_Uint8t' type-id='type-id-160' id='type-id-162'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-126' id='type-id-107'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-128' id='type-id-131'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-130' id='type-id-110'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-120' id='type-id-38'/>
+    <typedef-decl name='uint16_t' type-id='type-id-161' id='type-id-157'/>
+    <typedef-decl name='uint32_t' type-id='type-id-66' id='type-id-83'/>
+    <typedef-decl name='uint8_t' type-id='type-id-162' id='type-id-14'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-163' id='type-id-5'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-112' id='type-id-47'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-149' id='type-id-164'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-165' id='type-id-48'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-166' id='type-id-32'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-167' id='type-id-49'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-153' id='type-id-168'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-3' id='type-id-17'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-113' id='type-id-165'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-155' id='type-id-154'/>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-121'>
+      <data-member access='public'>
+        <var-decl name='__count' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__fd' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__clockid' type-id='type-id-3' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-8'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-159'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-127'/>
+    <array-type-def dimensions='1' type-id='type-id-127' size-in-bits='4096' id='type-id-136'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-52' id='type-id-169'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-16' size-in-bits='16000' id='type-id-150'>
+      <subrange length='250' lower-bound='0' upper-bound='249' type-id='type-id-52' id='type-id-170'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-16' size-in-bits='6336' id='type-id-129'>
+      <subrange length='99' lower-bound='0' upper-bound='98' type-id='type-id-52' id='type-id-106'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-114' const='yes' id='type-id-171'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-124'/>
+    <qualified-type-def type-id='type-id-104' const='yes' id='type-id-172'/>
+    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-25'/>
+    <pointer-type-def type-id='type-id-123' size-in-bits='64' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-135'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-134'/>
+    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-166'/>
+    <pointer-type-def type-id='type-id-173' size-in-bits='64' id='type-id-142'/>
+    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-141'/>
+    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-144'/>
+    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-137'/>
+    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-140'/>
+    <pointer-type-def type-id='type-id-178' size-in-bits='64' id='type-id-145'/>
+    <pointer-type-def type-id='type-id-179' size-in-bits='64' id='type-id-143'/>
+    <pointer-type-def type-id='type-id-180' size-in-bits='64' id='type-id-139'/>
+    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-167'/>
+    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-152'/>
+    <pointer-type-def type-id='type-id-181' size-in-bits='64' id='type-id-146'/>
+    <pointer-type-def type-id='type-id-127' size-in-bits='64' id='type-id-133'/>
+    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-163'/>
+    <pointer-type-def type-id='type-id-164' size-in-bits='64' id='type-id-1'/>
+    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-148'/>
+    <pointer-type-def type-id='type-id-48' size-in-bits='64' id='type-id-46'/>
+    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-182' size-in-bits='64' id='type-id-138'/>
+    <function-decl name='_Uaarch64_flush_cache' mangled-name='_Uaarch64_flush_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_flush_cache'>
+      <parameter type-id='type-id-5' name='as'/>
+      <parameter type-id='type-id-16' name='lo'/>
+      <parameter type-id='type-id-16' name='hi'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-173'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-174'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-45'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-175'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-24'/>
+      <parameter type-id='type-id-45'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-176'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-177'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-45'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-178'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-45'/>
+      <parameter type-id='type-id-45'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-179'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-1'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-180'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-45'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-181'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-182'>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-2'/>
+      <return type-id='type-id-41'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-66' size-in-bits='64' id='type-id-183'>
+      <subrange length='2' lower-bound='0' upper-bound='1' type-id='type-id-52' id='type-id-184'/>
+    </array-type-def>
+    <type-decl name='long int' size-in-bits='64' id='type-id-185'/>
+    <class-decl name='sigset_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-61' visibility='default' id='type-id-186'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__bits' type-id='type-id-183' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u32t' type-id='type-id-122' id='type-id-187'/>
+    <typedef-decl name='_Uint32t' type-id='type-id-187' id='type-id-66'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-61' id='type-id-188'/>
+    <typedef-decl name='sigset_t' type-id='type-id-186' id='type-id-61'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-122'/>
+    <var-decl name='_UIaarch64_full_mask' type-id='type-id-188' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-185' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/strerror.c' language='LANG_C99'>
+    <function-decl name='_Uaarch64_strerror' mangled-name='_Uaarch64_strerror' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_strerror'>
+      <parameter type-id='type-id-3' name='err_code'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/os-qnx.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-104'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-3'/>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-34'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-24' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u64t' type-id='type-id-52' id='type-id-189'/>
+    <typedef-decl name='_Sizet' type-id='type-id-50' id='type-id-69'/>
+    <typedef-decl name='_Uint64t' type-id='type-id-189' id='type-id-50'/>
+    <typedef-decl name='pid_t' type-id='type-id-3' id='type-id-190'/>
+    <typedef-decl name='size_t' type-id='type-id-69' id='type-id-24'/>
+    <typedef-decl name='uint64_t' type-id='type-id-50' id='type-id-156'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-156' id='type-id-16'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-44'/>
+    <pointer-type-def type-id='type-id-34' size-in-bits='64' id='type-id-191'/>
+    <pointer-type-def type-id='type-id-52' size-in-bits='64' id='type-id-192'/>
+    <function-decl name='_Uaarch64_get_elf_image' mangled-name='_Uaarch64_get_elf_image' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_elf_image'>
+      <parameter type-id='type-id-191' name='ei'/>
+      <parameter type-id='type-id-190' name='pid'/>
+      <parameter type-id='type-id-16' name='ip'/>
+      <parameter type-id='type-id-192' name='segbase'/>
+      <parameter type-id='type-id-192' name='mapoff'/>
+      <parameter type-id='type-id-44' name='path'/>
+      <parameter type-id='type-id-24' name='pathlen'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='_Uaarch64_get_exe_image_path' mangled-name='_Uaarch64_get_exe_image_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uaarch64_get_exe_image_path'>
+      <parameter type-id='type-id-44' name='path'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-41'/>
+    <pointer-type-def type-id='type-id-41' id='type-id-2'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/libunwind.supp
+++ b/src/abi/libunwind.supp
@@ -1,6 +1,8 @@
-#!/bin/sh
+# Abigail suppressions file
 #
-# This file is part of libunwind.
+# Copyright 2024 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+#
+# This file is a part of the libunwind project.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -9,9 +11,9 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
+# This permission notice shall be included in all copies or substantial portions
+# of the Software.
+# 
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,5 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-bindir="$(pwd)"
-"${bindir}/test-ptrace" -c -n -t "${bindir}/mapper" $*
+
+# Don't report about the (internal) global debug level
+[suppress_variable]
+  name_regexp=_UI.*_debug_level

--- a/src/abi/riscv/linux-gnu/libunwind-coredump.abi
+++ b/src/abi/riscv/linux-gnu/libunwind-coredump.abi
@@ -1,0 +1,1048 @@
+<abi-corpus version='2.2' architecture='elf-unknown-arch-value-243' soname='libunwind-coredump.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-riscv.so.8'/>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-riscv64-lp64d.so.1'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_UCD_access_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_access_mem' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_access_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_find_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_cursig' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_mapinfo' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_num_threads' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_pid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_threadinfo' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_put_unwind_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_select_thread' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_UCD_accessors' size='88' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_access_mem.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-1'/>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='320' id='type-id-2'>
+      <subrange length='40' lower-bound='0' upper-bound='39' type-id='type-id-3' id='type-id-4'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='544' id='type-id-5'>
+      <subrange length='68' lower-bound='0' upper-bound='67' type-id='type-id-3' id='type-id-6'/>
+    </array-type-def>
+    <type-decl name='double' size-in-bits='64' id='type-id-7'/>
+    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='16384' id='type-id-9'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-10'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='638976' id='type-id-12'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-10'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-13' id='type-id-14'>
+      <underlying-type type-id='type-id-15'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-16'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-17'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-18' visibility='default' id='type-id-19'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-21' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-23' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-24'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-25' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-25' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-26'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-28' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-29'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-32' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-35' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-36'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-38' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='4928' is-struct='yes' visibility='default' id='type-id-39'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-5' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='val' type-id='type-id-40' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='4992' is-struct='yes' visibility='default' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-42' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='660096' is-struct='yes' visibility='default' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='rr_head' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='log_size' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='prev_log_size' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='hash' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='generation' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='buckets' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='links' type-id='type-id-48' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='default_hash' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4736'>
+        <var-decl name='default_buckets' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='643712'>
+        <var-decl name='default_links' type-id='type-id-9' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-50'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-60' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='661184' is-struct='yes' visibility='default' id='type-id-61'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='big_endian' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='736'>
+        <var-decl name='addr_size' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='caching_policy' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='cache_generation' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_generation' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='global_cache' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='661120'>
+        <var-decl name='debug_frames' type-id='type-id-63' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='262144' is-struct='yes' visibility='default' id='type-id-64'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-65' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-66'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-67' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-63' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-69'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-70' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-70' visibility='default' id='type-id-71'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-72' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-73' id='type-id-22'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-74' id='type-id-32'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-73' id='type-id-21'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-19' id='type-id-18'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-46' id='type-id-20'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-73' id='type-id-23'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-24' id='type-id-28'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-38' id='type-id-75'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-27' id='type-id-76'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-3' id='type-id-77'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-78' id='type-id-79'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-36' id='type-id-8'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-39' id='type-id-42'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-41' id='type-id-11'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-80' id='type-id-44'/>
+    <typedef-decl name='size_t' type-id='type-id-3' id='type-id-34'/>
+    <typedef-decl name='uint16_t' type-id='type-id-75' id='type-id-74'/>
+    <typedef-decl name='uint32_t' type-id='type-id-76' id='type-id-46'/>
+    <typedef-decl name='uint64_t' type-id='type-id-77' id='type-id-73'/>
+    <typedef-decl name='uint8_t' type-id='type-id-79' id='type-id-72'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-81' id='type-id-82'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-14' id='type-id-13'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-64' id='type-id-83'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-84' id='type-id-85'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-86' id='type-id-87'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-88' id='type-id-62'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-69' id='type-id-89'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-16' id='type-id-90'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-7' id='type-id-84'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-71' id='type-id-70'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-73' id='type-id-37'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-44' visibility='default' id='type-id-80'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-17' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-15'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-78'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-27'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-3'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-33'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-38'/>
+    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='4096' id='type-id-49'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-3' id='type-id-91'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-37' size-in-bits='262144' id='type-id-65'>
+      <subrange length='4096' lower-bound='0' upper-bound='4095' type-id='type-id-3' id='type-id-92'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-37' size-in-bits='4352' id='type-id-40'>
+      <subrange length='68' lower-bound='0' upper-bound='67' type-id='type-id-3' id='type-id-6'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-25'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-67'/>
+    <qualified-type-def type-id='type-id-18' const='yes' id='type-id-93'/>
+    <pointer-type-def type-id='type-id-93' size-in-bits='64' id='type-id-31'/>
+    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-94'/>
+    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-95'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-47'/>
+    <pointer-type-def type-id='type-id-96' size-in-bits='64' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-97' size-in-bits='64' id='type-id-56'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-59'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-57'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-88'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-61' size-in-bits='64' id='type-id-81'/>
+    <pointer-type-def type-id='type-id-83' size-in-bits='64' id='type-id-107'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-63'/>
+    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-109'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-52'/>
+    <class-decl name='table_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-68'/>
+    <function-decl name='_UCD_access_mem' mangled-name='_UCD_access_mem' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_mem'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-37' name='addr'/>
+      <parameter type-id='type-id-110' name='val'/>
+      <parameter type-id='type-id-16' name='write'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-113' id='type-id-35'/>
+    <function-type size-in-bits='64' id='type-id-96'>
+      <parameter type-id='type-id-95'/>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-105'>
+      <parameter type-id='type-id-87'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-97'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-90'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-98'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-90'/>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-99'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-67'/>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-100'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-109'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-101'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-102'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-103'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-107'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-104'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-16'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-106'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-37'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-111'>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-109'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-113'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_access_reg_linux.c' language='LANG_C99'>
+    <function-decl name='_UCD_access_reg' mangled-name='_UCD_access_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_reg'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-90' name='regnum'/>
+      <parameter type-id='type-id-110' name='valp'/>
+      <parameter type-id='type-id-16' name='write'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-50' id='type-id-114'/>
+    <var-decl name='_UCD_accessors' type-id='type-id-114' mangled-name='_UCD_accessors' visibility='default' elf-symbol-id='_UCD_accessors'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_create.c' language='LANG_C99'>
+    <type-decl name='short int' size-in-bits='16' id='type-id-115'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-116'/>
+    <class-decl name='UCD_info' size-in-bits='2304' is-struct='yes' visibility='default' id='type-id-117'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='big_endian' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='coredump_fd' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coredump_filename' type-id='type-id-67' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='phdrs' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='phdrs_count' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ucd_file_table' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='note_phdr' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='prstatus' type-id='type-id-120' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='fpregset' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='n_threads' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='threads' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='edi' type-id='type-id-123' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='UCD_thread_info' size-in-bits='7296' is-struct='yes' visibility='default' id='type-id-124'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='prstatus' type-id='type-id-125' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3072'>
+        <var-decl name='fpregset' type-id='type-id-126' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__riscv_mc_d_ext_state' size-in-bits='2112' is-struct='yes' visibility='default' id='type-id-127'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__f' type-id='type-id-128' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='__fcsr' type-id='type-id-27' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__riscv_mc_f_ext_state' size-in-bits='1056' is-struct='yes' visibility='default' id='type-id-129'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__f' type-id='type-id-130' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='__fcsr' type-id='type-id-27' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__riscv_mc_q_ext_state' size-in-bits='4224' is-struct='yes' visibility='default' id='type-id-131'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__f' type-id='type-id-132' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4096'>
+        <var-decl name='__fcsr' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4128'>
+        <var-decl name='__glibc_reserved' type-id='type-id-133' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='coredump_phdr' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-134'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-135' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-135' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_filesz' type-id='type-id-135' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_memsz' type-id='type-id-135' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_align' type-id='type-id-135' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_backing_file_index' type-id='type-id-136' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-123'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-138' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-137'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-34' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_prstatus' size-in-bits='3008' is-struct='yes' visibility='default' id='type-id-139'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pr_info' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='pr_cursig' type-id='type-id-115' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pr_sigpend' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pr_sighold' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pr_pid' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='pr_ppid' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pr_pgrp' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pr_sid' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='pr_utime' type-id='type-id-142' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='pr_stime' type-id='type-id-142' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='pr_cutime' type-id='type-id-142' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='pr_cstime' type-id='type-id-142' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='pr_reg' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2944'>
+        <var-decl name='pr_fpvalid' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_siginfo' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-140'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='si_signo' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='si_code' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='si_errno' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='timeval' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-142'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tv_sec' type-id='type-id-144' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tv_usec' type-id='type-id-145' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucd_file_s' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-146'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='filename' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fd' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='size' type-id='type-id-147' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='image' type-id='type-id-148' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucd_file_table_s' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-149'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uft_count' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uft_size' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uft_files' type-id='type-id-150' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-151'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-152' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-152' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-153' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-153' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-154' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-155'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-156' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-156' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-157' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-153' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-37' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-158'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-153' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-159' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-160'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-161' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-153' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-162' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-163'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-37' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-164'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-110' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='UCD_proc_status_t' type-id='type-id-139' id='type-id-125'/>
+    <typedef-decl name='__int16_t' type-id='type-id-115' id='type-id-165'/>
+    <typedef-decl name='__int32_t' type-id='type-id-16' id='type-id-166'/>
+    <typedef-decl name='__int8_t' type-id='type-id-116' id='type-id-167'/>
+    <typedef-decl name='__off_t' type-id='type-id-17' id='type-id-168'/>
+    <typedef-decl name='__pid_t' type-id='type-id-16' id='type-id-141'/>
+    <typedef-decl name='__suseconds_t' type-id='type-id-17' id='type-id-145'/>
+    <typedef-decl name='__time_t' type-id='type-id-17' id='type-id-144'/>
+    <typedef-decl name='coredump_phdr_t' type-id='type-id-134' id='type-id-169'/>
+    <typedef-decl name='elf_fpregset_t' type-id='type-id-170' id='type-id-126'/>
+    <typedef-decl name='elf_gregset_t' type-id='type-id-171' id='type-id-143'/>
+    <typedef-decl name='int16_t' type-id='type-id-165' id='type-id-157'/>
+    <typedef-decl name='int32_t' type-id='type-id-166' id='type-id-153'/>
+    <typedef-decl name='int8_t' type-id='type-id-167' id='type-id-156'/>
+    <typedef-decl name='off_t' type-id='type-id-168' id='type-id-147'/>
+    <typedef-decl name='pid_t' type-id='type-id-141' id='type-id-172'/>
+    <typedef-decl name='ucd_file_index_t' type-id='type-id-16' id='type-id-136'/>
+    <typedef-decl name='ucd_file_t' type-id='type-id-146' id='type-id-173'/>
+    <typedef-decl name='ucd_file_table_t' type-id='type-id-149' id='type-id-119'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-151' id='type-id-138'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-155' id='type-id-174'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-158' id='type-id-175'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-160' id='type-id-176'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-163' id='type-id-177'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-164' id='type-id-178'/>
+    <typedef-decl name='uoff_t' type-id='type-id-73' id='type-id-135'/>
+    <union-decl name='__riscv_mc_fp_state' size-in-bits='4224' visibility='default' id='type-id-170'>
+      <data-member access='public'>
+        <var-decl name='__f' type-id='type-id-129' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__d' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__q' type-id='type-id-131' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-154'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-175' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-178' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-177' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-27' size-in-bits='1024' id='type-id-130'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-3' id='type-id-179'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-27' size-in-bits='96' id='type-id-133'>
+      <subrange length='3' lower-bound='0' upper-bound='2' type-id='type-id-3' id='type-id-180'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-3' size-in-bits='2048' id='type-id-171'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-3' id='type-id-179'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-33' size-in-bits='2048' id='type-id-128'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-3' id='type-id-179'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-33' size-in-bits='4096' id='type-id-132'>
+      <subrange length='64' lower-bound='0' upper-bound='63' type-id='type-id-3' id='type-id-181'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-174' size-in-bits='128' id='type-id-162'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-3' id='type-id-182'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-183'/>
+    <pointer-type-def type-id='type-id-125' size-in-bits='64' id='type-id-120'/>
+    <pointer-type-def type-id='type-id-124' size-in-bits='64' id='type-id-122'/>
+    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-118'/>
+    <pointer-type-def type-id='type-id-126' size-in-bits='64' id='type-id-121'/>
+    <pointer-type-def type-id='type-id-173' size-in-bits='64' id='type-id-150'/>
+    <pointer-type-def type-id='type-id-72' size-in-bits='64' id='type-id-148'/>
+    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-152'/>
+    <pointer-type-def type-id='type-id-160' size-in-bits='64' id='type-id-161'/>
+    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-159'/>
+    <function-decl name='_UCD_create' mangled-name='_UCD_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_create'>
+      <parameter type-id='type-id-30' name='filename'/>
+      <return type-id='type-id-183'/>
+    </function-decl>
+    <function-decl name='_UCD_get_num_threads' mangled-name='_UCD_get_num_threads' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_num_threads'>
+      <parameter type-id='type-id-183' name='ui'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='_UCD_select_thread' mangled-name='_UCD_select_thread' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_select_thread'>
+      <parameter type-id='type-id-183' name='ui'/>
+      <parameter type-id='type-id-16' name='n'/>
+      <return type-id='type-id-113'/>
+    </function-decl>
+    <function-decl name='_UCD_get_pid' mangled-name='_UCD_get_pid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_pid'>
+      <parameter type-id='type-id-183' name='ui'/>
+      <return type-id='type-id-172'/>
+    </function-decl>
+    <function-decl name='_UCD_get_cursig' mangled-name='_UCD_get_cursig' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_cursig'>
+      <parameter type-id='type-id-183' name='ui'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_destroy.c' language='LANG_C99'>
+    <function-decl name='_UCD_destroy' mangled-name='_UCD_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_destroy'>
+      <parameter type-id='type-id-183' name='ui'/>
+      <return type-id='type-id-113'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_find_proc_info.c' language='LANG_C99'>
+    <function-decl name='_UCD_find_proc_info' mangled-name='_UCD_find_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_find_proc_info'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-37' name='ip'/>
+      <parameter type-id='type-id-109' name='pi'/>
+      <parameter type-id='type-id-16' name='need_unwind_info'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_elf_filename' mangled-name='_UCD_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_elf_filename'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-37' name='ip'/>
+      <parameter type-id='type-id-67' name='buf'/>
+      <parameter type-id='type-id-34' name='buf_len'/>
+      <parameter type-id='type-id-110' name='offp'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_mapinfo_linux.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_mapinfo' mangled-name='_UCD_get_mapinfo' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_mapinfo'>
+      <parameter type-id='type-id-183' name='ui'/>
+      <parameter type-id='type-id-118' name='phdrs'/>
+      <parameter type-id='type-id-27' name='phdr_size'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_proc_name.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_proc_name' mangled-name='_UCD_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_proc_name'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-37' name='ip'/>
+      <parameter type-id='type-id-67' name='buf'/>
+      <parameter type-id='type-id-34' name='buf_len'/>
+      <parameter type-id='type-id-110' name='offp'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_threadinfo_prstatus.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_threadinfo' mangled-name='_UCD_get_threadinfo' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_threadinfo'>
+      <parameter type-id='type-id-183' name='ui'/>
+      <parameter type-id='type-id-118' name='phdrs'/>
+      <parameter type-id='type-id-27' name='phdr_size'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_access_fpreg.c' language='LANG_C99'>
+    <function-decl name='_UCD_access_fpreg' mangled-name='_UCD_access_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_fpreg'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-90' name='reg'/>
+      <parameter type-id='type-id-108' name='val'/>
+      <parameter type-id='type-id-16' name='write'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_get_dyn_info_list_addr.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_dyn_info_list_addr' mangled-name='_UCD_get_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_dyn_info_list_addr'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-110' name='dil_addr'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_put_unwind_info.c' language='LANG_C99'>
+    <function-decl name='_UCD_put_unwind_info' mangled-name='_UCD_put_unwind_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_put_unwind_info'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-109' name='pi'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-113'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_resume.c' language='LANG_C99'>
+    <function-decl name='_UCD_resume' mangled-name='_UCD_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_resume'>
+      <parameter type-id='type-id-82' name='as'/>
+      <parameter type-id='type-id-107' name='c'/>
+      <parameter type-id='type-id-35' name='arg'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-184' visibility='default' id='type-id-185'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-186' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-185' id='type-id-184'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-187' id='type-id-188'/>
+    <typedef-decl name='sigset_t' type-id='type-id-184' id='type-id-187'/>
+    <array-type-def dimensions='1' type-id='type-id-3' size-in-bits='1024' id='type-id-186'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-3' id='type-id-189'/>
+    </array-type-def>
+    <var-decl name='_UIriscv_full_mask' type-id='type-id-188' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-17' visibility='default'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/riscv/linux-gnu/libunwind-ptrace.abi
+++ b/src/abi/riscv/linux-gnu/libunwind-ptrace.abi
@@ -1,0 +1,630 @@
+<abi-corpus version='2.2' architecture='elf-unknown-arch-value-243' soname='libunwind-ptrace.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-riscv.so.8'/>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-riscv64-lp64d.so.1'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_UPT_access_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_access_mem' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_access_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_find_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_put_unwind_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_UPT_accessors' size='88' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_reg_offset' size='260' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-2' visibility='default' id='type-id-3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-3' id='type-id-2'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-5' id='type-id-6'/>
+    <typedef-decl name='sigset_t' type-id='type-id-2' id='type-id-5'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-7'/>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='1024' id='type-id-4'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-7' id='type-id-8'/>
+    </array-type-def>
+    <var-decl name='_UIriscv_full_mask' type-id='type-id-6' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-1' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_access_fpreg.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-9'/>
+    <array-type-def dimensions='1' type-id='type-id-9' size-in-bits='320' id='type-id-10'>
+      <subrange length='40' lower-bound='0' upper-bound='39' type-id='type-id-7' id='type-id-11'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-9' size-in-bits='544' id='type-id-12'>
+      <subrange length='68' lower-bound='0' upper-bound='67' type-id='type-id-7' id='type-id-13'/>
+    </array-type-def>
+    <type-decl name='double' size-in-bits='64' id='type-id-14'/>
+    <array-type-def dimensions='1' type-id='type-id-15' size-in-bits='16384' id='type-id-16'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-7' id='type-id-17'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-18' size-in-bits='638976' id='type-id-19'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-7' id='type-id-17'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-20' id='type-id-21'>
+      <underlying-type type-id='type-id-22'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-23'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-24' visibility='default' id='type-id-25'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-29' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-30'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-31' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-32'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-34' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-35'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-41' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-44' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='4928' is-struct='yes' visibility='default' id='type-id-45'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='val' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='4992' is-struct='yes' visibility='default' id='type-id-47'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-48' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='660096' is-struct='yes' visibility='default' id='type-id-49'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='rr_head' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='log_size' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='prev_log_size' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='hash' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='generation' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='buckets' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='links' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='default_hash' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4736'>
+        <var-decl name='default_buckets' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='643712'>
+        <var-decl name='default_links' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-56'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-66' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='661184' is-struct='yes' visibility='default' id='type-id-67'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='big_endian' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='736'>
+        <var-decl name='addr_size' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='caching_policy' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='cache_generation' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_generation' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='global_cache' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='661120'>
+        <var-decl name='debug_frames' type-id='type-id-69' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='262144' is-struct='yes' visibility='default' id='type-id-70'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-71' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-72'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-73' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-69' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-75'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-76' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-76' visibility='default' id='type-id-77'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-78' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-79' id='type-id-28'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-80' id='type-id-38'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-79' id='type-id-27'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-25' id='type-id-24'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-52' id='type-id-26'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-79' id='type-id-29'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-30' id='type-id-34'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-44' id='type-id-81'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-33' id='type-id-82'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-7' id='type-id-83'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-84' id='type-id-85'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-42' id='type-id-15'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-45' id='type-id-48'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-47' id='type-id-18'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-86' id='type-id-50'/>
+    <typedef-decl name='size_t' type-id='type-id-7' id='type-id-40'/>
+    <typedef-decl name='uint16_t' type-id='type-id-81' id='type-id-80'/>
+    <typedef-decl name='uint32_t' type-id='type-id-82' id='type-id-52'/>
+    <typedef-decl name='uint64_t' type-id='type-id-83' id='type-id-79'/>
+    <typedef-decl name='uint8_t' type-id='type-id-85' id='type-id-78'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-87' id='type-id-88'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-21' id='type-id-20'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-70' id='type-id-89'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-90' id='type-id-91'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-92' id='type-id-93'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-94' id='type-id-68'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-75' id='type-id-95'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-23' id='type-id-96'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-14' id='type-id-90'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-77' id='type-id-76'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-79' id='type-id-43'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-50' visibility='default' id='type-id-86'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-32' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-1' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-22'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-84'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-33'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-39'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-44'/>
+    <array-type-def dimensions='1' type-id='type-id-44' size-in-bits='4096' id='type-id-55'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-7' id='type-id-97'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-43' size-in-bits='262144' id='type-id-71'>
+      <subrange length='4096' lower-bound='0' upper-bound='4095' type-id='type-id-7' id='type-id-98'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-43' size-in-bits='4352' id='type-id-46'>
+      <subrange length='68' lower-bound='0' upper-bound='67' type-id='type-id-7' id='type-id-13'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-31'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-73'/>
+    <qualified-type-def type-id='type-id-24' const='yes' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-37'/>
+    <qualified-type-def type-id='type-id-9' const='yes' id='type-id-100'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-36'/>
+    <pointer-type-def type-id='type-id-35' size-in-bits='64' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-18' size-in-bits='64' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-92'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-62'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-61'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-64'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-57'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-65'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-63'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-59'/>
+    <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-94'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-66'/>
+    <pointer-type-def type-id='type-id-44' size-in-bits='64' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-67' size-in-bits='64' id='type-id-87'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-72' size-in-bits='64' id='type-id-69'/>
+    <pointer-type-def type-id='type-id-91' size-in-bits='64' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-115'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-116'/>
+    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-58'/>
+    <class-decl name='table_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-118'/>
+    <pointer-type-def type-id='type-id-118' size-in-bits='64' id='type-id-74'/>
+    <function-decl name='_UPT_access_fpreg' mangled-name='_UPT_access_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_access_fpreg'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-96' name='reg'/>
+      <parameter type-id='type-id-114' name='val'/>
+      <parameter type-id='type-id-23' name='write'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-119'/>
+    <pointer-type-def type-id='type-id-119' id='type-id-41'/>
+    <function-type size-in-bits='64' id='type-id-102'>
+      <parameter type-id='type-id-101'/>
+      <parameter type-id='type-id-40'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-111'>
+      <parameter type-id='type-id-93'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-103'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-96'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-104'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-96'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-105'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-43'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-40'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-106'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-43'/>
+      <parameter type-id='type-id-115'/>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-107'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-43'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-108'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-43'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-109'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-113'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-110'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-112'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-43'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-117'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-115'/>
+      <parameter type-id='type-id-41'/>
+      <return type-id='type-id-119'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_access_mem.c' language='LANG_C99'>
+    <function-decl name='_UPT_access_mem' mangled-name='_UPT_access_mem' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_access_mem'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-43' name='addr'/>
+      <parameter type-id='type-id-116' name='val'/>
+      <parameter type-id='type-id-23' name='write'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_access_reg.c' language='LANG_C99'>
+    <function-decl name='_UPT_access_reg' mangled-name='_UPT_access_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_access_reg'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-96' name='reg'/>
+      <parameter type-id='type-id-116' name='val'/>
+      <parameter type-id='type-id-23' name='write'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-56' id='type-id-120'/>
+    <var-decl name='_UPT_accessors' type-id='type-id-120' mangled-name='_UPT_accessors' visibility='default' elf-symbol-id='_UPT_accessors'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_create.c' language='LANG_C99'>
+    <typedef-decl name='__pid_t' type-id='type-id-23' id='type-id-121'/>
+    <typedef-decl name='pid_t' type-id='type-id-121' id='type-id-122'/>
+    <function-decl name='_UPT_create' mangled-name='_UPT_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_create'>
+      <parameter type-id='type-id-122' name='pid'/>
+      <return type-id='type-id-41'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_destroy.c' language='LANG_C99'>
+    <function-decl name='_UPT_destroy' mangled-name='_UPT_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_destroy'>
+      <parameter type-id='type-id-41' name='ptr'/>
+      <return type-id='type-id-119'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_find_proc_info.c' language='LANG_C99'>
+    <function-decl name='_UPT_find_proc_info' mangled-name='_UPT_find_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_find_proc_info'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-43' name='ip'/>
+      <parameter type-id='type-id-115' name='pi'/>
+      <parameter type-id='type-id-23' name='need_unwind_info'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_get_dyn_info_list_addr.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_dyn_info_list_addr' mangled-name='_UPT_get_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_get_dyn_info_list_addr'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-116' name='dil_addr'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_get_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_elf_filename' mangled-name='_UPT_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_get_elf_filename'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-43' name='ip'/>
+      <parameter type-id='type-id-73' name='buf'/>
+      <parameter type-id='type-id-40' name='buf_len'/>
+      <parameter type-id='type-id-116' name='offp'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_get_proc_name.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_proc_name' mangled-name='_UPT_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_get_proc_name'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-43' name='ip'/>
+      <parameter type-id='type-id-73' name='buf'/>
+      <parameter type-id='type-id-40' name='buf_len'/>
+      <parameter type-id='type-id-116' name='offp'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_put_unwind_info.c' language='LANG_C99'>
+    <function-decl name='_UPT_put_unwind_info' mangled-name='_UPT_put_unwind_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_put_unwind_info'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-115' name='pi'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-119'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_reg_offset.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-123' size-in-bits='2080' id='type-id-124'>
+      <subrange length='65' lower-bound='0' upper-bound='64' type-id='type-id-7' id='type-id-125'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-23' const='yes' id='type-id-123'/>
+    <var-decl name='_UPT_reg_offset' type-id='type-id-124' mangled-name='_UPT_reg_offset' visibility='default' elf-symbol-id='_UPT_reg_offset'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_resume.c' language='LANG_C99'>
+    <function-decl name='_UPT_resume' mangled-name='_UPT_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_resume'>
+      <parameter type-id='type-id-88' name='as'/>
+      <parameter type-id='type-id-113' name='c'/>
+      <parameter type-id='type-id-41' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/riscv/linux-gnu/libunwind-riscv.abi
+++ b/src/abi/riscv/linux-gnu/libunwind-riscv.abi
@@ -1,0 +1,1167 @@
+<abi-corpus version='2.2' architecture='elf-unknown-arch-value-243' soname='libunwind-riscv.so.8'>
+  <elf-needed>
+    <dependency name='libunwind.so.8'/>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-riscv64-lp64d.so.1'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_Uriscv_apply_reg_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_create_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_destroy_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_dwarf_find_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_dwarf_search_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_flush_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_accessors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_elf_filename_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_elf_image' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_exe_image_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_proc_info_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_proc_info_in_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_proc_name_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_save_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_init_local' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_init_local2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_init_remote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_is_signal_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_reg_states_iterate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_set_cache_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_set_caching_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_set_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_set_iterate_phdr_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_set_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_Uriscv_local_addr_space' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/dwarf/Gfind_proc_info-lsb.c' language='LANG_C99'>
+    <type-decl name='short int' size-in-bits='16' id='type-id-1'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-2'/>
+    <class-decl name='table_entry' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip_offset' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fde_offset' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-5'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-9'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-12'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-14' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-15'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-17' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-18'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-19'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-20' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int16_t' type-id='type-id-1' id='type-id-21'/>
+    <typedef-decl name='__int32_t' type-id='type-id-22' id='type-id-23'/>
+    <typedef-decl name='__int8_t' type-id='type-id-2' id='type-id-24'/>
+    <typedef-decl name='int16_t' type-id='type-id-21' id='type-id-11'/>
+    <typedef-decl name='int32_t' type-id='type-id-23' id='type-id-4'/>
+    <typedef-decl name='int8_t' type-id='type-id-24' id='type-id-10'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-5' id='type-id-25'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-9' id='type-id-26'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-12' id='type-id-27'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-15' id='type-id-28'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-18' id='type-id-29'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-19' id='type-id-30'/>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-8'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-29' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-26' size-in-bits='128' id='type-id-17'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-31' id='type-id-32'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-33'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-16'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-14'/>
+    <function-decl name='_Uriscv_dwarf_search_unwind_table' mangled-name='_Uriscv_dwarf_search_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_dwarf_search_unwind_table'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-7' name='ip'/>
+      <parameter type-id='type-id-33' name='di'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <parameter type-id='type-id-22' name='need_unwind_info'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-37'>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-40'>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Gfind_unwind_table.c' language='LANG_C99'>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-25' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-25' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-42' size-in-bits='64' id='type-id-44'/>
+    <function-decl name='_Uriscv_dwarf_find_unwind_table' mangled-name='_Uriscv_dwarf_find_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_dwarf_find_unwind_table'>
+      <parameter type-id='type-id-44' name='edi'/>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-45' name='path'/>
+      <parameter type-id='type-id-7' name='segbase'/>
+      <parameter type-id='type-id-7' name='mapoff'/>
+      <parameter type-id='type-id-7' name='ip'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Gget_proc_info_in_range.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_get_proc_info_in_range' mangled-name='_Uriscv_get_proc_info_in_range' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_proc_info_in_range'>
+      <parameter type-id='type-id-7' name='start_ip'/>
+      <parameter type-id='type-id-7' name='end_ip'/>
+      <parameter type-id='type-id-7' name='eh_frame_table'/>
+      <parameter type-id='type-id-7' name='eh_frame_table_len'/>
+      <parameter type-id='type-id-7' name='exidx_frame_table'/>
+      <parameter type-id='type-id-7' name='exidx_frame_table_len'/>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-7' name='ip'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <parameter type-id='type-id-22' name='need_unwind_info'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/global.c' language='LANG_C99'>
+    <class-decl name='mempool' size-in-bits='640' is-struct='yes' visibility='default' id='type-id-46'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='obj_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='chunk_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='reserve' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='num_free' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='free_list' type-id='type-id-48' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='object' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-49'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-48' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-49' size-in-bits='64' id='type-id-48'/>
+    <var-decl name='dwarf_reg_state_pool' type-id='type-id-46' visibility='default'/>
+    <var-decl name='dwarf_cie_info_pool' type-id='type-id-46' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gdestroy_addr_space.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_destroy_addr_space' mangled-name='_Uriscv_destroy_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_destroy_addr_space'>
+      <parameter type-id='type-id-34' name='as'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-51' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-52' size-in-bits='64' id='type-id-53'/>
+    <function-decl name='_Uriscv_get_accessors' mangled-name='_Uriscv_get_accessors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_accessors'>
+      <parameter type-id='type-id-34' name='as'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_get_elf_filename_by_ip' mangled-name='_Uriscv_get_elf_filename_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_elf_filename_by_ip'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-7' name='ip'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-20' name='offp'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Uriscv_get_elf_filename' mangled-name='_Uriscv_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_elf_filename'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-20' name='offp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_get_fpreg' mangled-name='_Uriscv_get_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_fpreg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-56' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_proc_info_by_ip.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_get_proc_info_by_ip' mangled-name='_Uriscv_get_proc_info_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_proc_info_by_ip'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-7' name='ip'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <parameter type-id='type-id-36' name='as_arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_proc_name.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_get_proc_name_by_ip' mangled-name='_Uriscv_get_proc_name_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_proc_name_by_ip'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-7' name='ip'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-20' name='offp'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Uriscv_get_proc_name' mangled-name='_Uriscv_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_proc_name'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-20' name='offp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_reg.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_get_reg' mangled-name='_Uriscv_get_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_reg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-20' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_cache_size.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_set_cache_size' mangled-name='_Uriscv_set_cache_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_set_cache_size'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-39' name='size'/>
+      <parameter type-id='type-id-22' name='flag'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_caching_policy.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_set_caching_policy' mangled-name='_Uriscv_set_caching_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_set_caching_policy'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-57' name='policy'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_set_fpreg' mangled-name='_Uriscv_set_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_set_fpreg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-58' name='val'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_iterate_phdr_function.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_set_iterate_phdr_function' mangled-name='_Uriscv_set_iterate_phdr_function' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_set_iterate_phdr_function'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-59' name='function'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_reg.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_set_reg' mangled-name='_Uriscv_set_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_set_reg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-7' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/flush_cache.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='320' id='type-id-61'>
+      <subrange length='40' lower-bound='0' upper-bound='39' type-id='type-id-31' id='type-id-62'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='544' id='type-id-63'>
+      <subrange length='68' lower-bound='0' upper-bound='67' type-id='type-id-31' id='type-id-64'/>
+    </array-type-def>
+    <type-decl name='double' size-in-bits='64' id='type-id-65'/>
+    <array-type-def dimensions='1' type-id='type-id-66' size-in-bits='16384' id='type-id-67'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-31' id='type-id-68'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-69' size-in-bits='638976' id='type-id-70'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-31' id='type-id-68'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-57' id='type-id-71'>
+      <underlying-type type-id='type-id-72'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-73' visibility='default' id='type-id-74'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-78' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-79'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-80' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-80' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-81'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-82' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-82' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-83' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-84'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-85' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-86' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-36' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-88'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-89' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='4928' is-struct='yes' visibility='default' id='type-id-90'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='val' type-id='type-id-91' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='4992' is-struct='yes' visibility='default' id='type-id-92'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-93' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='660096' is-struct='yes' visibility='default' id='type-id-94'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='rr_head' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='log_size' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='prev_log_size' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='hash' type-id='type-id-95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='generation' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='buckets' type-id='type-id-96' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='links' type-id='type-id-97' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='default_hash' type-id='type-id-98' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4736'>
+        <var-decl name='default_buckets' type-id='type-id-70' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='643712'>
+        <var-decl name='default_links' type-id='type-id-67' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-51'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-99' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-100' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-101' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-102' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-103' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-105' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-106' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-106' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-107' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-108' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='661184' is-struct='yes' visibility='default' id='type-id-109'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='big_endian' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='736'>
+        <var-decl name='addr_size' type-id='type-id-82' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='caching_policy' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='cache_generation' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_generation' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='global_cache' type-id='type-id-94' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='661120'>
+        <var-decl name='debug_frames' type-id='type-id-110' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='262144' is-struct='yes' visibility='default' id='type-id-111'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-112' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-113'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-114' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-110' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-115'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-116' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-116' visibility='default' id='type-id-117'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-118' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-119' id='type-id-77'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-120' id='type-id-86'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-119' id='type-id-76'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-74' id='type-id-73'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-13' id='type-id-75'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-119' id='type-id-78'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-79' id='type-id-83'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-89' id='type-id-121'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-82' id='type-id-122'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-123' id='type-id-124'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-88' id='type-id-66'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-90' id='type-id-93'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-92' id='type-id-69'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-125' id='type-id-47'/>
+    <typedef-decl name='uint16_t' type-id='type-id-121' id='type-id-120'/>
+    <typedef-decl name='uint32_t' type-id='type-id-122' id='type-id-13'/>
+    <typedef-decl name='uint8_t' type-id='type-id-124' id='type-id-118'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-126' id='type-id-34'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-71' id='type-id-57'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-111' id='type-id-127'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-128' id='type-id-58'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-129' id='type-id-41'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-130' id='type-id-59'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-115' id='type-id-131'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-22' id='type-id-132'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-65' id='type-id-128'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-117' id='type-id-116'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-47' visibility='default' id='type-id-125'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-81' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-133' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-72'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-123'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-82'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-87'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-89'/>
+    <array-type-def dimensions='1' type-id='type-id-89' size-in-bits='4096' id='type-id-98'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-31' id='type-id-134'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='262144' id='type-id-112'>
+      <subrange length='4096' lower-bound='0' upper-bound='4095' type-id='type-id-31' id='type-id-135'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='4352' id='type-id-91'>
+      <subrange length='68' lower-bound='0' upper-bound='67' type-id='type-id-31' id='type-id-64'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-80'/>
+    <qualified-type-def type-id='type-id-73' const='yes' id='type-id-136'/>
+    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-85'/>
+    <qualified-type-def type-id='type-id-60' const='yes' id='type-id-137'/>
+    <pointer-type-def type-id='type-id-137' size-in-bits='64' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-84' size-in-bits='64' id='type-id-38'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-96'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-129'/>
+    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-104'/>
+    <pointer-type-def type-id='type-id-139' size-in-bits='64' id='type-id-103'/>
+    <pointer-type-def type-id='type-id-140' size-in-bits='64' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-141' size-in-bits='64' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-143' size-in-bits='64' id='type-id-107'/>
+    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-40' size-in-bits='64' id='type-id-130'/>
+    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-146' size-in-bits='64' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-95'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-126'/>
+    <pointer-type-def type-id='type-id-127' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-58' size-in-bits='64' id='type-id-56'/>
+    <pointer-type-def type-id='type-id-131' size-in-bits='64' id='type-id-35'/>
+    <pointer-type-def type-id='type-id-7' size-in-bits='64' id='type-id-20'/>
+    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-100'/>
+    <function-decl name='_Uriscv_flush_cache' mangled-name='_Uriscv_flush_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_flush_cache'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-7' name='lo'/>
+      <parameter type-id='type-id-7' name='hi'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-138'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-132'/>
+      <parameter type-id='type-id-56'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-139'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-132'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-140'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-54'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-141'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-142'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-143'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-144'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-55'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-145'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-146'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-147'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-50'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-133'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-148' visibility='default' id='type-id-149'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-150' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-149' id='type-id-148'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-151' id='type-id-152'/>
+    <typedef-decl name='sigset_t' type-id='type-id-148' id='type-id-151'/>
+    <array-type-def dimensions='1' type-id='type-id-31' size-in-bits='1024' id='type-id-150'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-31' id='type-id-153'/>
+    </array-type-def>
+    <var-decl name='_UIriscv_full_mask' type-id='type-id-152' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-133' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/strerror.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_strerror' mangled-name='_Uriscv_strerror' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_strerror'>
+      <parameter type-id='type-id-22' name='err_code'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/os-linux.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-60'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pid_t' type-id='type-id-22' id='type-id-154'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-31' id='type-id-155'/>
+    <typedef-decl name='pid_t' type-id='type-id-154' id='type-id-156'/>
+    <typedef-decl name='size_t' type-id='type-id-31' id='type-id-39'/>
+    <typedef-decl name='uint64_t' type-id='type-id-155' id='type-id-119'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-119' id='type-id-7'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-31'/>
+    <pointer-type-def type-id='type-id-60' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-157'/>
+    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-158'/>
+    <function-decl name='_Uriscv_get_elf_image' mangled-name='_Uriscv_get_elf_image' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_elf_image'>
+      <parameter type-id='type-id-157' name='ei'/>
+      <parameter type-id='type-id-156' name='pid'/>
+      <parameter type-id='type-id-7' name='ip'/>
+      <parameter type-id='type-id-158' name='segbase'/>
+      <parameter type-id='type-id-158' name='mapoff'/>
+      <parameter type-id='type-id-54' name='path'/>
+      <parameter type-id='type-id-39' name='pathlen'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Uriscv_get_exe_image_path' mangled-name='_Uriscv_get_exe_image_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_exe_image_path'>
+      <parameter type-id='type-id-54' name='path'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-50' id='type-id-36'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Gapply_reg_state.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_apply_reg_state' mangled-name='_Uriscv_apply_reg_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_apply_reg_state'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-36' name='reg_states_data'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Gcreate_addr_space.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_create_addr_space' mangled-name='_Uriscv_create_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_create_addr_space'>
+      <parameter type-id='type-id-53' name='a'/>
+      <parameter type-id='type-id-22' name='byte_order'/>
+      <return type-id='type-id-34'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Gget_proc_info.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_get_proc_info' mangled-name='_Uriscv_get_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_proc_info'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Gget_save_loc.c' language='LANG_C99'>
+    <enum-decl name='unw_save_loc_type' id='type-id-159'>
+      <underlying-type type-id='type-id-72'/>
+      <enumerator name='UNW_SLT_NONE' value='0'/>
+      <enumerator name='UNW_SLT_MEMORY' value='1'/>
+      <enumerator name='UNW_SLT_REG' value='2'/>
+    </enum-decl>
+    <class-decl name='unw_save_loc' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-160'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-161' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='u' type-id='type-id-162' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='extra' type-id='type-id-163' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_save_loc' size-in-bits='8' is-struct='yes' visibility='default' id='type-id-164'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-118' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_save_loc_t' type-id='type-id-160' id='type-id-165'/>
+    <typedef-decl name='unw_save_loc_type_t' type-id='type-id-159' id='type-id-161'/>
+    <typedef-decl name='unw_tdep_save_loc_t' type-id='type-id-164' id='type-id-163'/>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-162'>
+      <data-member access='public'>
+        <var-decl name='addr' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='regnum' type-id='type-id-132' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-165' size-in-bits='64' id='type-id-166'/>
+    <function-decl name='_Uriscv_get_save_loc' mangled-name='_Uriscv_get_save_loc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_save_loc'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='reg'/>
+      <parameter type-id='type-id-166' name='sloc'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Gglobal.c' language='LANG_C99'>
+    <type-decl name='atomic_bool' size-in-bits='8' id='type-id-167'/>
+    <array-type-def dimensions='1' type-id='type-id-168' size-in-bits='528' id='type-id-169'>
+      <subrange length='66' lower-bound='0' upper-bound='65' type-id='type-id-31' id='type-id-170'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-118' const='yes' id='type-id-168'/>
+    <var-decl name='_Uriscv_dwarf_to_unw_regnum_map' type-id='type-id-169' visibility='default'/>
+    <var-decl name='_Uriscv_init_done' type-id='type-id-167' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Ginit.c' language='LANG_C99'>
+    <var-decl name='_Uriscv_local_addr_space' type-id='type-id-34' mangled-name='_Uriscv_local_addr_space' visibility='default' elf-symbol-id='_Uriscv_local_addr_space'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Ginit_local.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='unknown' id='type-id-171'>
+      <subrange length='unknown' lower-bound='0' upper-bound='-1' type-id='type-id-31' id='type-id-172'/>
+    </array-type-def>
+    <class-decl name='__riscv_mc_d_ext_state' size-in-bits='2112' is-struct='yes' visibility='default' id='type-id-173'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__f' type-id='type-id-174' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='__fcsr' type-id='type-id-82' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__riscv_mc_f_ext_state' size-in-bits='1056' is-struct='yes' visibility='default' id='type-id-175'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__f' type-id='type-id-176' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='__fcsr' type-id='type-id-82' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__riscv_mc_q_ext_state' size-in-bits='4224' is-struct='yes' visibility='default' id='type-id-177'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__f' type-id='type-id-178' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4096'>
+        <var-decl name='__fcsr' type-id='type-id-82' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4128'>
+        <var-decl name='__glibc_reserved' type-id='type-id-179' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='mcontext_t' size-in-bits='6272' is-struct='yes' visibility='default' id='type-id-180'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__gregs' type-id='type-id-181' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='__fpregs' type-id='type-id-182' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='stack_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-183' visibility='default' id='type-id-184'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ss_sp' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ss_flags' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ss_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucontext_t' size-in-bits='7680' is-struct='yes' visibility='default' id='type-id-185'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__uc_flags' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uc_link' type-id='type-id-186' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uc_stack' type-id='type-id-183' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='uc_sigmask' type-id='type-id-151' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='__glibc_reserved' type-id='type-id-171' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='uc_mcontext' type-id='type-id-187' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__riscv_mc_gp_state' type-id='type-id-188' id='type-id-181'/>
+    <typedef-decl name='mcontext_t' type-id='type-id-180' id='type-id-187'/>
+    <typedef-decl name='stack_t' type-id='type-id-184' id='type-id-183'/>
+    <typedef-decl name='ucontext_t' type-id='type-id-185' id='type-id-189'/>
+    <typedef-decl name='unw_context_t' type-id='type-id-190' id='type-id-191'/>
+    <typedef-decl name='unw_tdep_context_t' type-id='type-id-189' id='type-id-190'/>
+    <union-decl name='__riscv_mc_fp_state' size-in-bits='4224' visibility='default' id='type-id-182'>
+      <data-member access='public'>
+        <var-decl name='__f' type-id='type-id-175' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__d' type-id='type-id-173' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__q' type-id='type-id-177' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-82' size-in-bits='1024' id='type-id-176'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-31' id='type-id-192'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-82' size-in-bits='96' id='type-id-179'>
+      <subrange length='3' lower-bound='0' upper-bound='2' type-id='type-id-31' id='type-id-193'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-31' size-in-bits='2048' id='type-id-188'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-31' id='type-id-192'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-87' size-in-bits='2048' id='type-id-174'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-31' id='type-id-192'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-87' size-in-bits='4096' id='type-id-178'>
+      <subrange length='64' lower-bound='0' upper-bound='63' type-id='type-id-31' id='type-id-194'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-185' size-in-bits='64' id='type-id-186'/>
+    <pointer-type-def type-id='type-id-191' size-in-bits='64' id='type-id-195'/>
+    <function-decl name='_Uriscv_init_local' mangled-name='_Uriscv_init_local' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_init_local'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-195' name='uc'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Uriscv_init_local2' mangled-name='_Uriscv_init_local2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_init_local2'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-195' name='uc'/>
+      <parameter type-id='type-id-22' name='flag'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Ginit_remote.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_init_remote' mangled-name='_Uriscv_init_remote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_init_remote'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-36' name='as_arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Gis_signal_frame.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_is_signal_frame' mangled-name='_Uriscv_is_signal_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_is_signal_frame'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Greg_states_iterate.c' language='LANG_C99'>
+    <typedef-decl name='unw_reg_states_callback' type-id='type-id-196' id='type-id-197'/>
+    <pointer-type-def type-id='type-id-198' size-in-bits='64' id='type-id-196'/>
+    <function-decl name='_Uriscv_reg_states_iterate' mangled-name='_Uriscv_reg_states_iterate' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_reg_states_iterate'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-197' name='cb'/>
+      <parameter type-id='type-id-36' name='token'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-198'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-7'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Gresume.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_resume' mangled-name='_Uriscv_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_resume'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Gstep.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_step' mangled-name='_Uriscv_step' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_step'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/is_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_is_fpreg' mangled-name='_Uriscv_is_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_is_fpreg'>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/regname.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_regname' mangled-name='_Uriscv_regname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_regname'>
+      <parameter type-id='type-id-132' name='reg'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/riscv/linux-gnu/libunwind-setjmp.abi
+++ b/src/abi/riscv/linux-gnu/libunwind-setjmp.abi
@@ -1,0 +1,24 @@
+<abi-corpus version='2.2' architecture='elf-unknown-arch-value-243' soname='libunwind-setjmp.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-riscv.so.8'/>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-riscv64-lp64d.so.1'/>
+  </elf-needed>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-2' visibility='default' id='type-id-3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-3' id='type-id-2'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-5' id='type-id-6'/>
+    <typedef-decl name='sigset_t' type-id='type-id-2' id='type-id-5'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-7'/>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='1024' id='type-id-4'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-7' id='type-id-8'/>
+    </array-type-def>
+    <var-decl name='_UIriscv_full_mask' type-id='type-id-6' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-1' visibility='default'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/riscv/linux-gnu/libunwind.abi
+++ b/src/abi/riscv/linux-gnu/libunwind.abi
@@ -1,0 +1,1452 @@
+<abi-corpus version='2.2' architecture='elf-unknown-arch-value-243' soname='libunwind.so.8'>
+  <elf-needed>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-riscv64-lp64d.so.1'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_ReadSLEB' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ReadULEB' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_apply_reg_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_create_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_destroy_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_dwarf_find_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_dwarf_search_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_get_elf_filename_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_get_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_get_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_get_proc_info_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_get_proc_info_in_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_get_proc_name_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_get_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_get_save_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_init_local' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_init_local2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_init_remote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_is_signal_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_reg_states_iterate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_set_cache_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_set_caching_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_set_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_set_iterate_phdr_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_set_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULriscv_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_cancel' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_register' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Unwind_Backtrace' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_Backtrace' is-defined='yes'/>
+    <elf-symbol name='_Unwind_DeleteException' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_DeleteException' is-defined='yes'/>
+    <elf-symbol name='_Unwind_FindEnclosingFunction' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_FindEnclosingFunction' is-defined='yes'/>
+    <elf-symbol name='_Unwind_ForcedUnwind' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_ForcedUnwind' is-defined='yes'/>
+    <elf-symbol name='_Unwind_GetBSP' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_GetBSP' is-defined='yes'/>
+    <elf-symbol name='_Unwind_GetCFA' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_GetCFA' is-defined='yes'/>
+    <elf-symbol name='_Unwind_GetDataRelBase' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_GetDataRelBase' is-defined='yes'/>
+    <elf-symbol name='_Unwind_GetGR' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_GetGR' is-defined='yes'/>
+    <elf-symbol name='_Unwind_GetIP' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_GetIP' is-defined='yes'/>
+    <elf-symbol name='_Unwind_GetIPInfo' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_GetIPInfo' is-defined='yes'/>
+    <elf-symbol name='_Unwind_GetLanguageSpecificData' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_GetLanguageSpecificData' is-defined='yes'/>
+    <elf-symbol name='_Unwind_GetRegionStart' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_GetRegionStart' is-defined='yes'/>
+    <elf-symbol name='_Unwind_GetTextRelBase' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_GetTextRelBase' is-defined='yes'/>
+    <elf-symbol name='_Unwind_RaiseException' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_RaiseException' is-defined='yes'/>
+    <elf-symbol name='_Unwind_Resume' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_Resume' is-defined='yes'/>
+    <elf-symbol name='_Unwind_Resume_or_Rethrow' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_Resume_or_Rethrow' is-defined='yes'/>
+    <elf-symbol name='_Unwind_SetGR' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_SetGR' is-defined='yes'/>
+    <elf-symbol name='_Unwind_SetIP' type='func-type' binding='global-binding' visibility='default-visibility' alias='__libunwind_Unwind_SetIP' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_flush_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_accessors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_elf_image' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_get_exe_image_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_getcontext' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_setcontext' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Uriscv_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_Backtrace' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_DeleteException' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_FindEnclosingFunction' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_ForcedUnwind' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_GetBSP' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_GetCFA' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_GetDataRelBase' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_GetGR' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_GetIP' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_GetIPInfo' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_GetLanguageSpecificData' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_GetRegionStart' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_GetTextRelBase' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_RaiseException' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_Resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_Resume_or_Rethrow' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_SetGR' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='__libunwind_Unwind_SetIP' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='backtrace' type='func-type' binding='weak-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_backtrace' type='func-type' binding='global-binding' visibility='default-visibility' alias='backtrace' is-defined='yes'/>
+    <elf-symbol name='unw_backtrace2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_ULriscv_local_addr_space' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/dwarf/Lfind_proc_info-lsb.c' language='LANG_C99'>
+    <class-decl name='table_entry' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-1'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip_offset' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fde_offset' type-id='type-id-2' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <function-decl name='_ULriscv_dwarf_search_unwind_table' mangled-name='_ULriscv_dwarf_search_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_dwarf_search_unwind_table'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-5' name='di'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-7' name='need_unwind_info'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-9'>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-12'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Lfind_unwind_table.c' language='LANG_C99'>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-14'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-17'/>
+    <function-decl name='_ULriscv_dwarf_find_unwind_table' mangled-name='_ULriscv_dwarf_find_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_dwarf_find_unwind_table'>
+      <parameter type-id='type-id-17' name='edi'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-18' name='path'/>
+      <parameter type-id='type-id-4' name='segbase'/>
+      <parameter type-id='type-id-4' name='mapoff'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Lget_proc_info_in_range.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_get_proc_info_in_range' mangled-name='_ULriscv_get_proc_info_in_range' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_get_proc_info_in_range'>
+      <parameter type-id='type-id-4' name='start_ip'/>
+      <parameter type-id='type-id-4' name='end_ip'/>
+      <parameter type-id='type-id-4' name='eh_frame_table'/>
+      <parameter type-id='type-id-4' name='eh_frame_table_len'/>
+      <parameter type-id='type-id-4' name='exidx_frame_table'/>
+      <parameter type-id='type-id-4' name='exidx_frame_table_len'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-7' name='need_unwind_info'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/global.c' language='LANG_C99'>
+    <class-decl name='mempool' size-in-bits='640' is-struct='yes' visibility='default' id='type-id-19'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='obj_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='chunk_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='reserve' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='num_free' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='free_list' type-id='type-id-21' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='object' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-22'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-21' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-21'/>
+    <var-decl name='dwarf_reg_state_pool' type-id='type-id-19' visibility='default'/>
+    <var-decl name='dwarf_cie_info_pool' type-id='type-id-19' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Ldestroy_addr_space.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_destroy_addr_space' mangled-name='_ULriscv_destroy_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_destroy_addr_space'>
+      <parameter type-id='type-id-3' name='as'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-24' id='type-id-25'/>
+    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-26'/>
+    <function-decl name='_Uriscv_get_accessors' mangled-name='_Uriscv_get_accessors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_accessors'>
+      <parameter type-id='type-id-3' name='as'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_get_elf_filename_by_ip' mangled-name='_ULriscv_get_elf_filename_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_get_elf_filename_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULriscv_get_elf_filename' mangled-name='_ULriscv_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_get_elf_filename'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_fpreg.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_get_fpreg' mangled-name='_ULriscv_get_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_get_fpreg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-30' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_proc_info_by_ip.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_get_proc_info_by_ip' mangled-name='_ULriscv_get_proc_info_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_get_proc_info_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-8' name='as_arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_proc_name.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_get_proc_name_by_ip' mangled-name='_ULriscv_get_proc_name_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_get_proc_name_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULriscv_get_proc_name' mangled-name='_ULriscv_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_get_proc_name'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_reg.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_get_reg' mangled-name='_ULriscv_get_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_get_reg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-28' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_cache_size.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_set_cache_size' mangled-name='_ULriscv_set_cache_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_set_cache_size'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-11' name='size'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_caching_policy.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_set_caching_policy' mangled-name='_ULriscv_set_caching_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_set_caching_policy'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-31' name='policy'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_fpreg.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_set_fpreg' mangled-name='_ULriscv_set_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_set_fpreg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-32' name='val'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_iterate_phdr_function.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_set_iterate_phdr_function' mangled-name='_ULriscv_set_iterate_phdr_function' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_set_iterate_phdr_function'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-33' name='function'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_reg.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_set_reg' mangled-name='_ULriscv_set_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_set_reg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-4' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/_ReadSLEB.c' language='LANG_C99'>
+    <function-decl name='_ReadSLEB' mangled-name='_ReadSLEB' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ReadSLEB'>
+      <parameter type-id='type-id-34' name='dpp'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/_ReadULEB.c' language='LANG_C99'>
+    <pointer-type-def type-id='type-id-35' size-in-bits='64' id='type-id-36'/>
+    <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-34'/>
+    <function-decl name='_ReadULEB' mangled-name='_ReadULEB' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ReadULEB'>
+      <parameter type-id='type-id-34' name='dpp'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/backtrace.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-37' size-in-bits='unknown' id='type-id-38'>
+      <subrange length='unknown' lower-bound='0' upper-bound='-1' type-id='type-id-39' id='type-id-40'/>
+    </array-type-def>
+    <class-decl name='__riscv_mc_d_ext_state' size-in-bits='2112' is-struct='yes' visibility='default' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__f' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='__fcsr' type-id='type-id-43' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__riscv_mc_f_ext_state' size-in-bits='1056' is-struct='yes' visibility='default' id='type-id-44'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__f' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='__fcsr' type-id='type-id-43' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__riscv_mc_q_ext_state' size-in-bits='4224' is-struct='yes' visibility='default' id='type-id-46'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__f' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4096'>
+        <var-decl name='__fcsr' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4128'>
+        <var-decl name='__glibc_reserved' type-id='type-id-48' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='mcontext_t' size-in-bits='6272' is-struct='yes' visibility='default' id='type-id-49'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__gregs' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='__fpregs' type-id='type-id-51' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='stack_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-52' visibility='default' id='type-id-53'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ss_sp' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ss_flags' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ss_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucontext_t' size-in-bits='7680' is-struct='yes' visibility='default' id='type-id-54'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__uc_flags' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uc_link' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uc_stack' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='uc_sigmask' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='__glibc_reserved' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='uc_mcontext' type-id='type-id-57' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__riscv_mc_gp_state' type-id='type-id-58' id='type-id-50'/>
+    <typedef-decl name='mcontext_t' type-id='type-id-49' id='type-id-57'/>
+    <typedef-decl name='stack_t' type-id='type-id-53' id='type-id-52'/>
+    <typedef-decl name='ucontext_t' type-id='type-id-54' id='type-id-59'/>
+    <typedef-decl name='unw_context_t' type-id='type-id-60' id='type-id-61'/>
+    <typedef-decl name='unw_tdep_context_t' type-id='type-id-59' id='type-id-60'/>
+    <union-decl name='__riscv_mc_fp_state' size-in-bits='4224' visibility='default' id='type-id-51'>
+      <data-member access='public'>
+        <var-decl name='__f' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__d' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__q' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-43' size-in-bits='1024' id='type-id-45'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-39' id='type-id-62'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-43' size-in-bits='96' id='type-id-48'>
+      <subrange length='3' lower-bound='0' upper-bound='2' type-id='type-id-39' id='type-id-63'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-39' size-in-bits='2048' id='type-id-58'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-39' id='type-id-62'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-64' size-in-bits='2048' id='type-id-42'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-39' id='type-id-62'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-64' size-in-bits='4096' id='type-id-47'>
+      <subrange length='64' lower-bound='0' upper-bound='63' type-id='type-id-39' id='type-id-65'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-61' size-in-bits='64' id='type-id-66'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-67'/>
+    <function-decl name='unw_backtrace' mangled-name='unw_backtrace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_backtrace'>
+      <parameter type-id='type-id-67' name='buffer'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='unw_backtrace2' mangled-name='unw_backtrace2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_backtrace2'>
+      <parameter type-id='type-id-67' name='buffer'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <parameter type-id='type-id-66' name='uc2'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-cancel.c' language='LANG_C99'>
+    <type-decl name='short int' size-in-bits='16' id='type-id-68'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-69'/>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-70'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-71' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-71' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-72' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-73'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-76'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-78' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-79'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-80' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-81' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-82'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-83'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-28' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int16_t' type-id='type-id-68' id='type-id-84'/>
+    <typedef-decl name='__int32_t' type-id='type-id-7' id='type-id-85'/>
+    <typedef-decl name='__int8_t' type-id='type-id-69' id='type-id-86'/>
+    <typedef-decl name='int16_t' type-id='type-id-84' id='type-id-75'/>
+    <typedef-decl name='int32_t' type-id='type-id-85' id='type-id-2'/>
+    <typedef-decl name='int8_t' type-id='type-id-86' id='type-id-74'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-70' id='type-id-16'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-73' id='type-id-87'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-76' id='type-id-88'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-79' id='type-id-89'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-82' id='type-id-90'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-83' id='type-id-91'/>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-72'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-88' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-91' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-90' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-87' size-in-bits='128' id='type-id-81'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-39' id='type-id-92'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-70' size-in-bits='64' id='type-id-71'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-5'/>
+    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-78'/>
+    <function-decl name='_U_dyn_cancel' mangled-name='_U_dyn_cancel' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_cancel'>
+      <parameter type-id='type-id-5' name='di'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-info-list.c' language='LANG_C99'>
+    <class-decl name='unw_dyn_info_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-93'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='version' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='generation' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='first' type-id='type-id-5' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_dyn_info_list_t' type-id='type-id-93' id='type-id-94'/>
+    <var-decl name='_U_dyn_info_list' type-id='type-id-94' visibility='default'/>
+    <function-decl name='_U_dyn_info_list_addr' mangled-name='_U_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_info_list_addr'>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-register.c' language='LANG_C99'>
+    <var-decl name='_U_dyn_info_list_lock' type-id='type-id-20' visibility='default'/>
+    <function-decl name='_U_dyn_register' mangled-name='_U_dyn_register' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_register'>
+      <parameter type-id='type-id-5' name='di'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/flush_cache.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-37' size-in-bits='320' id='type-id-95'>
+      <subrange length='40' lower-bound='0' upper-bound='39' type-id='type-id-39' id='type-id-96'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-37' size-in-bits='544' id='type-id-97'>
+      <subrange length='68' lower-bound='0' upper-bound='67' type-id='type-id-39' id='type-id-98'/>
+    </array-type-def>
+    <type-decl name='double' size-in-bits='64' id='type-id-99'/>
+    <array-type-def dimensions='1' type-id='type-id-100' size-in-bits='16384' id='type-id-101'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-39' id='type-id-102'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-103' size-in-bits='638976' id='type-id-104'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-39' id='type-id-102'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-31' id='type-id-105'>
+      <underlying-type type-id='type-id-106'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-107' visibility='default' id='type-id-108'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-109' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-109' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-110' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-111' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-111' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-112' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-112' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-112' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-113'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-114' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-114' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-115'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-116' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-117'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-111' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-120'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-121' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='4928' is-struct='yes' visibility='default' id='type-id-122'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-97' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='val' type-id='type-id-123' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='4992' is-struct='yes' visibility='default' id='type-id-124'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-125' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='660096' is-struct='yes' visibility='default' id='type-id-126'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='rr_head' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='log_size' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='prev_log_size' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='hash' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='generation' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='buckets' type-id='type-id-128' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='links' type-id='type-id-129' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='default_hash' type-id='type-id-130' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4736'>
+        <var-decl name='default_buckets' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='643712'>
+        <var-decl name='default_links' type-id='type-id-101' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-24'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-132' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-133' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-135' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-136' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-139' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-140' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='661184' is-struct='yes' visibility='default' id='type-id-141'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='big_endian' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='736'>
+        <var-decl name='addr_size' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='caching_policy' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='cache_generation' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_generation' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='global_cache' type-id='type-id-126' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='661120'>
+        <var-decl name='debug_frames' type-id='type-id-142' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='262144' is-struct='yes' visibility='default' id='type-id-143'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-144' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-145'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-146' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-142' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-147'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-148' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-148' visibility='default' id='type-id-149'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-150' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-151' id='type-id-111'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-152' id='type-id-119'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-151' id='type-id-110'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-108' id='type-id-107'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-77' id='type-id-109'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-151' id='type-id-112'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-113' id='type-id-116'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-121' id='type-id-153'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-43' id='type-id-154'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-35' id='type-id-155'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-120' id='type-id-100'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-122' id='type-id-125'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-124' id='type-id-103'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-156' id='type-id-20'/>
+    <typedef-decl name='uint16_t' type-id='type-id-153' id='type-id-152'/>
+    <typedef-decl name='uint32_t' type-id='type-id-154' id='type-id-77'/>
+    <typedef-decl name='uint8_t' type-id='type-id-155' id='type-id-150'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-157' id='type-id-3'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-105' id='type-id-31'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-143' id='type-id-158'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-159' id='type-id-32'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-160' id='type-id-13'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-161' id='type-id-33'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-147' id='type-id-162'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-7' id='type-id-163'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-99' id='type-id-159'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-149' id='type-id-148'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-20' visibility='default' id='type-id-156'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-115' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-95' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-164' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-106'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-35'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-43'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-64'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-121'/>
+    <array-type-def dimensions='1' type-id='type-id-121' size-in-bits='4096' id='type-id-130'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-39' id='type-id-165'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-4' size-in-bits='262144' id='type-id-144'>
+      <subrange length='4096' lower-bound='0' upper-bound='4095' type-id='type-id-39' id='type-id-166'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-4' size-in-bits='4352' id='type-id-123'>
+      <subrange length='68' lower-bound='0' upper-bound='67' type-id='type-id-39' id='type-id-98'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-114'/>
+    <qualified-type-def type-id='type-id-107' const='yes' id='type-id-167'/>
+    <pointer-type-def type-id='type-id-167' size-in-bits='64' id='type-id-118'/>
+    <qualified-type-def type-id='type-id-37' const='yes' id='type-id-168'/>
+    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-18'/>
+    <pointer-type-def type-id='type-id-117' size-in-bits='64' id='type-id-10'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-129'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-128'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-160'/>
+    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-136'/>
+    <pointer-type-def type-id='type-id-170' size-in-bits='64' id='type-id-135'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-138'/>
+    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-131'/>
+    <pointer-type-def type-id='type-id-173' size-in-bits='64' id='type-id-134'/>
+    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-139'/>
+    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-137'/>
+    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-133'/>
+    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-161'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-146'/>
+    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-140'/>
+    <pointer-type-def type-id='type-id-121' size-in-bits='64' id='type-id-127'/>
+    <pointer-type-def type-id='type-id-141' size-in-bits='64' id='type-id-157'/>
+    <pointer-type-def type-id='type-id-158' size-in-bits='64' id='type-id-29'/>
+    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-142'/>
+    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-162' size-in-bits='64' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-28'/>
+    <pointer-type-def type-id='type-id-178' size-in-bits='64' id='type-id-132'/>
+    <function-decl name='_Uriscv_flush_cache' mangled-name='_Uriscv_flush_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_flush_cache'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='lo'/>
+      <parameter type-id='type-id-4' name='hi'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-169'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-30'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-170'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-163'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-171'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-172'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-173'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-174'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-175'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-176'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-177'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-4'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-178'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-164'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-179' visibility='default' id='type-id-180'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-181' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-180' id='type-id-179'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-56' id='type-id-182'/>
+    <typedef-decl name='sigset_t' type-id='type-id-179' id='type-id-56'/>
+    <array-type-def dimensions='1' type-id='type-id-39' size-in-bits='1024' id='type-id-181'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-39' id='type-id-183'/>
+    </array-type-def>
+    <var-decl name='_UIriscv_full_mask' type-id='type-id-182' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-164' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/strerror.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_strerror' mangled-name='_Uriscv_strerror' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_strerror'>
+      <parameter type-id='type-id-7' name='err_code'/>
+      <return type-id='type-id-18'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/os-linux.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-37'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-7'/>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-15'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pid_t' type-id='type-id-7' id='type-id-184'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-39' id='type-id-185'/>
+    <typedef-decl name='pid_t' type-id='type-id-184' id='type-id-186'/>
+    <typedef-decl name='size_t' type-id='type-id-39' id='type-id-11'/>
+    <typedef-decl name='uint64_t' type-id='type-id-185' id='type-id-151'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-151' id='type-id-4'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-39'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-27'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-187'/>
+    <pointer-type-def type-id='type-id-39' size-in-bits='64' id='type-id-188'/>
+    <function-decl name='_Uriscv_get_elf_image' mangled-name='_Uriscv_get_elf_image' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_elf_image'>
+      <parameter type-id='type-id-187' name='ei'/>
+      <parameter type-id='type-id-186' name='pid'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-188' name='segbase'/>
+      <parameter type-id='type-id-188' name='mapoff'/>
+      <parameter type-id='type-id-27' name='path'/>
+      <parameter type-id='type-id-11' name='pathlen'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_Uriscv_get_exe_image_path' mangled-name='_Uriscv_get_exe_image_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_get_exe_image_path'>
+      <parameter type-id='type-id-27' name='path'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-23'/>
+    <pointer-type-def type-id='type-id-23' id='type-id-8'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Lapply_reg_state.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_apply_reg_state' mangled-name='_ULriscv_apply_reg_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_apply_reg_state'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-8' name='reg_states_data'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Lcreate_addr_space.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_create_addr_space' mangled-name='_ULriscv_create_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_create_addr_space'>
+      <parameter type-id='type-id-26' name='a'/>
+      <parameter type-id='type-id-7' name='byte_order'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Lget_proc_info.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_get_proc_info' mangled-name='_ULriscv_get_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_get_proc_info'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Lget_save_loc.c' language='LANG_C99'>
+    <enum-decl name='unw_save_loc_type' id='type-id-189'>
+      <underlying-type type-id='type-id-106'/>
+      <enumerator name='UNW_SLT_NONE' value='0'/>
+      <enumerator name='UNW_SLT_MEMORY' value='1'/>
+      <enumerator name='UNW_SLT_REG' value='2'/>
+    </enum-decl>
+    <class-decl name='unw_save_loc' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-190'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-191' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='u' type-id='type-id-192' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='extra' type-id='type-id-193' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_save_loc' size-in-bits='8' is-struct='yes' visibility='default' id='type-id-194'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-150' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_save_loc_t' type-id='type-id-190' id='type-id-195'/>
+    <typedef-decl name='unw_save_loc_type_t' type-id='type-id-189' id='type-id-191'/>
+    <typedef-decl name='unw_tdep_save_loc_t' type-id='type-id-194' id='type-id-193'/>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-192'>
+      <data-member access='public'>
+        <var-decl name='addr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='regnum' type-id='type-id-163' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-195' size-in-bits='64' id='type-id-196'/>
+    <function-decl name='_ULriscv_get_save_loc' mangled-name='_ULriscv_get_save_loc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_get_save_loc'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='reg'/>
+      <parameter type-id='type-id-196' name='sloc'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Lglobal.c' language='LANG_C99'>
+    <type-decl name='atomic_bool' size-in-bits='8' id='type-id-197'/>
+    <array-type-def dimensions='1' type-id='type-id-198' size-in-bits='528' id='type-id-199'>
+      <subrange length='66' lower-bound='0' upper-bound='65' type-id='type-id-39' id='type-id-200'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-150' const='yes' id='type-id-198'/>
+    <var-decl name='_ULriscv_dwarf_to_unw_regnum_map' type-id='type-id-199' visibility='default'/>
+    <var-decl name='_ULriscv_init_done' type-id='type-id-197' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Linit.c' language='LANG_C99'>
+    <var-decl name='_ULriscv_local_addr_space' type-id='type-id-3' mangled-name='_ULriscv_local_addr_space' visibility='default' elf-symbol-id='_ULriscv_local_addr_space'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Linit_local.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_init_local' mangled-name='_ULriscv_init_local' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_init_local'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-66' name='uc'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULriscv_init_local2' mangled-name='_ULriscv_init_local2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_init_local2'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-66' name='uc'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Linit_remote.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_init_remote' mangled-name='_ULriscv_init_remote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_init_remote'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-8' name='as_arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Lis_signal_frame.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_is_signal_frame' mangled-name='_ULriscv_is_signal_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_is_signal_frame'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Lreg_states_iterate.c' language='LANG_C99'>
+    <typedef-decl name='unw_reg_states_callback' type-id='type-id-201' id='type-id-202'/>
+    <pointer-type-def type-id='type-id-203' size-in-bits='64' id='type-id-201'/>
+    <function-decl name='_ULriscv_reg_states_iterate' mangled-name='_ULriscv_reg_states_iterate' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_reg_states_iterate'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-202' name='cb'/>
+      <parameter type-id='type-id-8' name='token'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-203'>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Lresume.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_resume' mangled-name='_ULriscv_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_resume'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/Lstep.c' language='LANG_C99'>
+    <function-decl name='_ULriscv_step' mangled-name='_ULriscv_step' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULriscv_step'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/is_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_is_fpreg' mangled-name='_Uriscv_is_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_is_fpreg'>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/riscv/regname.c' language='LANG_C99'>
+    <function-decl name='_Uriscv_regname' mangled-name='_Uriscv_regname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Uriscv_regname'>
+      <parameter type-id='type-id-163' name='reg'/>
+      <return type-id='type-id-18'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/Backtrace.c' language='LANG_C99'>
+    <enum-decl name='_Unwind_Reason_Code' naming-typedef-id='type-id-204' id='type-id-205'>
+      <underlying-type type-id='type-id-106'/>
+      <enumerator name='_URC_NO_REASON' value='0'/>
+      <enumerator name='_URC_FOREIGN_EXCEPTION_CAUGHT' value='1'/>
+      <enumerator name='_URC_FATAL_PHASE2_ERROR' value='2'/>
+      <enumerator name='_URC_FATAL_PHASE1_ERROR' value='3'/>
+      <enumerator name='_URC_NORMAL_STOP' value='4'/>
+      <enumerator name='_URC_END_OF_STACK' value='5'/>
+      <enumerator name='_URC_HANDLER_FOUND' value='6'/>
+      <enumerator name='_URC_INSTALL_CONTEXT' value='7'/>
+      <enumerator name='_URC_CONTINUE_UNWIND' value='8'/>
+    </enum-decl>
+    <class-decl name='_Unwind_Context' size-in-bits='262208' is-struct='yes' visibility='default' id='type-id-206'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cursor' type-id='type-id-158' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='262144'>
+        <var-decl name='end_of_stack' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_Unwind_Reason_Code' type-id='type-id-205' id='type-id-204'/>
+    <typedef-decl name='_Unwind_Trace_Fn' type-id='type-id-207' id='type-id-208'/>
+    <pointer-type-def type-id='type-id-206' size-in-bits='64' id='type-id-209'/>
+    <pointer-type-def type-id='type-id-210' size-in-bits='64' id='type-id-207'/>
+    <function-decl name='_Unwind_Backtrace' mangled-name='_Unwind_Backtrace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_Backtrace'>
+      <parameter type-id='type-id-208' name='trace'/>
+      <parameter type-id='type-id-8' name='trace_parameter'/>
+      <return type-id='type-id-204'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-210'>
+      <parameter type-id='type-id-209'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-204'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/DeleteException.c' language='LANG_C99'>
+    <class-decl name='_Unwind_Exception' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-211'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='exception_class' type-id='type-id-151' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='exception_cleanup' type-id='type-id-212' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='private_1' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='private_2' type-id='type-id-39' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_Unwind_Exception_Cleanup_Fn' type-id='type-id-213' id='type-id-212'/>
+    <pointer-type-def type-id='type-id-211' size-in-bits='64' id='type-id-214'/>
+    <pointer-type-def type-id='type-id-215' size-in-bits='64' id='type-id-213'/>
+    <function-decl name='_Unwind_DeleteException' mangled-name='_Unwind_DeleteException' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_DeleteException'>
+      <parameter type-id='type-id-214' name='exception_object'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-215'>
+      <parameter type-id='type-id-204'/>
+      <parameter type-id='type-id-214'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/FindEnclosingFunction.c' language='LANG_C99'>
+    <function-decl name='_Unwind_FindEnclosingFunction' mangled-name='_Unwind_FindEnclosingFunction' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_FindEnclosingFunction'>
+      <parameter type-id='type-id-8' name='ip'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/ForcedUnwind.c' language='LANG_C99'>
+    <typedef-decl name='_Unwind_Action' type-id='type-id-7' id='type-id-216'/>
+    <typedef-decl name='_Unwind_Stop_Fn' type-id='type-id-217' id='type-id-218'/>
+    <pointer-type-def type-id='type-id-219' size-in-bits='64' id='type-id-217'/>
+    <function-decl name='_Unwind_ForcedUnwind' mangled-name='_Unwind_ForcedUnwind' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_ForcedUnwind'>
+      <parameter type-id='type-id-214' name='exception_object'/>
+      <parameter type-id='type-id-218' name='stop'/>
+      <parameter type-id='type-id-8' name='stop_parameter'/>
+      <return type-id='type-id-204'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-219'>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-216'/>
+      <parameter type-id='type-id-151'/>
+      <parameter type-id='type-id-214'/>
+      <parameter type-id='type-id-209'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-204'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/GetBSP.c' language='LANG_C99'>
+    <function-decl name='_Unwind_GetBSP' mangled-name='_Unwind_GetBSP' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_GetBSP'>
+      <parameter type-id='type-id-209' name='context'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/GetCFA.c' language='LANG_C99'>
+    <function-decl name='_Unwind_GetCFA' mangled-name='_Unwind_GetCFA' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_GetCFA'>
+      <parameter type-id='type-id-209' name='context'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/GetDataRelBase.c' language='LANG_C99'>
+    <function-decl name='_Unwind_GetDataRelBase' mangled-name='_Unwind_GetDataRelBase' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_GetDataRelBase'>
+      <parameter type-id='type-id-209' name='context'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/GetGR.c' language='LANG_C99'>
+    <function-decl name='_Unwind_GetGR' mangled-name='_Unwind_GetGR' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_GetGR'>
+      <parameter type-id='type-id-209' name='context'/>
+      <parameter type-id='type-id-7' name='index'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/GetIP.c' language='LANG_C99'>
+    <function-decl name='_Unwind_GetIP' mangled-name='_Unwind_GetIP' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_GetIP'>
+      <parameter type-id='type-id-209' name='context'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/GetIPInfo.c' language='LANG_C99'>
+    <pointer-type-def type-id='type-id-7' size-in-bits='64' id='type-id-220'/>
+    <function-decl name='_Unwind_GetIPInfo' mangled-name='_Unwind_GetIPInfo' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_GetIPInfo'>
+      <parameter type-id='type-id-209' name='context'/>
+      <parameter type-id='type-id-220' name='ip_before_insn'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/GetLanguageSpecificData.c' language='LANG_C99'>
+    <function-decl name='_Unwind_GetLanguageSpecificData' mangled-name='_Unwind_GetLanguageSpecificData' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_GetLanguageSpecificData'>
+      <parameter type-id='type-id-209' name='context'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/GetRegionStart.c' language='LANG_C99'>
+    <function-decl name='_Unwind_GetRegionStart' mangled-name='_Unwind_GetRegionStart' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_GetRegionStart'>
+      <parameter type-id='type-id-209' name='context'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/GetTextRelBase.c' language='LANG_C99'>
+    <function-decl name='_Unwind_GetTextRelBase' mangled-name='_Unwind_GetTextRelBase' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_GetTextRelBase'>
+      <parameter type-id='type-id-209' name='context'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/RaiseException.c' language='LANG_C99'>
+    <function-decl name='_Unwind_RaiseException' mangled-name='_Unwind_RaiseException' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_RaiseException'>
+      <parameter type-id='type-id-214' name='exception_object'/>
+      <return type-id='type-id-204'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/Resume.c' language='LANG_C99'>
+    <function-decl name='_Unwind_Resume' mangled-name='_Unwind_Resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_Resume'>
+      <parameter type-id='type-id-214' name='exception_object'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/Resume_or_Rethrow.c' language='LANG_C99'>
+    <function-decl name='_Unwind_Resume_or_Rethrow' mangled-name='_Unwind_Resume_or_Rethrow' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_Resume_or_Rethrow'>
+      <parameter type-id='type-id-214' name='exception_object'/>
+      <return type-id='type-id-204'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/SetGR.c' language='LANG_C99'>
+    <function-decl name='_Unwind_SetGR' mangled-name='_Unwind_SetGR' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_SetGR'>
+      <parameter type-id='type-id-209' name='context'/>
+      <parameter type-id='type-id-7' name='index'/>
+      <parameter type-id='type-id-39' name='new_value'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/unwind/SetIP.c' language='LANG_C99'>
+    <function-decl name='_Unwind_SetIP' mangled-name='_Unwind_SetIP' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Unwind_SetIP'>
+      <parameter type-id='type-id-209' name='context'/>
+      <parameter type-id='type-id-39' name='new_value'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/s390x/linux-gnu/libunwind-ptrace.abi
+++ b/src/abi/s390x/linux-gnu/libunwind-ptrace.abi
@@ -1,0 +1,627 @@
+<abi-corpus version='2.2' architecture='elf-ibm-s390' soname='libunwind-ptrace.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-s390x.so.8'/>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_UPT_access_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_access_mem' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_access_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_find_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_put_unwind_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_UPT_accessors' size='88' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_reg_offset' size='132' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-2' visibility='default' id='type-id-3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-3' id='type-id-2'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-5' id='type-id-6'/>
+    <typedef-decl name='sigset_t' type-id='type-id-2' id='type-id-5'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-7'/>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='1024' id='type-id-4'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-7' id='type-id-8'/>
+    </array-type-def>
+    <var-decl name='_UIs390x_full_mask' type-id='type-id-6' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-1' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_access_fpreg.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-9'/>
+    <array-type-def dimensions='1' type-id='type-id-9' size-in-bits='320' id='type-id-10'>
+      <subrange length='40' lower-bound='0' upper-bound='39' type-id='type-id-7' id='type-id-11'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-9' size-in-bits='544' id='type-id-12'>
+      <subrange length='68' lower-bound='0' upper-bound='67' type-id='type-id-7' id='type-id-13'/>
+    </array-type-def>
+    <type-decl name='double' size-in-bits='64' id='type-id-14'/>
+    <array-type-def dimensions='1' type-id='type-id-15' size-in-bits='16384' id='type-id-16'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-7' id='type-id-17'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-18' size-in-bits='638976' id='type-id-19'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-7' id='type-id-17'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-20' id='type-id-21'>
+      <underlying-type type-id='type-id-22'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-23'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-24'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-25' visibility='default' id='type-id-26'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-30' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-31'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-32' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-32' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-33'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='__elision' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-35' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-36'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-42' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-45' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='4928' is-struct='yes' visibility='default' id='type-id-46'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='val' type-id='type-id-47' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='4992' is-struct='yes' visibility='default' id='type-id-48'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-49' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='660096' is-struct='yes' visibility='default' id='type-id-50'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='rr_head' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='log_size' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='prev_log_size' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='hash' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='generation' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='buckets' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='links' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='default_hash' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4736'>
+        <var-decl name='default_buckets' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='643712'>
+        <var-decl name='default_links' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-57'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-66' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-67' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='661120' is-struct='yes' visibility='default' id='type-id-68'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-69' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='caching_policy' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='cache_generation' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='dyn_generation' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='global_cache' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='661056'>
+        <var-decl name='debug_frames' type-id='type-id-70' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='24576' is-struct='yes' visibility='default' id='type-id-71'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-72' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-73'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-70' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-76'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-77' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-77' visibility='default' id='type-id-78'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-79' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-80' id='type-id-29'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-81' id='type-id-39'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-80' id='type-id-28'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-26' id='type-id-25'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-53' id='type-id-27'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-80' id='type-id-30'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-31' id='type-id-35'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-45' id='type-id-82'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-34' id='type-id-83'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-7' id='type-id-84'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-85' id='type-id-86'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-43' id='type-id-15'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-46' id='type-id-49'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-48' id='type-id-18'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-87' id='type-id-51'/>
+    <typedef-decl name='size_t' type-id='type-id-7' id='type-id-41'/>
+    <typedef-decl name='uint16_t' type-id='type-id-82' id='type-id-81'/>
+    <typedef-decl name='uint32_t' type-id='type-id-83' id='type-id-53'/>
+    <typedef-decl name='uint64_t' type-id='type-id-84' id='type-id-80'/>
+    <typedef-decl name='uint8_t' type-id='type-id-86' id='type-id-79'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-88' id='type-id-89'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-21' id='type-id-20'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-71' id='type-id-90'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-91' id='type-id-92'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-93' id='type-id-94'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-95' id='type-id-69'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-76' id='type-id-96'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-23' id='type-id-97'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-14' id='type-id-91'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-78' id='type-id-77'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-80' id='type-id-44'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-51' visibility='default' id='type-id-87'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-1' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-22'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-85'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-34'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-40'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-45'/>
+    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='4096' id='type-id-56'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-7' id='type-id-98'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-44' size-in-bits='24576' id='type-id-72'>
+      <subrange length='384' lower-bound='0' upper-bound='383' type-id='type-id-7' id='type-id-99'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-44' size-in-bits='4352' id='type-id-47'>
+      <subrange length='68' lower-bound='0' upper-bound='67' type-id='type-id-7' id='type-id-13'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-32'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-74'/>
+    <qualified-type-def type-id='type-id-25' const='yes' id='type-id-100'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-38'/>
+    <qualified-type-def type-id='type-id-9' const='yes' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-37'/>
+    <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-18' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-93'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-63'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-62'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-65'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-61'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-66'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-64'/>
+    <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-95'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-45' size-in-bits='64' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-88'/>
+    <pointer-type-def type-id='type-id-90' size-in-bits='64' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-70'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-115'/>
+    <pointer-type-def type-id='type-id-96' size-in-bits='64' id='type-id-116'/>
+    <pointer-type-def type-id='type-id-44' size-in-bits='64' id='type-id-117'/>
+    <pointer-type-def type-id='type-id-118' size-in-bits='64' id='type-id-59'/>
+    <class-decl name='table_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-119'/>
+    <pointer-type-def type-id='type-id-119' size-in-bits='64' id='type-id-75'/>
+    <function-decl name='_UPT_access_fpreg' mangled-name='_UPT_access_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_access_fpreg'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-97' name='reg'/>
+      <parameter type-id='type-id-115' name='val'/>
+      <parameter type-id='type-id-23' name='write'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-120'/>
+    <pointer-type-def type-id='type-id-120' id='type-id-42'/>
+    <function-type size-in-bits='64' id='type-id-103'>
+      <parameter type-id='type-id-102'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-112'>
+      <parameter type-id='type-id-94'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-104'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-97'/>
+      <parameter type-id='type-id-115'/>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-105'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-97'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-106'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-107'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-108'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-109'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-110'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-111'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-113'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-44'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-118'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-120'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_access_mem.c' language='LANG_C99'>
+    <function-decl name='_UPT_access_mem' mangled-name='_UPT_access_mem' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_access_mem'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-44' name='addr'/>
+      <parameter type-id='type-id-117' name='val'/>
+      <parameter type-id='type-id-23' name='write'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_access_reg.c' language='LANG_C99'>
+    <function-decl name='_UPT_access_reg' mangled-name='_UPT_access_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_access_reg'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-97' name='reg'/>
+      <parameter type-id='type-id-117' name='val'/>
+      <parameter type-id='type-id-23' name='write'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-57' id='type-id-121'/>
+    <var-decl name='_UPT_accessors' type-id='type-id-121' mangled-name='_UPT_accessors' visibility='default' elf-symbol-id='_UPT_accessors'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_create.c' language='LANG_C99'>
+    <typedef-decl name='__pid_t' type-id='type-id-23' id='type-id-122'/>
+    <typedef-decl name='pid_t' type-id='type-id-122' id='type-id-123'/>
+    <function-decl name='_UPT_create' mangled-name='_UPT_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_create'>
+      <parameter type-id='type-id-123' name='pid'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_destroy.c' language='LANG_C99'>
+    <function-decl name='_UPT_destroy' mangled-name='_UPT_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_destroy'>
+      <parameter type-id='type-id-42' name='ptr'/>
+      <return type-id='type-id-120'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_find_proc_info.c' language='LANG_C99'>
+    <function-decl name='_UPT_find_proc_info' mangled-name='_UPT_find_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_find_proc_info'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-44' name='ip'/>
+      <parameter type-id='type-id-116' name='pi'/>
+      <parameter type-id='type-id-23' name='need_unwind_info'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_get_dyn_info_list_addr.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_dyn_info_list_addr' mangled-name='_UPT_get_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_get_dyn_info_list_addr'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-117' name='dil_addr'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_get_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_elf_filename' mangled-name='_UPT_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_get_elf_filename'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-44' name='ip'/>
+      <parameter type-id='type-id-74' name='buf'/>
+      <parameter type-id='type-id-41' name='buf_len'/>
+      <parameter type-id='type-id-117' name='offp'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_get_proc_name.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_proc_name' mangled-name='_UPT_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_get_proc_name'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-44' name='ip'/>
+      <parameter type-id='type-id-74' name='buf'/>
+      <parameter type-id='type-id-41' name='buf_len'/>
+      <parameter type-id='type-id-117' name='offp'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_put_unwind_info.c' language='LANG_C99'>
+    <function-decl name='_UPT_put_unwind_info' mangled-name='_UPT_put_unwind_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_put_unwind_info'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-116' name='pi'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-120'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_reg_offset.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-124' size-in-bits='1056' id='type-id-125'>
+      <subrange length='33' lower-bound='0' upper-bound='32' type-id='type-id-7' id='type-id-126'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-23' const='yes' id='type-id-124'/>
+    <var-decl name='_UPT_reg_offset' type-id='type-id-125' mangled-name='_UPT_reg_offset' visibility='default' elf-symbol-id='_UPT_reg_offset'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_resume.c' language='LANG_C99'>
+    <function-decl name='_UPT_resume' mangled-name='_UPT_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_resume'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-114' name='c'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/s390x/linux-gnu/libunwind-s390x.abi
+++ b/src/abi/s390x/linux-gnu/libunwind-s390x.abi
@@ -1,0 +1,1141 @@
+<abi-corpus version='2.2' architecture='elf-ibm-s390' soname='libunwind-s390x.so.8'>
+  <elf-needed>
+    <dependency name='libunwind.so.8'/>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_Us390x_apply_reg_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_create_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_destroy_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_dwarf_find_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_dwarf_search_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_flush_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_accessors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_elf_filename_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_elf_image' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_exe_image_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_proc_info_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_proc_info_in_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_proc_name_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_save_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_init_local' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_init_local2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_init_remote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_is_signal_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_reg_states_iterate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_set_cache_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_set_caching_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_set_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_set_iterate_phdr_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_set_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_Us390x_local_addr_space' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/dwarf/Gfind_proc_info-lsb.c' language='LANG_C99'>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-1'/>
+    <class-decl name='table_entry' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-2'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip_offset' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fde_offset' type-id='type-id-3' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-4'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-5' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-5' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-8'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-6' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-11'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-13' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-14'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-17'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-6' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-18'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-19' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int16_t' type-id='type-id-20' id='type-id-21'/>
+    <typedef-decl name='__int32_t' type-id='type-id-22' id='type-id-23'/>
+    <typedef-decl name='__int8_t' type-id='type-id-1' id='type-id-24'/>
+    <typedef-decl name='int16_t' type-id='type-id-21' id='type-id-10'/>
+    <typedef-decl name='int32_t' type-id='type-id-23' id='type-id-3'/>
+    <typedef-decl name='int8_t' type-id='type-id-24' id='type-id-9'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-4' id='type-id-25'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-8' id='type-id-26'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-11' id='type-id-27'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-14' id='type-id-28'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-17' id='type-id-29'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-18' id='type-id-30'/>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-7'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-29' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-26' size-in-bits='128' id='type-id-16'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-31' id='type-id-32'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-5'/>
+    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-33'/>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-15'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-13'/>
+    <function-decl name='_Us390x_dwarf_search_unwind_table' mangled-name='_Us390x_dwarf_search_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_dwarf_search_unwind_table'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-33' name='di'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <parameter type-id='type-id-22' name='need_unwind_info'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-37'>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-40'>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Gfind_unwind_table.c' language='LANG_C99'>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-25' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-25' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-42' size-in-bits='64' id='type-id-44'/>
+    <function-decl name='_Us390x_dwarf_find_unwind_table' mangled-name='_Us390x_dwarf_find_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_dwarf_find_unwind_table'>
+      <parameter type-id='type-id-44' name='edi'/>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-45' name='path'/>
+      <parameter type-id='type-id-6' name='segbase'/>
+      <parameter type-id='type-id-6' name='mapoff'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Gget_proc_info_in_range.c' language='LANG_C99'>
+    <function-decl name='_Us390x_get_proc_info_in_range' mangled-name='_Us390x_get_proc_info_in_range' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_proc_info_in_range'>
+      <parameter type-id='type-id-6' name='start_ip'/>
+      <parameter type-id='type-id-6' name='end_ip'/>
+      <parameter type-id='type-id-6' name='eh_frame_table'/>
+      <parameter type-id='type-id-6' name='eh_frame_table_len'/>
+      <parameter type-id='type-id-6' name='exidx_frame_table'/>
+      <parameter type-id='type-id-6' name='exidx_frame_table_len'/>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <parameter type-id='type-id-22' name='need_unwind_info'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/global.c' language='LANG_C99'>
+    <class-decl name='mempool' size-in-bits='640' is-struct='yes' visibility='default' id='type-id-46'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='obj_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='chunk_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='reserve' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='num_free' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='free_list' type-id='type-id-48' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='object' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-49'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-48' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-49' size-in-bits='64' id='type-id-48'/>
+    <var-decl name='dwarf_reg_state_pool' type-id='type-id-46' visibility='default'/>
+    <var-decl name='dwarf_cie_info_pool' type-id='type-id-46' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gdestroy_addr_space.c' language='LANG_C99'>
+    <function-decl name='_Us390x_destroy_addr_space' mangled-name='_Us390x_destroy_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_destroy_addr_space'>
+      <parameter type-id='type-id-34' name='as'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-51' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-52' size-in-bits='64' id='type-id-53'/>
+    <function-decl name='_Us390x_get_accessors' mangled-name='_Us390x_get_accessors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_accessors'>
+      <parameter type-id='type-id-34' name='as'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_Us390x_get_elf_filename_by_ip' mangled-name='_Us390x_get_elf_filename_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_elf_filename_by_ip'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-19' name='offp'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Us390x_get_elf_filename' mangled-name='_Us390x_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_elf_filename'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-19' name='offp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Us390x_get_fpreg' mangled-name='_Us390x_get_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_fpreg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-56' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_proc_info_by_ip.c' language='LANG_C99'>
+    <function-decl name='_Us390x_get_proc_info_by_ip' mangled-name='_Us390x_get_proc_info_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_proc_info_by_ip'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <parameter type-id='type-id-36' name='as_arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_proc_name.c' language='LANG_C99'>
+    <function-decl name='_Us390x_get_proc_name_by_ip' mangled-name='_Us390x_get_proc_name_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_proc_name_by_ip'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-19' name='offp'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Us390x_get_proc_name' mangled-name='_Us390x_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_proc_name'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-19' name='offp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_reg.c' language='LANG_C99'>
+    <function-decl name='_Us390x_get_reg' mangled-name='_Us390x_get_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_reg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-19' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_cache_size.c' language='LANG_C99'>
+    <function-decl name='_Us390x_set_cache_size' mangled-name='_Us390x_set_cache_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_set_cache_size'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-39' name='size'/>
+      <parameter type-id='type-id-22' name='flag'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_caching_policy.c' language='LANG_C99'>
+    <function-decl name='_Us390x_set_caching_policy' mangled-name='_Us390x_set_caching_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_set_caching_policy'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-57' name='policy'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Us390x_set_fpreg' mangled-name='_Us390x_set_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_set_fpreg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-58' name='val'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_iterate_phdr_function.c' language='LANG_C99'>
+    <function-decl name='_Us390x_set_iterate_phdr_function' mangled-name='_Us390x_set_iterate_phdr_function' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_set_iterate_phdr_function'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-59' name='function'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_reg.c' language='LANG_C99'>
+    <function-decl name='_Us390x_set_reg' mangled-name='_Us390x_set_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_set_reg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-6' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/flush_cache.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='320' id='type-id-61'>
+      <subrange length='40' lower-bound='0' upper-bound='39' type-id='type-id-31' id='type-id-62'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='544' id='type-id-63'>
+      <subrange length='68' lower-bound='0' upper-bound='67' type-id='type-id-31' id='type-id-64'/>
+    </array-type-def>
+    <type-decl name='double' size-in-bits='64' id='type-id-65'/>
+    <array-type-def dimensions='1' type-id='type-id-66' size-in-bits='16384' id='type-id-67'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-31' id='type-id-68'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-69' size-in-bits='638976' id='type-id-70'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-31' id='type-id-68'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-57' id='type-id-71'>
+      <underlying-type type-id='type-id-72'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='short int' size-in-bits='16' id='type-id-20'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-73' visibility='default' id='type-id-74'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-78' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-79'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-80' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-80' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-81'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-82' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-82' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='__elision' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-83' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-84'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-85' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-86' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-36' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-88'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-89' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='4928' is-struct='yes' visibility='default' id='type-id-90'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='val' type-id='type-id-91' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='4992' is-struct='yes' visibility='default' id='type-id-92'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-93' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='660096' is-struct='yes' visibility='default' id='type-id-94'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='rr_head' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='log_size' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='prev_log_size' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='hash' type-id='type-id-95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='generation' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='buckets' type-id='type-id-96' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='links' type-id='type-id-97' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='default_hash' type-id='type-id-98' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4736'>
+        <var-decl name='default_buckets' type-id='type-id-70' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='643712'>
+        <var-decl name='default_links' type-id='type-id-67' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-51'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-99' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-100' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-101' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-102' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-103' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-105' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-106' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-106' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-107' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-108' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='661120' is-struct='yes' visibility='default' id='type-id-109'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='caching_policy' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='cache_generation' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='dyn_generation' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='global_cache' type-id='type-id-94' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='661056'>
+        <var-decl name='debug_frames' type-id='type-id-110' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='24576' is-struct='yes' visibility='default' id='type-id-111'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-112' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-113'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-114' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-110' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-115'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-116' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-116' visibility='default' id='type-id-117'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-118' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-119' id='type-id-77'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-120' id='type-id-86'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-119' id='type-id-76'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-74' id='type-id-73'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-12' id='type-id-75'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-119' id='type-id-78'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-79' id='type-id-83'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-89' id='type-id-121'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-82' id='type-id-122'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-123' id='type-id-124'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-88' id='type-id-66'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-90' id='type-id-93'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-92' id='type-id-69'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-125' id='type-id-47'/>
+    <typedef-decl name='uint16_t' type-id='type-id-121' id='type-id-120'/>
+    <typedef-decl name='uint32_t' type-id='type-id-122' id='type-id-12'/>
+    <typedef-decl name='uint8_t' type-id='type-id-124' id='type-id-118'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-126' id='type-id-34'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-71' id='type-id-57'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-111' id='type-id-127'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-128' id='type-id-58'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-129' id='type-id-41'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-130' id='type-id-59'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-115' id='type-id-131'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-22' id='type-id-132'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-65' id='type-id-128'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-117' id='type-id-116'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-47' visibility='default' id='type-id-125'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-81' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-133' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-72'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-123'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-82'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-87'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-89'/>
+    <array-type-def dimensions='1' type-id='type-id-89' size-in-bits='4096' id='type-id-98'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-31' id='type-id-134'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='24576' id='type-id-112'>
+      <subrange length='384' lower-bound='0' upper-bound='383' type-id='type-id-31' id='type-id-135'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='4352' id='type-id-91'>
+      <subrange length='68' lower-bound='0' upper-bound='67' type-id='type-id-31' id='type-id-64'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-80'/>
+    <qualified-type-def type-id='type-id-73' const='yes' id='type-id-136'/>
+    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-85'/>
+    <qualified-type-def type-id='type-id-60' const='yes' id='type-id-137'/>
+    <pointer-type-def type-id='type-id-137' size-in-bits='64' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-84' size-in-bits='64' id='type-id-38'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-96'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-129'/>
+    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-104'/>
+    <pointer-type-def type-id='type-id-139' size-in-bits='64' id='type-id-103'/>
+    <pointer-type-def type-id='type-id-140' size-in-bits='64' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-141' size-in-bits='64' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-143' size-in-bits='64' id='type-id-107'/>
+    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-40' size-in-bits='64' id='type-id-130'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-146' size-in-bits='64' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-95'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-126'/>
+    <pointer-type-def type-id='type-id-127' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-58' size-in-bits='64' id='type-id-56'/>
+    <pointer-type-def type-id='type-id-131' size-in-bits='64' id='type-id-35'/>
+    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-100'/>
+    <function-decl name='_Us390x_flush_cache' mangled-name='_Us390x_flush_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_flush_cache'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='lo'/>
+      <parameter type-id='type-id-6' name='hi'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-138'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-132'/>
+      <parameter type-id='type-id-56'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-139'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-132'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-140'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-54'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-141'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-142'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-143'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-144'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-55'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-145'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-146'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-6'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-147'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-50'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-133'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-148' visibility='default' id='type-id-149'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-150' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-149' id='type-id-148'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-151' id='type-id-152'/>
+    <typedef-decl name='sigset_t' type-id='type-id-148' id='type-id-151'/>
+    <array-type-def dimensions='1' type-id='type-id-31' size-in-bits='1024' id='type-id-150'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-31' id='type-id-153'/>
+    </array-type-def>
+    <var-decl name='_UIs390x_full_mask' type-id='type-id-152' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-133' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/strerror.c' language='LANG_C99'>
+    <function-decl name='_Us390x_strerror' mangled-name='_Us390x_strerror' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_strerror'>
+      <parameter type-id='type-id-22' name='err_code'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/os-linux.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-60'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pid_t' type-id='type-id-22' id='type-id-154'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-31' id='type-id-155'/>
+    <typedef-decl name='pid_t' type-id='type-id-154' id='type-id-156'/>
+    <typedef-decl name='size_t' type-id='type-id-31' id='type-id-39'/>
+    <typedef-decl name='uint64_t' type-id='type-id-155' id='type-id-119'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-119' id='type-id-6'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-31'/>
+    <pointer-type-def type-id='type-id-60' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-157'/>
+    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-158'/>
+    <function-decl name='_Us390x_get_elf_image' mangled-name='_Us390x_get_elf_image' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_elf_image'>
+      <parameter type-id='type-id-157' name='ei'/>
+      <parameter type-id='type-id-156' name='pid'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-158' name='segbase'/>
+      <parameter type-id='type-id-158' name='mapoff'/>
+      <parameter type-id='type-id-54' name='path'/>
+      <parameter type-id='type-id-39' name='pathlen'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Us390x_get_exe_image_path' mangled-name='_Us390x_get_exe_image_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_exe_image_path'>
+      <parameter type-id='type-id-54' name='path'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-50' id='type-id-36'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Gapply_reg_state.c' language='LANG_C99'>
+    <function-decl name='_Us390x_apply_reg_state' mangled-name='_Us390x_apply_reg_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_apply_reg_state'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-36' name='reg_states_data'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Gcreate_addr_space.c' language='LANG_C99'>
+    <function-decl name='_Us390x_create_addr_space' mangled-name='_Us390x_create_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_create_addr_space'>
+      <parameter type-id='type-id-53' name='a'/>
+      <parameter type-id='type-id-22' name='byte_order'/>
+      <return type-id='type-id-34'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Gget_proc_info.c' language='LANG_C99'>
+    <function-decl name='_Us390x_get_proc_info' mangled-name='_Us390x_get_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_proc_info'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Gget_save_loc.c' language='LANG_C99'>
+    <enum-decl name='unw_save_loc_type' id='type-id-159'>
+      <underlying-type type-id='type-id-72'/>
+      <enumerator name='UNW_SLT_NONE' value='0'/>
+      <enumerator name='UNW_SLT_MEMORY' value='1'/>
+      <enumerator name='UNW_SLT_REG' value='2'/>
+    </enum-decl>
+    <class-decl name='unw_save_loc' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-160'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-161' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='u' type-id='type-id-162' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='extra' type-id='type-id-163' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_save_loc' size-in-bits='8' is-struct='yes' visibility='default' id='type-id-164'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-118' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_save_loc_t' type-id='type-id-160' id='type-id-165'/>
+    <typedef-decl name='unw_save_loc_type_t' type-id='type-id-159' id='type-id-161'/>
+    <typedef-decl name='unw_tdep_save_loc_t' type-id='type-id-164' id='type-id-163'/>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-162'>
+      <data-member access='public'>
+        <var-decl name='addr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='regnum' type-id='type-id-132' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-165' size-in-bits='64' id='type-id-166'/>
+    <function-decl name='_Us390x_get_save_loc' mangled-name='_Us390x_get_save_loc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_save_loc'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='reg'/>
+      <parameter type-id='type-id-166' name='sloc'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Gglobal.c' language='LANG_C99'>
+    <type-decl name='atomic_bool' size-in-bits='8' id='type-id-167'/>
+    <array-type-def dimensions='1' type-id='type-id-168' size-in-bits='528' id='type-id-169'>
+      <subrange length='66' lower-bound='0' upper-bound='65' type-id='type-id-31' id='type-id-170'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-118' const='yes' id='type-id-168'/>
+    <var-decl name='_Us390x_dwarf_to_unw_regnum_map' type-id='type-id-169' visibility='default'/>
+    <var-decl name='_Us390x_init_done' type-id='type-id-167' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Ginit.c' language='LANG_C99'>
+    <var-decl name='_Us390x_local_addr_space' type-id='type-id-34' mangled-name='_Us390x_local_addr_space' visibility='default' elf-symbol-id='_Us390x_local_addr_space'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Ginit_local.c' language='LANG_C99'>
+    <type-decl name='float' size-in-bits='32' id='type-id-171'/>
+    <array-type-def dimensions='1' type-id='type-id-172' size-in-bits='1024' id='type-id-173'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-31' id='type-id-153'/>
+    </array-type-def>
+    <class-decl name='__psw_t' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-174' visibility='default' id='type-id-175'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mask' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='addr' type-id='type-id-31' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='fpregset_t' size-in-bits='1088' is-struct='yes' naming-typedef-id='type-id-176' visibility='default' id='type-id-177'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fpc' type-id='type-id-82' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fprs' type-id='type-id-173' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='mcontext_t' size-in-bits='2752' is-struct='yes' naming-typedef-id='type-id-178' visibility='default' id='type-id-179'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='psw' type-id='type-id-174' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='gregs' type-id='type-id-150' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='aregs' type-id='type-id-180' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='fpregs' type-id='type-id-176' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='stack_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-181' visibility='default' id='type-id-182'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ss_sp' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ss_flags' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ss_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucontext_t' size-in-bits='4096' is-struct='yes' visibility='default' id='type-id-183'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uc_flags' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uc_link' type-id='type-id-184' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uc_stack' type-id='type-id-181' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='uc_mcontext' type-id='type-id-178' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3072'>
+        <var-decl name='uc_sigmask' type-id='type-id-151' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__psw_t' type-id='type-id-175' id='type-id-174'/>
+    <typedef-decl name='fpreg_t' type-id='type-id-185' id='type-id-172'/>
+    <typedef-decl name='fpregset_t' type-id='type-id-177' id='type-id-176'/>
+    <typedef-decl name='mcontext_t' type-id='type-id-179' id='type-id-178'/>
+    <typedef-decl name='stack_t' type-id='type-id-182' id='type-id-181'/>
+    <typedef-decl name='ucontext_t' type-id='type-id-183' id='type-id-186'/>
+    <union-decl name='fpreg_t' size-in-bits='64' naming-typedef-id='type-id-172' visibility='default' id='type-id-185'>
+      <data-member access='public'>
+        <var-decl name='d' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='f' type-id='type-id-171' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-82' size-in-bits='512' id='type-id-180'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-31' id='type-id-153'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-183' size-in-bits='64' id='type-id-184'/>
+    <pointer-type-def type-id='type-id-186' size-in-bits='64' id='type-id-187'/>
+    <function-decl name='_Us390x_init_local' mangled-name='_Us390x_init_local' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_init_local'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-187' name='uc'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Us390x_init_local2' mangled-name='_Us390x_init_local2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_init_local2'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-187' name='uc'/>
+      <parameter type-id='type-id-22' name='flag'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Ginit_remote.c' language='LANG_C99'>
+    <function-decl name='_Us390x_init_remote' mangled-name='_Us390x_init_remote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_init_remote'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-36' name='as_arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Gis_signal_frame.c' language='LANG_C99'>
+    <function-decl name='_Us390x_is_signal_frame' mangled-name='_Us390x_is_signal_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_is_signal_frame'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Greg_states_iterate.c' language='LANG_C99'>
+    <typedef-decl name='unw_reg_states_callback' type-id='type-id-188' id='type-id-189'/>
+    <pointer-type-def type-id='type-id-190' size-in-bits='64' id='type-id-188'/>
+    <function-decl name='_Us390x_reg_states_iterate' mangled-name='_Us390x_reg_states_iterate' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_reg_states_iterate'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-189' name='cb'/>
+      <parameter type-id='type-id-36' name='token'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-190'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Gresume.c' language='LANG_C99'>
+    <function-decl name='_Us390x_resume' mangled-name='_Us390x_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_resume'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Gstep.c' language='LANG_C99'>
+    <function-decl name='_Us390x_step' mangled-name='_Us390x_step' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_step'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/is_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Us390x_is_fpreg' mangled-name='_Us390x_is_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_is_fpreg'>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/regname.c' language='LANG_C99'>
+    <function-decl name='_Us390x_regname' mangled-name='_Us390x_regname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_regname'>
+      <parameter type-id='type-id-132' name='reg'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/s390x/linux-gnu/libunwind-setjmp.abi
+++ b/src/abi/s390x/linux-gnu/libunwind-setjmp.abi
@@ -1,0 +1,23 @@
+<abi-corpus version='2.2' architecture='elf-ibm-s390' soname='libunwind-setjmp.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-s390x.so.8'/>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-2' visibility='default' id='type-id-3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-3' id='type-id-2'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-5' id='type-id-6'/>
+    <typedef-decl name='sigset_t' type-id='type-id-2' id='type-id-5'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-7'/>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='1024' id='type-id-4'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-7' id='type-id-8'/>
+    </array-type-def>
+    <var-decl name='_UIs390x_full_mask' type-id='type-id-6' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-1' visibility='default'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/s390x/linux-gnu/libunwind.abi
+++ b/src/abi/s390x/linux-gnu/libunwind.abi
@@ -1,0 +1,1197 @@
+<abi-corpus version='2.2' architecture='elf-ibm-s390' soname='libunwind.so.8'>
+  <elf-needed>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_ULs390x_apply_reg_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_create_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_destroy_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_dwarf_find_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_dwarf_search_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_get_elf_filename_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_get_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_get_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_get_proc_info_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_get_proc_info_in_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_get_proc_name_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_get_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_get_save_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_init_local' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_init_local2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_init_remote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_is_signal_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_reg_states_iterate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_set_cache_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_set_caching_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_set_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_set_iterate_phdr_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_set_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULs390x_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_cancel' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_register' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_flush_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_accessors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_elf_image' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_get_exe_image_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_getcontext' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_setcontext' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Us390x_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='backtrace' type='func-type' binding='weak-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_backtrace' type='func-type' binding='global-binding' visibility='default-visibility' alias='backtrace' is-defined='yes'/>
+    <elf-symbol name='unw_backtrace2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_ULs390x_local_addr_space' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/dwarf/Lfind_proc_info-lsb.c' language='LANG_C99'>
+    <class-decl name='table_entry' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-1'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip_offset' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fde_offset' type-id='type-id-2' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <function-decl name='_ULs390x_dwarf_search_unwind_table' mangled-name='_ULs390x_dwarf_search_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_dwarf_search_unwind_table'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-5' name='di'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-7' name='need_unwind_info'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-9'>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-12'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Lfind_unwind_table.c' language='LANG_C99'>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-14'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-17'/>
+    <function-decl name='_ULs390x_dwarf_find_unwind_table' mangled-name='_ULs390x_dwarf_find_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_dwarf_find_unwind_table'>
+      <parameter type-id='type-id-17' name='edi'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-18' name='path'/>
+      <parameter type-id='type-id-4' name='segbase'/>
+      <parameter type-id='type-id-4' name='mapoff'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Lget_proc_info_in_range.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_get_proc_info_in_range' mangled-name='_ULs390x_get_proc_info_in_range' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_get_proc_info_in_range'>
+      <parameter type-id='type-id-4' name='start_ip'/>
+      <parameter type-id='type-id-4' name='end_ip'/>
+      <parameter type-id='type-id-4' name='eh_frame_table'/>
+      <parameter type-id='type-id-4' name='eh_frame_table_len'/>
+      <parameter type-id='type-id-4' name='exidx_frame_table'/>
+      <parameter type-id='type-id-4' name='exidx_frame_table_len'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-7' name='need_unwind_info'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/global.c' language='LANG_C99'>
+    <class-decl name='mempool' size-in-bits='640' is-struct='yes' visibility='default' id='type-id-19'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='obj_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='chunk_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='reserve' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='num_free' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='free_list' type-id='type-id-21' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='object' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-22'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-21' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-21'/>
+    <var-decl name='dwarf_reg_state_pool' type-id='type-id-19' visibility='default'/>
+    <var-decl name='dwarf_cie_info_pool' type-id='type-id-19' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Ldestroy_addr_space.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_destroy_addr_space' mangled-name='_ULs390x_destroy_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_destroy_addr_space'>
+      <parameter type-id='type-id-3' name='as'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-24' id='type-id-25'/>
+    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-26'/>
+    <function-decl name='_Us390x_get_accessors' mangled-name='_Us390x_get_accessors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_accessors'>
+      <parameter type-id='type-id-3' name='as'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_get_elf_filename_by_ip' mangled-name='_ULs390x_get_elf_filename_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_get_elf_filename_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULs390x_get_elf_filename' mangled-name='_ULs390x_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_get_elf_filename'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_fpreg.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_get_fpreg' mangled-name='_ULs390x_get_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_get_fpreg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-30' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_proc_info_by_ip.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_get_proc_info_by_ip' mangled-name='_ULs390x_get_proc_info_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_get_proc_info_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-8' name='as_arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_proc_name.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_get_proc_name_by_ip' mangled-name='_ULs390x_get_proc_name_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_get_proc_name_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULs390x_get_proc_name' mangled-name='_ULs390x_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_get_proc_name'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_reg.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_get_reg' mangled-name='_ULs390x_get_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_get_reg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-28' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_cache_size.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_set_cache_size' mangled-name='_ULs390x_set_cache_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_set_cache_size'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-11' name='size'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_caching_policy.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_set_caching_policy' mangled-name='_ULs390x_set_caching_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_set_caching_policy'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-31' name='policy'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_fpreg.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_set_fpreg' mangled-name='_ULs390x_set_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_set_fpreg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-32' name='val'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_iterate_phdr_function.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_set_iterate_phdr_function' mangled-name='_ULs390x_set_iterate_phdr_function' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_set_iterate_phdr_function'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-33' name='function'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_reg.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_set_reg' mangled-name='_ULs390x_set_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_set_reg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-4' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/backtrace.c' language='LANG_C99'>
+    <type-decl name='float' size-in-bits='32' id='type-id-34'/>
+    <array-type-def dimensions='1' type-id='type-id-35' size-in-bits='1024' id='type-id-36'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-37' id='type-id-38'/>
+    </array-type-def>
+    <class-decl name='__psw_t' size-in-bits='128' is-struct='yes' naming-typedef-id='type-id-39' visibility='default' id='type-id-40'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='mask' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='addr' type-id='type-id-37' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='fpregset_t' size-in-bits='1088' is-struct='yes' naming-typedef-id='type-id-41' visibility='default' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fpc' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fprs' type-id='type-id-36' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='mcontext_t' size-in-bits='2752' is-struct='yes' naming-typedef-id='type-id-44' visibility='default' id='type-id-45'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='psw' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='gregs' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='aregs' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='fpregs' type-id='type-id-41' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='stack_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-48' visibility='default' id='type-id-49'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ss_sp' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ss_flags' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ss_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucontext_t' size-in-bits='4096' is-struct='yes' visibility='default' id='type-id-50'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uc_flags' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uc_link' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uc_stack' type-id='type-id-48' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='uc_mcontext' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3072'>
+        <var-decl name='uc_sigmask' type-id='type-id-52' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__psw_t' type-id='type-id-40' id='type-id-39'/>
+    <typedef-decl name='fpreg_t' type-id='type-id-53' id='type-id-35'/>
+    <typedef-decl name='fpregset_t' type-id='type-id-42' id='type-id-41'/>
+    <typedef-decl name='mcontext_t' type-id='type-id-45' id='type-id-44'/>
+    <typedef-decl name='stack_t' type-id='type-id-49' id='type-id-48'/>
+    <typedef-decl name='ucontext_t' type-id='type-id-50' id='type-id-54'/>
+    <typedef-decl name='unw_context_t' type-id='type-id-55' id='type-id-56'/>
+    <typedef-decl name='unw_tdep_context_t' type-id='type-id-54' id='type-id-55'/>
+    <union-decl name='fpreg_t' size-in-bits='64' naming-typedef-id='type-id-35' visibility='default' id='type-id-53'>
+      <data-member access='public'>
+        <var-decl name='d' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='f' type-id='type-id-34' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-43' size-in-bits='512' id='type-id-47'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-37' id='type-id-38'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-50' size-in-bits='64' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-56' size-in-bits='64' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-59'/>
+    <function-decl name='unw_backtrace' mangled-name='unw_backtrace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_backtrace'>
+      <parameter type-id='type-id-59' name='buffer'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='unw_backtrace2' mangled-name='unw_backtrace2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_backtrace2'>
+      <parameter type-id='type-id-59' name='buffer'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <parameter type-id='type-id-58' name='uc2'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-cancel.c' language='LANG_C99'>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-60'/>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-61'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-63' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-64'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-66' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-67'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-69' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-70'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-71' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-72' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-73'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-74'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-28' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int16_t' type-id='type-id-75' id='type-id-76'/>
+    <typedef-decl name='__int32_t' type-id='type-id-7' id='type-id-77'/>
+    <typedef-decl name='__int8_t' type-id='type-id-60' id='type-id-78'/>
+    <typedef-decl name='int16_t' type-id='type-id-76' id='type-id-66'/>
+    <typedef-decl name='int32_t' type-id='type-id-77' id='type-id-2'/>
+    <typedef-decl name='int8_t' type-id='type-id-78' id='type-id-65'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-61' id='type-id-16'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-64' id='type-id-79'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-67' id='type-id-80'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-70' id='type-id-81'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-73' id='type-id-82'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-74' id='type-id-83'/>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-63'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-80' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-82' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-79' size-in-bits='128' id='type-id-72'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-37' id='type-id-84'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-61' size-in-bits='64' id='type-id-62'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-5'/>
+    <pointer-type-def type-id='type-id-70' size-in-bits='64' id='type-id-71'/>
+    <pointer-type-def type-id='type-id-81' size-in-bits='64' id='type-id-69'/>
+    <function-decl name='_U_dyn_cancel' mangled-name='_U_dyn_cancel' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_cancel'>
+      <parameter type-id='type-id-5' name='di'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-info-list.c' language='LANG_C99'>
+    <class-decl name='unw_dyn_info_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-85'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='version' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='generation' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='first' type-id='type-id-5' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_dyn_info_list_t' type-id='type-id-85' id='type-id-86'/>
+    <var-decl name='_U_dyn_info_list' type-id='type-id-86' visibility='default'/>
+    <function-decl name='_U_dyn_info_list_addr' mangled-name='_U_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_info_list_addr'>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-register.c' language='LANG_C99'>
+    <var-decl name='_U_dyn_info_list_lock' type-id='type-id-20' visibility='default'/>
+    <function-decl name='_U_dyn_register' mangled-name='_U_dyn_register' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_register'>
+      <parameter type-id='type-id-5' name='di'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/flush_cache.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-87' size-in-bits='320' id='type-id-88'>
+      <subrange length='40' lower-bound='0' upper-bound='39' type-id='type-id-37' id='type-id-89'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-87' size-in-bits='544' id='type-id-90'>
+      <subrange length='68' lower-bound='0' upper-bound='67' type-id='type-id-37' id='type-id-91'/>
+    </array-type-def>
+    <type-decl name='double' size-in-bits='64' id='type-id-57'/>
+    <array-type-def dimensions='1' type-id='type-id-92' size-in-bits='16384' id='type-id-93'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-37' id='type-id-94'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-95' size-in-bits='638976' id='type-id-96'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-37' id='type-id-94'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-31' id='type-id-97'>
+      <underlying-type type-id='type-id-98'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='short int' size-in-bits='16' id='type-id-75'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-99' visibility='default' id='type-id-100'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-101' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-101' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-102' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-103' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-103' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-104' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-105'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-106' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-106' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-107'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='__elision' type-id='type-id-75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-108' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-109'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-103' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-110' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-111' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-112' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-112' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-113'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-114' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-114' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-114' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-114' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='4928' is-struct='yes' visibility='default' id='type-id-115'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-90' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='val' type-id='type-id-116' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='4992' is-struct='yes' visibility='default' id='type-id-117'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-118' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='660096' is-struct='yes' visibility='default' id='type-id-119'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='rr_head' type-id='type-id-114' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='log_size' type-id='type-id-114' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='prev_log_size' type-id='type-id-114' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='hash' type-id='type-id-120' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='generation' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='buckets' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='links' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='default_hash' type-id='type-id-123' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4736'>
+        <var-decl name='default_buckets' type-id='type-id-96' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='643712'>
+        <var-decl name='default_links' type-id='type-id-93' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-24'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-125' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-126' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-128' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-129' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-130' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-132' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-133' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='661120' is-struct='yes' visibility='default' id='type-id-134'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='caching_policy' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='cache_generation' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='dyn_generation' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='global_cache' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='661056'>
+        <var-decl name='debug_frames' type-id='type-id-135' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='24576' is-struct='yes' visibility='default' id='type-id-136'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-137' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-138'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-139' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-135' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-140'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-141' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-141' visibility='default' id='type-id-142'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-143' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-144' id='type-id-103'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-145' id='type-id-111'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-144' id='type-id-102'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-100' id='type-id-99'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-68' id='type-id-101'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-144' id='type-id-104'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-105' id='type-id-108'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-114' id='type-id-146'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-43' id='type-id-147'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-148' id='type-id-149'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-113' id='type-id-92'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-115' id='type-id-118'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-117' id='type-id-95'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-150' id='type-id-20'/>
+    <typedef-decl name='uint16_t' type-id='type-id-146' id='type-id-145'/>
+    <typedef-decl name='uint32_t' type-id='type-id-147' id='type-id-68'/>
+    <typedef-decl name='uint8_t' type-id='type-id-149' id='type-id-143'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-151' id='type-id-3'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-97' id='type-id-31'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-136' id='type-id-152'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-153' id='type-id-32'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-154' id='type-id-13'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-155' id='type-id-33'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-140' id='type-id-156'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-7' id='type-id-157'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-57' id='type-id-153'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-142' id='type-id-141'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-20' visibility='default' id='type-id-150'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-107' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-88' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-158' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-98'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-148'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-43'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-112'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-114'/>
+    <array-type-def dimensions='1' type-id='type-id-114' size-in-bits='4096' id='type-id-123'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-37' id='type-id-159'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-4' size-in-bits='24576' id='type-id-137'>
+      <subrange length='384' lower-bound='0' upper-bound='383' type-id='type-id-37' id='type-id-160'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-4' size-in-bits='4352' id='type-id-116'>
+      <subrange length='68' lower-bound='0' upper-bound='67' type-id='type-id-37' id='type-id-91'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-106'/>
+    <qualified-type-def type-id='type-id-99' const='yes' id='type-id-161'/>
+    <pointer-type-def type-id='type-id-161' size-in-bits='64' id='type-id-110'/>
+    <qualified-type-def type-id='type-id-87' const='yes' id='type-id-162'/>
+    <pointer-type-def type-id='type-id-162' size-in-bits='64' id='type-id-18'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-10'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-122'/>
+    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-121'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-154'/>
+    <pointer-type-def type-id='type-id-163' size-in-bits='64' id='type-id-129'/>
+    <pointer-type-def type-id='type-id-164' size-in-bits='64' id='type-id-128'/>
+    <pointer-type-def type-id='type-id-165' size-in-bits='64' id='type-id-131'/>
+    <pointer-type-def type-id='type-id-166' size-in-bits='64' id='type-id-124'/>
+    <pointer-type-def type-id='type-id-167' size-in-bits='64' id='type-id-127'/>
+    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-132'/>
+    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-130'/>
+    <pointer-type-def type-id='type-id-170' size-in-bits='64' id='type-id-126'/>
+    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-155'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-139'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-133'/>
+    <pointer-type-def type-id='type-id-114' size-in-bits='64' id='type-id-120'/>
+    <pointer-type-def type-id='type-id-134' size-in-bits='64' id='type-id-151'/>
+    <pointer-type-def type-id='type-id-152' size-in-bits='64' id='type-id-29'/>
+    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-135'/>
+    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-156' size-in-bits='64' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-28'/>
+    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-125'/>
+    <function-decl name='_Us390x_flush_cache' mangled-name='_Us390x_flush_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_flush_cache'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='lo'/>
+      <parameter type-id='type-id-4' name='hi'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-163'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-157'/>
+      <parameter type-id='type-id-30'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-164'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-157'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-165'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-166'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-167'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-168'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-169'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-170'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-171'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-4'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-172'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-158'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-173' visibility='default' id='type-id-174'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-46' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-174' id='type-id-173'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-52' id='type-id-175'/>
+    <typedef-decl name='sigset_t' type-id='type-id-173' id='type-id-52'/>
+    <array-type-def dimensions='1' type-id='type-id-37' size-in-bits='1024' id='type-id-46'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-37' id='type-id-38'/>
+    </array-type-def>
+    <var-decl name='_UIs390x_full_mask' type-id='type-id-175' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-158' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/strerror.c' language='LANG_C99'>
+    <function-decl name='_Us390x_strerror' mangled-name='_Us390x_strerror' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_strerror'>
+      <parameter type-id='type-id-7' name='err_code'/>
+      <return type-id='type-id-18'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/os-linux.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-87'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-7'/>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-15'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pid_t' type-id='type-id-7' id='type-id-176'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-37' id='type-id-177'/>
+    <typedef-decl name='pid_t' type-id='type-id-176' id='type-id-178'/>
+    <typedef-decl name='size_t' type-id='type-id-37' id='type-id-11'/>
+    <typedef-decl name='uint64_t' type-id='type-id-177' id='type-id-144'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-144' id='type-id-4'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-37'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-27'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-179'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-180'/>
+    <function-decl name='_Us390x_get_elf_image' mangled-name='_Us390x_get_elf_image' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_elf_image'>
+      <parameter type-id='type-id-179' name='ei'/>
+      <parameter type-id='type-id-178' name='pid'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-180' name='segbase'/>
+      <parameter type-id='type-id-180' name='mapoff'/>
+      <parameter type-id='type-id-27' name='path'/>
+      <parameter type-id='type-id-11' name='pathlen'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_Us390x_get_exe_image_path' mangled-name='_Us390x_get_exe_image_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_get_exe_image_path'>
+      <parameter type-id='type-id-27' name='path'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-23'/>
+    <pointer-type-def type-id='type-id-23' id='type-id-8'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Lapply_reg_state.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_apply_reg_state' mangled-name='_ULs390x_apply_reg_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_apply_reg_state'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-8' name='reg_states_data'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Lcreate_addr_space.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_create_addr_space' mangled-name='_ULs390x_create_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_create_addr_space'>
+      <parameter type-id='type-id-26' name='a'/>
+      <parameter type-id='type-id-7' name='byte_order'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Lget_proc_info.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_get_proc_info' mangled-name='_ULs390x_get_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_get_proc_info'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Lget_save_loc.c' language='LANG_C99'>
+    <enum-decl name='unw_save_loc_type' id='type-id-181'>
+      <underlying-type type-id='type-id-98'/>
+      <enumerator name='UNW_SLT_NONE' value='0'/>
+      <enumerator name='UNW_SLT_MEMORY' value='1'/>
+      <enumerator name='UNW_SLT_REG' value='2'/>
+    </enum-decl>
+    <class-decl name='unw_save_loc' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-182'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-183' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='u' type-id='type-id-184' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='extra' type-id='type-id-185' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_save_loc' size-in-bits='8' is-struct='yes' visibility='default' id='type-id-186'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-143' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_save_loc_t' type-id='type-id-182' id='type-id-187'/>
+    <typedef-decl name='unw_save_loc_type_t' type-id='type-id-181' id='type-id-183'/>
+    <typedef-decl name='unw_tdep_save_loc_t' type-id='type-id-186' id='type-id-185'/>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-184'>
+      <data-member access='public'>
+        <var-decl name='addr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='regnum' type-id='type-id-157' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-187' size-in-bits='64' id='type-id-188'/>
+    <function-decl name='_ULs390x_get_save_loc' mangled-name='_ULs390x_get_save_loc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_get_save_loc'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='reg'/>
+      <parameter type-id='type-id-188' name='sloc'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Lglobal.c' language='LANG_C99'>
+    <type-decl name='atomic_bool' size-in-bits='8' id='type-id-189'/>
+    <array-type-def dimensions='1' type-id='type-id-190' size-in-bits='528' id='type-id-191'>
+      <subrange length='66' lower-bound='0' upper-bound='65' type-id='type-id-37' id='type-id-192'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-143' const='yes' id='type-id-190'/>
+    <var-decl name='_ULs390x_dwarf_to_unw_regnum_map' type-id='type-id-191' visibility='default'/>
+    <var-decl name='_ULs390x_init_done' type-id='type-id-189' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Linit.c' language='LANG_C99'>
+    <var-decl name='_ULs390x_local_addr_space' type-id='type-id-3' mangled-name='_ULs390x_local_addr_space' visibility='default' elf-symbol-id='_ULs390x_local_addr_space'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Linit_local.c' language='LANG_C99'>
+    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-193'/>
+    <function-decl name='_ULs390x_init_local' mangled-name='_ULs390x_init_local' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_init_local'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-193' name='uc'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULs390x_init_local2' mangled-name='_ULs390x_init_local2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_init_local2'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-193' name='uc'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Linit_remote.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_init_remote' mangled-name='_ULs390x_init_remote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_init_remote'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-8' name='as_arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Lis_signal_frame.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_is_signal_frame' mangled-name='_ULs390x_is_signal_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_is_signal_frame'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Lreg_states_iterate.c' language='LANG_C99'>
+    <typedef-decl name='unw_reg_states_callback' type-id='type-id-194' id='type-id-195'/>
+    <pointer-type-def type-id='type-id-196' size-in-bits='64' id='type-id-194'/>
+    <function-decl name='_ULs390x_reg_states_iterate' mangled-name='_ULs390x_reg_states_iterate' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_reg_states_iterate'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-195' name='cb'/>
+      <parameter type-id='type-id-8' name='token'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-196'>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Lresume.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_resume' mangled-name='_ULs390x_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_resume'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/Lstep.c' language='LANG_C99'>
+    <function-decl name='_ULs390x_step' mangled-name='_ULs390x_step' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULs390x_step'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/is_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Us390x_is_fpreg' mangled-name='_Us390x_is_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_is_fpreg'>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/s390x/regname.c' language='LANG_C99'>
+    <function-decl name='_Us390x_regname' mangled-name='_Us390x_regname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Us390x_regname'>
+      <parameter type-id='type-id-157' name='reg'/>
+      <return type-id='type-id-18'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/x86/linux-gnu/libunwind-coredump.abi
+++ b/src/abi/x86/linux-gnu/libunwind-coredump.abi
@@ -1,0 +1,1062 @@
+<abi-corpus version='2.2' architecture='elf-intel-80386' soname='libunwind-coredump.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-x86.so.8'/>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_UCD_access_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_access_mem' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_access_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_find_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_cursig' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_mapinfo' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_num_threads' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_pid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_threadinfo' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_put_unwind_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_select_thread' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_UCD_accessors' size='44' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='32' path='../../src/coredump/_UCD_access_mem.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-1'/>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='152' id='type-id-2'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-3' id='type-id-4'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='192' id='type-id-5'>
+      <subrange length='24' lower-bound='0' upper-bound='23' type-id='type-id-3' id='type-id-6'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='12288' id='type-id-8'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-9'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-10' size-in-bits='102400' id='type-id-11'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-9'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-12' id='type-id-13'>
+      <underlying-type type-id='type-id-14'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-15'/>
+    <type-decl name='long int' size-in-bits='32' id='type-id-16'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-17'/>
+    <class-decl name='Elf32_Phdr' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-18' visibility='default' id='type-id-19'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_offset' type-id='type-id-21' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_vaddr' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='p_paddr' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_filesz' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='p_memsz' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_flags' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='p_align' type-id='type-id-20' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_slist' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-23'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__next' type-id='type-id-24' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-25'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__kind' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__nusers' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='' type-id='type-id-26' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-27'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='dlpi_name' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_phdr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='dlpi_phnum' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_adds' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_subs' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-32' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-33' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-34'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='coll_chain' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='hint' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='valid' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='65'>
+        <var-decl name='signal_frame' type-id='type-id-36' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='768' is-struct='yes' visibility='default' id='type-id-37'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='val' type-id='type-id-38' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='800' is-struct='yes' visibility='default' id='type-id-39'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='reg' type-id='type-id-40' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='119168' is-struct='yes' visibility='default' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='rr_head' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='208'>
+        <var-decl name='log_size' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='prev_log_size' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='hash' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='generation' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='buckets' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='links' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='default_hash' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4480'>
+        <var-decl name='default_buckets' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='106880'>
+        <var-decl name='default_links' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='352' is-struct='yes' visibility='default' id='type-id-48'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='put_unwind_info' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='access_mem' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='access_reg' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='access_fpreg' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='resume' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='get_proc_name' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='get_elf_filename' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-58' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='119712' is-struct='yes' visibility='default' id='type-id-59'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-48' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='caching_policy' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='cache_generation' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dyn_generation' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='global_cache' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='119680'>
+        <var-decl name='debug_frames' type-id='type-id-61' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='4064' is-struct='yes' visibility='default' id='type-id-62'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-63' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-64'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='end' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='load_offset' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='debug_frame' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='debug_frame_size' type-id='type-id-32' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='index' type-id='type-id-66' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='index_size' type-id='type-id-32' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='next' type-id='type-id-61' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-67'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='end_ip' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='lsda' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='handler' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='gp' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='flags' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='format' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='unwind_info_size' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='unwind_info' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='extra' type-id='type-id-68' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-68' visibility='default' id='type-id-69'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-70' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__3' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-71'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__espins' type-id='type-id-17' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='__eelision' type-id='type-id-17' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__1' size-in-bits='80' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-72'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='b' type-id='type-id-73' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__2' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-74'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='b' type-id='type-id-75' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-76'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='b' type-id='type-id-77' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf32_Addr' type-id='type-id-44' id='type-id-22'/>
+    <typedef-decl name='Elf32_Half' type-id='type-id-78' id='type-id-30'/>
+    <typedef-decl name='Elf32_Off' type-id='type-id-44' id='type-id-21'/>
+    <typedef-decl name='Elf32_Phdr' type-id='type-id-19' id='type-id-18'/>
+    <typedef-decl name='Elf32_Word' type-id='type-id-44' id='type-id-20'/>
+    <typedef-decl name='__pthread_slist_t' type-id='type-id-23' id='type-id-79'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-36' id='type-id-80'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-3' id='type-id-81'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-82' id='type-id-83'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-34' id='type-id-7'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-37' id='type-id-40'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-39' id='type-id-10'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-84' id='type-id-42'/>
+    <typedef-decl name='size_t' type-id='type-id-3' id='type-id-32'/>
+    <typedef-decl name='uint16_t' type-id='type-id-80' id='type-id-78'/>
+    <typedef-decl name='uint32_t' type-id='type-id-81' id='type-id-44'/>
+    <typedef-decl name='uint8_t' type-id='type-id-83' id='type-id-70'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-85' id='type-id-86'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-13' id='type-id-12'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-62' id='type-id-87'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-88' id='type-id-89'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-90' id='type-id-91'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-92' id='type-id-60'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-67' id='type-id-93'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-15' id='type-id-94'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-95' id='type-id-88'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-69' id='type-id-68'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-44' id='type-id-35'/>
+    <array-type-def dimensions='1' type-id='type-id-70' size-in-bits='80' id='type-id-73'>
+      <subrange length='10' lower-bound='0' upper-bound='9' type-id='type-id-3' id='type-id-96'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-70' size-in-bits='128' id='type-id-75'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-3' id='type-id-97'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-70' size-in-bits='32' id='type-id-77'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-3' id='type-id-98'/>
+    </array-type-def>
+    <union-decl name='pthread_mutex_t' size-in-bits='192' naming-typedef-id='type-id-42' visibility='default' id='type-id-84'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-25' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-5' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='unw_tdep_fpreg_t' size-in-bits='128' naming-typedef-id='type-id-88' visibility='default' id='type-id-95'>
+      <data-member access='public'>
+        <var-decl name='val32' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='val80' type-id='type-id-72' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='val128' type-id='type-id-74' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__1' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-26'>
+      <data-member access='public'>
+        <var-decl name='__elision_data' type-id='type-id-71' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__list' type-id='type-id-79' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-14'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-82'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-3'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-31'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-36'/>
+    <array-type-def dimensions='1' type-id='type-id-36' size-in-bits='4096' id='type-id-47'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-3' id='type-id-99'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-35' size-in-bits='4064' id='type-id-63'>
+      <subrange length='127' lower-bound='0' upper-bound='126' type-id='type-id-3' id='type-id-100'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-35' size-in-bits='608' id='type-id-38'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-3' id='type-id-4'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-23' size-in-bits='32' id='type-id-24'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='32' id='type-id-65'/>
+    <qualified-type-def type-id='type-id-18' const='yes' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='32' id='type-id-29'/>
+    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='32' id='type-id-28'/>
+    <pointer-type-def type-id='type-id-27' size-in-bits='32' id='type-id-103'/>
+    <pointer-type-def type-id='type-id-7' size-in-bits='32' id='type-id-46'/>
+    <pointer-type-def type-id='type-id-10' size-in-bits='32' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='32' id='type-id-90'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='32' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='32' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='32' id='type-id-56'/>
+    <pointer-type-def type-id='type-id-108' size-in-bits='32' id='type-id-49'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='32' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='32' id='type-id-57'/>
+    <pointer-type-def type-id='type-id-111' size-in-bits='32' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='32' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='32' id='type-id-92'/>
+    <pointer-type-def type-id='type-id-114' size-in-bits='32' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-36' size-in-bits='32' id='type-id-43'/>
+    <pointer-type-def type-id='type-id-59' size-in-bits='32' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='32' id='type-id-115'/>
+    <pointer-type-def type-id='type-id-64' size-in-bits='32' id='type-id-61'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='32' id='type-id-116'/>
+    <pointer-type-def type-id='type-id-93' size-in-bits='32' id='type-id-117'/>
+    <pointer-type-def type-id='type-id-35' size-in-bits='32' id='type-id-118'/>
+    <pointer-type-def type-id='type-id-119' size-in-bits='32' id='type-id-50'/>
+    <class-decl name='table_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-120'/>
+    <pointer-type-def type-id='type-id-120' size-in-bits='32' id='type-id-66'/>
+    <function-decl name='_UCD_access_mem' mangled-name='_UCD_access_mem' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_access_mem'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-35' name='addr'/>
+      <parameter type-id='type-id-118' name='val'/>
+      <parameter type-id='type-id-15' name='write'/>
+      <parameter type-id='type-id-33' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-121'/>
+    <pointer-type-def type-id='type-id-121' id='type-id-33'/>
+    <function-type size-in-bits='32' id='type-id-104'>
+      <parameter type-id='type-id-103'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-113'>
+      <parameter type-id='type-id-91'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-105'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-94'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-106'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-94'/>
+      <parameter type-id='type-id-118'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-107'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-65'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-118'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-108'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-109'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-118'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-110'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-118'/>
+      <parameter type-id='type-id-118'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-111'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-115'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-112'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-118'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-114'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-35'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-119'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-33'/>
+      <return type-id='type-id-121'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/coredump/_UCD_access_reg_linux.c' language='LANG_C99'>
+    <function-decl name='_UCD_access_reg' mangled-name='_UCD_access_reg' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_access_reg'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-94' name='regnum'/>
+      <parameter type-id='type-id-118' name='valp'/>
+      <parameter type-id='type-id-15' name='write'/>
+      <parameter type-id='type-id-33' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/coredump/_UCD_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-48' id='type-id-122'/>
+    <var-decl name='_UCD_accessors' type-id='type-id-122' mangled-name='_UCD_accessors' visibility='default' elf-symbol-id='_UCD_accessors'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/coredump/_UCD_create.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-123' size-in-bits='544' id='type-id-124'>
+      <subrange length='17' lower-bound='0' upper-bound='16' type-id='type-id-3' id='type-id-125'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-16' size-in-bits='640' id='type-id-126'>
+      <subrange length='20' lower-bound='0' upper-bound='19' type-id='type-id-3' id='type-id-127'/>
+    </array-type-def>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-128'/>
+    <class-decl name='UCD_info' size-in-bits='1312' is-struct='yes' visibility='default' id='type-id-129'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='big_endian' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='coredump_fd' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coredump_filename' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='phdrs' type-id='type-id-130' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='phdrs_count' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='ucd_file_table' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='note_phdr' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='prstatus' type-id='type-id-132' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='fpregset' type-id='type-id-133' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='n_threads' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='threads' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='edi' type-id='type-id-135' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='UCD_thread_info' size-in-bits='2016' is-struct='yes' visibility='default' id='type-id-136'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='prstatus' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='fpregset' type-id='type-id-138' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='coredump_phdr' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-139'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='p_vaddr' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_filesz' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='p_memsz' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_align' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='p_backing_file_index' type-id='type-id-141' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_dyn_info' size-in-bits='896' is-struct='yes' visibility='default' id='type-id-135'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-142' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='di_cache' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='di_debug' type-id='type-id-143' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_image' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-142'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='size' type-id='type-id-32' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_prstatus' size-in-bits='1152' is-struct='yes' visibility='default' id='type-id-144'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pr_info' type-id='type-id-145' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='pr_cursig' type-id='type-id-17' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pr_sigpend' type-id='type-id-146' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pr_sighold' type-id='type-id-146' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pr_pid' type-id='type-id-147' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='pr_ppid' type-id='type-id-147' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pr_pgrp' type-id='type-id-147' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='pr_sid' type-id='type-id-147' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pr_utime' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='pr_stime' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='pr_cutime' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='pr_cstime' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='pr_reg' type-id='type-id-149' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1120'>
+        <var-decl name='pr_fpvalid' type-id='type-id-15' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_siginfo' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-145'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='si_signo' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='si_code' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='si_errno' type-id='type-id-15' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='timeval' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-148'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tv_sec' type-id='type-id-150' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='tv_usec' type-id='type-id-151' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucd_file_s' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-152'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='filename' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fd' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-153' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='image' type-id='type-id-154' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucd_file_table_s' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-155'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uft_count' type-id='type-id-32' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='uft_size' type-id='type-id-32' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uft_files' type-id='type-id-156' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_info' size-in-bits='416' is-struct='yes' visibility='default' id='type-id-157'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-158' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='prev' type-id='type-id-158' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='start_ip' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='end_ip' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='gp' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='format' type-id='type-id-159' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pad' type-id='type-id-159' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='load_offset' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='u' type-id='type-id-160' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-161'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-162' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-162' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-163' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-159' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-35' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='160' is-struct='yes' visibility='default' id='type-id-164'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='handler' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='flags' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='pad0' type-id='type-id-159' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='regions' type-id='type-id-165' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-166'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-167' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='insn_count' type-id='type-id-159' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='op_count' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op' type-id='type-id-168' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-169'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='segbase' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='table_len' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='table_data' type-id='type-id-35' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-170'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='segbase' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='table_len' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='table_data' type-id='type-id-118' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='user_fpregs_struct' size-in-bits='864' is-struct='yes' visibility='default' id='type-id-171'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cwd' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='swd' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='twd' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='fip' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='fcs' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='foo' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='fos' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='st_space' type-id='type-id-126' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='UCD_proc_status_t' type-id='type-id-144' id='type-id-137'/>
+    <typedef-decl name='__int16_t' type-id='type-id-17' id='type-id-172'/>
+    <typedef-decl name='__int32_t' type-id='type-id-15' id='type-id-173'/>
+    <typedef-decl name='__int8_t' type-id='type-id-128' id='type-id-174'/>
+    <typedef-decl name='__off_t' type-id='type-id-16' id='type-id-175'/>
+    <typedef-decl name='__pid_t' type-id='type-id-15' id='type-id-147'/>
+    <typedef-decl name='__suseconds_t' type-id='type-id-16' id='type-id-151'/>
+    <typedef-decl name='__time_t' type-id='type-id-16' id='type-id-150'/>
+    <typedef-decl name='coredump_phdr_t' type-id='type-id-139' id='type-id-176'/>
+    <typedef-decl name='elf_fpregset_t' type-id='type-id-171' id='type-id-138'/>
+    <typedef-decl name='elf_greg_t' type-id='type-id-146' id='type-id-123'/>
+    <typedef-decl name='elf_gregset_t' type-id='type-id-124' id='type-id-149'/>
+    <typedef-decl name='int16_t' type-id='type-id-172' id='type-id-163'/>
+    <typedef-decl name='int32_t' type-id='type-id-173' id='type-id-159'/>
+    <typedef-decl name='int8_t' type-id='type-id-174' id='type-id-162'/>
+    <typedef-decl name='off_t' type-id='type-id-175' id='type-id-153'/>
+    <typedef-decl name='pid_t' type-id='type-id-147' id='type-id-177'/>
+    <typedef-decl name='ucd_file_index_t' type-id='type-id-15' id='type-id-141'/>
+    <typedef-decl name='ucd_file_t' type-id='type-id-152' id='type-id-178'/>
+    <typedef-decl name='ucd_file_table_t' type-id='type-id-155' id='type-id-131'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-157' id='type-id-143'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-161' id='type-id-179'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-164' id='type-id-180'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-166' id='type-id-181'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-169' id='type-id-182'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-170' id='type-id-183'/>
+    <typedef-decl name='uoff_t' type-id='type-id-44' id='type-id-140'/>
+    <union-decl name='__anonymous_union__' size-in-bits='160' is-anonymous='yes' visibility='default' id='type-id-160'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-180' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-183' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-182' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-146'/>
+    <array-type-def dimensions='1' type-id='type-id-179' size-in-bits='96' id='type-id-168'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-3' id='type-id-184'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-129' size-in-bits='32' id='type-id-185'/>
+    <pointer-type-def type-id='type-id-137' size-in-bits='32' id='type-id-132'/>
+    <pointer-type-def type-id='type-id-136' size-in-bits='32' id='type-id-134'/>
+    <pointer-type-def type-id='type-id-176' size-in-bits='32' id='type-id-130'/>
+    <pointer-type-def type-id='type-id-138' size-in-bits='32' id='type-id-133'/>
+    <pointer-type-def type-id='type-id-178' size-in-bits='32' id='type-id-156'/>
+    <pointer-type-def type-id='type-id-70' size-in-bits='32' id='type-id-154'/>
+    <pointer-type-def type-id='type-id-157' size-in-bits='32' id='type-id-158'/>
+    <pointer-type-def type-id='type-id-166' size-in-bits='32' id='type-id-167'/>
+    <pointer-type-def type-id='type-id-181' size-in-bits='32' id='type-id-165'/>
+    <function-decl name='_UCD_create' mangled-name='_UCD_create' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_create'>
+      <parameter type-id='type-id-28' name='filename'/>
+      <return type-id='type-id-185'/>
+    </function-decl>
+    <function-decl name='_UCD_get_num_threads' mangled-name='_UCD_get_num_threads' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_get_num_threads'>
+      <parameter type-id='type-id-185' name='ui'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='_UCD_select_thread' mangled-name='_UCD_select_thread' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_select_thread'>
+      <parameter type-id='type-id-185' name='ui'/>
+      <parameter type-id='type-id-15' name='n'/>
+      <return type-id='type-id-121'/>
+    </function-decl>
+    <function-decl name='_UCD_get_pid' mangled-name='_UCD_get_pid' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_get_pid'>
+      <parameter type-id='type-id-185' name='ui'/>
+      <return type-id='type-id-177'/>
+    </function-decl>
+    <function-decl name='_UCD_get_cursig' mangled-name='_UCD_get_cursig' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_get_cursig'>
+      <parameter type-id='type-id-185' name='ui'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/coredump/_UCD_destroy.c' language='LANG_C99'>
+    <function-decl name='_UCD_destroy' mangled-name='_UCD_destroy' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_destroy'>
+      <parameter type-id='type-id-185' name='ui'/>
+      <return type-id='type-id-121'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/coredump/_UCD_find_proc_info.c' language='LANG_C99'>
+    <function-decl name='_UCD_find_proc_info' mangled-name='_UCD_find_proc_info' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_find_proc_info'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-35' name='ip'/>
+      <parameter type-id='type-id-117' name='pi'/>
+      <parameter type-id='type-id-15' name='need_unwind_info'/>
+      <parameter type-id='type-id-33' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/coredump/_UCD_get_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_elf_filename' mangled-name='_UCD_get_elf_filename' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_get_elf_filename'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-35' name='ip'/>
+      <parameter type-id='type-id-65' name='buf'/>
+      <parameter type-id='type-id-32' name='buf_len'/>
+      <parameter type-id='type-id-118' name='offp'/>
+      <parameter type-id='type-id-33' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/coredump/_UCD_get_mapinfo_linux.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_mapinfo' mangled-name='_UCD_get_mapinfo' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_get_mapinfo'>
+      <parameter type-id='type-id-185' name='ui'/>
+      <parameter type-id='type-id-130' name='phdrs'/>
+      <parameter type-id='type-id-3' name='phdr_size'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/coredump/_UCD_get_proc_name.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_proc_name' mangled-name='_UCD_get_proc_name' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_get_proc_name'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-35' name='ip'/>
+      <parameter type-id='type-id-65' name='buf'/>
+      <parameter type-id='type-id-32' name='buf_len'/>
+      <parameter type-id='type-id-118' name='offp'/>
+      <parameter type-id='type-id-33' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/coredump/_UCD_get_threadinfo_prstatus.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_threadinfo' mangled-name='_UCD_get_threadinfo' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_get_threadinfo'>
+      <parameter type-id='type-id-185' name='ui'/>
+      <parameter type-id='type-id-130' name='phdrs'/>
+      <parameter type-id='type-id-3' name='phdr_size'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/coredump/_UPT_access_fpreg.c' language='LANG_C99'>
+    <function-decl name='_UCD_access_fpreg' mangled-name='_UCD_access_fpreg' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_access_fpreg'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-94' name='reg'/>
+      <parameter type-id='type-id-116' name='val'/>
+      <parameter type-id='type-id-15' name='write'/>
+      <parameter type-id='type-id-33' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/coredump/_UPT_get_dyn_info_list_addr.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_dyn_info_list_addr' mangled-name='_UCD_get_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_get_dyn_info_list_addr'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-118' name='dil_addr'/>
+      <parameter type-id='type-id-33' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/coredump/_UPT_put_unwind_info.c' language='LANG_C99'>
+    <function-decl name='_UCD_put_unwind_info' mangled-name='_UCD_put_unwind_info' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_put_unwind_info'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-117' name='pi'/>
+      <parameter type-id='type-id-33' name='arg'/>
+      <return type-id='type-id-121'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/coredump/_UPT_resume.c' language='LANG_C99'>
+    <function-decl name='_UCD_resume' mangled-name='_UCD_resume' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UCD_resume'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-115' name='c'/>
+      <parameter type-id='type-id-33' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/init.c' language='LANG_C99'>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-186' visibility='default' id='type-id-187'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-188' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-187' id='type-id-186'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-189' id='type-id-190'/>
+    <typedef-decl name='sigset_t' type-id='type-id-186' id='type-id-189'/>
+    <array-type-def dimensions='1' type-id='type-id-146' size-in-bits='1024' id='type-id-188'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-3' id='type-id-191'/>
+    </array-type-def>
+    <var-decl name='_UIx86_full_mask' type-id='type-id-190' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-16' visibility='default'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/x86/linux-gnu/libunwind-ptrace.abi
+++ b/src/abi/x86/linux-gnu/libunwind-ptrace.abi
@@ -1,0 +1,665 @@
+<abi-corpus version='2.2' architecture='elf-intel-80386' soname='libunwind-ptrace.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-x86.so.8'/>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_UPT_access_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_access_mem' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_access_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_find_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_put_unwind_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_UPT_accessors' size='44' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_reg_offset' size='244' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='32' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='32' id='type-id-1'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-2' visibility='default' id='type-id-3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-3' id='type-id-2'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-5' id='type-id-6'/>
+    <typedef-decl name='sigset_t' type-id='type-id-2' id='type-id-5'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-7'/>
+    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-8'/>
+    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='1024' id='type-id-4'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-7' id='type-id-9'/>
+    </array-type-def>
+    <var-decl name='_UIx86_full_mask' type-id='type-id-6' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-1' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/ptrace/_UPT_access_fpreg.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-10'/>
+    <array-type-def dimensions='1' type-id='type-id-10' size-in-bits='152' id='type-id-11'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-7' id='type-id-12'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-10' size-in-bits='192' id='type-id-13'>
+      <subrange length='24' lower-bound='0' upper-bound='23' type-id='type-id-7' id='type-id-14'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-15' size-in-bits='12288' id='type-id-16'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-7' id='type-id-17'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-18' size-in-bits='102400' id='type-id-19'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-7' id='type-id-17'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-20' id='type-id-21'>
+      <underlying-type type-id='type-id-22'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-23'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-24'/>
+    <class-decl name='Elf32_Phdr' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-25' visibility='default' id='type-id-26'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_offset' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_vaddr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='p_paddr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_filesz' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='p_memsz' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_flags' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='p_align' type-id='type-id-27' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_slist' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-30'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__next' type-id='type-id-31' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-32'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__kind' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__nusers' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='' type-id='type-id-33' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-34'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='dlpi_name' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_phdr' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='dlpi_phnum' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_adds' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_subs' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-40' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='coll_chain' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='hint' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='valid' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='65'>
+        <var-decl name='signal_frame' type-id='type-id-43' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='768' is-struct='yes' visibility='default' id='type-id-44'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='val' type-id='type-id-45' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='800' is-struct='yes' visibility='default' id='type-id-46'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='reg' type-id='type-id-47' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='119168' is-struct='yes' visibility='default' id='type-id-48'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='rr_head' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='208'>
+        <var-decl name='log_size' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='prev_log_size' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='hash' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='generation' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='buckets' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='links' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='default_hash' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4480'>
+        <var-decl name='default_buckets' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='106880'>
+        <var-decl name='default_links' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='352' is-struct='yes' visibility='default' id='type-id-55'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='put_unwind_info' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='access_mem' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='access_reg' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='access_fpreg' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='resume' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='get_proc_name' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='get_elf_filename' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-65' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='119712' is-struct='yes' visibility='default' id='type-id-66'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-67' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='caching_policy' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='cache_generation' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dyn_generation' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='global_cache' type-id='type-id-48' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='119680'>
+        <var-decl name='debug_frames' type-id='type-id-68' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='4064' is-struct='yes' visibility='default' id='type-id-69'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-70' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-71'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='end' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='load_offset' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='debug_frame' type-id='type-id-72' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='debug_frame_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='index' type-id='type-id-73' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='index_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='next' type-id='type-id-68' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-74'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='end_ip' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='lsda' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='handler' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='gp' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='flags' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='format' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='unwind_info_size' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='unwind_info' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='extra' type-id='type-id-75' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-75' visibility='default' id='type-id-76'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-77' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__3' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-78'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__espins' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='__eelision' type-id='type-id-24' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__1' size-in-bits='80' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-79'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='b' type-id='type-id-80' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__2' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-81'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='b' type-id='type-id-82' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-83'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='b' type-id='type-id-84' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf32_Addr' type-id='type-id-51' id='type-id-29'/>
+    <typedef-decl name='Elf32_Half' type-id='type-id-85' id='type-id-37'/>
+    <typedef-decl name='Elf32_Off' type-id='type-id-51' id='type-id-28'/>
+    <typedef-decl name='Elf32_Phdr' type-id='type-id-26' id='type-id-25'/>
+    <typedef-decl name='Elf32_Word' type-id='type-id-51' id='type-id-27'/>
+    <typedef-decl name='__pthread_slist_t' type-id='type-id-30' id='type-id-86'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-43' id='type-id-87'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-7' id='type-id-88'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-89' id='type-id-90'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-41' id='type-id-15'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-44' id='type-id-47'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-46' id='type-id-18'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-91' id='type-id-49'/>
+    <typedef-decl name='size_t' type-id='type-id-7' id='type-id-39'/>
+    <typedef-decl name='uint16_t' type-id='type-id-87' id='type-id-85'/>
+    <typedef-decl name='uint32_t' type-id='type-id-88' id='type-id-51'/>
+    <typedef-decl name='uint8_t' type-id='type-id-90' id='type-id-77'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-92' id='type-id-93'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-21' id='type-id-20'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-69' id='type-id-94'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-95' id='type-id-96'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-97' id='type-id-98'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-99' id='type-id-67'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-74' id='type-id-100'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-23' id='type-id-101'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-102' id='type-id-95'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-76' id='type-id-75'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-51' id='type-id-42'/>
+    <array-type-def dimensions='1' type-id='type-id-77' size-in-bits='80' id='type-id-80'>
+      <subrange length='10' lower-bound='0' upper-bound='9' type-id='type-id-7' id='type-id-103'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-77' size-in-bits='128' id='type-id-82'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-7' id='type-id-104'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-77' size-in-bits='32' id='type-id-84'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-7' id='type-id-105'/>
+    </array-type-def>
+    <union-decl name='pthread_mutex_t' size-in-bits='192' naming-typedef-id='type-id-49' visibility='default' id='type-id-91'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-32' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-1' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='unw_tdep_fpreg_t' size-in-bits='128' naming-typedef-id='type-id-95' visibility='default' id='type-id-102'>
+      <data-member access='public'>
+        <var-decl name='val32' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='val80' type-id='type-id-79' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='val128' type-id='type-id-81' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__1' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-33'>
+      <data-member access='public'>
+        <var-decl name='__elision_data' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__list' type-id='type-id-86' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-22'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-89'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-38'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-43'/>
+    <array-type-def dimensions='1' type-id='type-id-43' size-in-bits='4096' id='type-id-54'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-7' id='type-id-106'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-42' size-in-bits='4064' id='type-id-70'>
+      <subrange length='127' lower-bound='0' upper-bound='126' type-id='type-id-7' id='type-id-107'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-42' size-in-bits='608' id='type-id-45'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-7' id='type-id-12'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-30' size-in-bits='32' id='type-id-31'/>
+    <pointer-type-def type-id='type-id-10' size-in-bits='32' id='type-id-72'/>
+    <qualified-type-def type-id='type-id-25' const='yes' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-108' size-in-bits='32' id='type-id-36'/>
+    <qualified-type-def type-id='type-id-10' const='yes' id='type-id-109'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='32' id='type-id-35'/>
+    <pointer-type-def type-id='type-id-34' size-in-bits='32' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='32' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-18' size-in-bits='32' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-111' size-in-bits='32' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='32' id='type-id-61'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='32' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-114' size-in-bits='32' id='type-id-63'/>
+    <pointer-type-def type-id='type-id-115' size-in-bits='32' id='type-id-56'/>
+    <pointer-type-def type-id='type-id-116' size-in-bits='32' id='type-id-59'/>
+    <pointer-type-def type-id='type-id-117' size-in-bits='32' id='type-id-64'/>
+    <pointer-type-def type-id='type-id-118' size-in-bits='32' id='type-id-62'/>
+    <pointer-type-def type-id='type-id-119' size-in-bits='32' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-120' size-in-bits='32' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-121' size-in-bits='32' id='type-id-65'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='32' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='32' id='type-id-92'/>
+    <pointer-type-def type-id='type-id-94' size-in-bits='32' id='type-id-122'/>
+    <pointer-type-def type-id='type-id-71' size-in-bits='32' id='type-id-68'/>
+    <pointer-type-def type-id='type-id-96' size-in-bits='32' id='type-id-123'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='32' id='type-id-124'/>
+    <pointer-type-def type-id='type-id-42' size-in-bits='32' id='type-id-125'/>
+    <pointer-type-def type-id='type-id-126' size-in-bits='32' id='type-id-57'/>
+    <class-decl name='table_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-127'/>
+    <pointer-type-def type-id='type-id-127' size-in-bits='32' id='type-id-73'/>
+    <function-decl name='_UPT_access_fpreg' mangled-name='_UPT_access_fpreg' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UPT_access_fpreg'>
+      <parameter type-id='type-id-93' name='as'/>
+      <parameter type-id='type-id-101' name='reg'/>
+      <parameter type-id='type-id-123' name='val'/>
+      <parameter type-id='type-id-23' name='write'/>
+      <parameter type-id='type-id-40' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-128'/>
+    <pointer-type-def type-id='type-id-128' id='type-id-40'/>
+    <function-type size-in-bits='32' id='type-id-111'>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-120'>
+      <parameter type-id='type-id-98'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-112'>
+      <parameter type-id='type-id-93'/>
+      <parameter type-id='type-id-101'/>
+      <parameter type-id='type-id-123'/>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-113'>
+      <parameter type-id='type-id-93'/>
+      <parameter type-id='type-id-101'/>
+      <parameter type-id='type-id-125'/>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-114'>
+      <parameter type-id='type-id-93'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-72'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-125'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-115'>
+      <parameter type-id='type-id-93'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-124'/>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-116'>
+      <parameter type-id='type-id-93'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-125'/>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-117'>
+      <parameter type-id='type-id-93'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-125'/>
+      <parameter type-id='type-id-125'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-118'>
+      <parameter type-id='type-id-93'/>
+      <parameter type-id='type-id-122'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-119'>
+      <parameter type-id='type-id-93'/>
+      <parameter type-id='type-id-125'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-121'>
+      <parameter type-id='type-id-93'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-42'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-126'>
+      <parameter type-id='type-id-93'/>
+      <parameter type-id='type-id-124'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-128'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/ptrace/_UPT_access_mem.c' language='LANG_C99'>
+    <function-decl name='_UPT_access_mem' mangled-name='_UPT_access_mem' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UPT_access_mem'>
+      <parameter type-id='type-id-93' name='as'/>
+      <parameter type-id='type-id-42' name='addr'/>
+      <parameter type-id='type-id-125' name='val'/>
+      <parameter type-id='type-id-23' name='write'/>
+      <parameter type-id='type-id-40' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/ptrace/_UPT_access_reg.c' language='LANG_C99'>
+    <function-decl name='_UPT_access_reg' mangled-name='_UPT_access_reg' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UPT_access_reg'>
+      <parameter type-id='type-id-93' name='as'/>
+      <parameter type-id='type-id-101' name='reg'/>
+      <parameter type-id='type-id-125' name='val'/>
+      <parameter type-id='type-id-23' name='write'/>
+      <parameter type-id='type-id-40' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/ptrace/_UPT_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-55' id='type-id-129'/>
+    <var-decl name='_UPT_accessors' type-id='type-id-129' mangled-name='_UPT_accessors' visibility='default' elf-symbol-id='_UPT_accessors'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/ptrace/_UPT_create.c' language='LANG_C99'>
+    <typedef-decl name='__pid_t' type-id='type-id-23' id='type-id-130'/>
+    <typedef-decl name='pid_t' type-id='type-id-130' id='type-id-131'/>
+    <function-decl name='_UPT_create' mangled-name='_UPT_create' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UPT_create'>
+      <parameter type-id='type-id-131' name='pid'/>
+      <return type-id='type-id-40'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/ptrace/_UPT_destroy.c' language='LANG_C99'>
+    <function-decl name='_UPT_destroy' mangled-name='_UPT_destroy' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UPT_destroy'>
+      <parameter type-id='type-id-40' name='ptr'/>
+      <return type-id='type-id-128'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/ptrace/_UPT_find_proc_info.c' language='LANG_C99'>
+    <function-decl name='_UPT_find_proc_info' mangled-name='_UPT_find_proc_info' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UPT_find_proc_info'>
+      <parameter type-id='type-id-93' name='as'/>
+      <parameter type-id='type-id-42' name='ip'/>
+      <parameter type-id='type-id-124' name='pi'/>
+      <parameter type-id='type-id-23' name='need_unwind_info'/>
+      <parameter type-id='type-id-40' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/ptrace/_UPT_get_dyn_info_list_addr.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_dyn_info_list_addr' mangled-name='_UPT_get_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UPT_get_dyn_info_list_addr'>
+      <parameter type-id='type-id-93' name='as'/>
+      <parameter type-id='type-id-125' name='dil_addr'/>
+      <parameter type-id='type-id-40' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/ptrace/_UPT_get_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_elf_filename' mangled-name='_UPT_get_elf_filename' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UPT_get_elf_filename'>
+      <parameter type-id='type-id-93' name='as'/>
+      <parameter type-id='type-id-42' name='ip'/>
+      <parameter type-id='type-id-72' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-125' name='offp'/>
+      <parameter type-id='type-id-40' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/ptrace/_UPT_get_proc_name.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_proc_name' mangled-name='_UPT_get_proc_name' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UPT_get_proc_name'>
+      <parameter type-id='type-id-93' name='as'/>
+      <parameter type-id='type-id-42' name='ip'/>
+      <parameter type-id='type-id-72' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-125' name='offp'/>
+      <parameter type-id='type-id-40' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/ptrace/_UPT_put_unwind_info.c' language='LANG_C99'>
+    <function-decl name='_UPT_put_unwind_info' mangled-name='_UPT_put_unwind_info' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UPT_put_unwind_info'>
+      <parameter type-id='type-id-93' name='as'/>
+      <parameter type-id='type-id-124' name='pi'/>
+      <parameter type-id='type-id-40' name='arg'/>
+      <return type-id='type-id-128'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/ptrace/_UPT_reg_offset.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-132' size-in-bits='1952' id='type-id-133'>
+      <subrange length='61' lower-bound='0' upper-bound='60' type-id='type-id-7' id='type-id-134'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-23' const='yes' id='type-id-132'/>
+    <var-decl name='_UPT_reg_offset' type-id='type-id-133' mangled-name='_UPT_reg_offset' visibility='default' elf-symbol-id='_UPT_reg_offset'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/ptrace/_UPT_resume.c' language='LANG_C99'>
+    <function-decl name='_UPT_resume' mangled-name='_UPT_resume' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_UPT_resume'>
+      <parameter type-id='type-id-93' name='as'/>
+      <parameter type-id='type-id-122' name='c'/>
+      <parameter type-id='type-id-40' name='arg'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/x86/linux-gnu/libunwind-setjmp.abi
+++ b/src/abi/x86/linux-gnu/libunwind-setjmp.abi
@@ -1,0 +1,28 @@
+<abi-corpus version='2.2' architecture='elf-intel-80386' soname='libunwind-setjmp.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-x86.so.8'/>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_UI_longjmp_cont' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UI_siglongjmp_cont' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <abi-instr address-size='32' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='32' id='type-id-1'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-2' visibility='default' id='type-id-3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-3' id='type-id-2'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-5' id='type-id-6'/>
+    <typedef-decl name='sigset_t' type-id='type-id-2' id='type-id-5'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-7'/>
+    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-8'/>
+    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='1024' id='type-id-4'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-7' id='type-id-9'/>
+    </array-type-def>
+    <var-decl name='_UIx86_full_mask' type-id='type-id-6' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-1' visibility='default'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/x86/linux-gnu/libunwind-x86.abi
+++ b/src/abi/x86/linux-gnu/libunwind-x86.abi
@@ -1,0 +1,1203 @@
+<abi-corpus version='2.2' architecture='elf-intel-80386' soname='libunwind-x86.so.8'>
+  <elf-needed>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_Ux86_apply_reg_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_create_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_destroy_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_dwarf_find_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_dwarf_search_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_flush_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_accessors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_elf_filename_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_elf_image' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_exe_image_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_proc_info_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_proc_info_in_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_proc_name_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_save_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_init_local' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_init_local2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_init_remote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_is_signal_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_reg_states_iterate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_set_cache_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_set_caching_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_set_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_set_iterate_phdr_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_set_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_Ux86_local_addr_space' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='32' path='../../src/dwarf/Gfind_proc_info-lsb.c' language='LANG_C99'>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-1'/>
+    <class-decl name='table_entry' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-2'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip_offset' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fde_offset' type-id='type-id-3' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_info' size-in-bits='416' is-struct='yes' visibility='default' id='type-id-4'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-5' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='prev' type-id='type-id-5' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='start_ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='end_ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='gp' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='format' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pad' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='load_offset' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='u' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-8'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-6' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='160' is-struct='yes' visibility='default' id='type-id-11'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='handler' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='flags' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='pad0' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='regions' type-id='type-id-13' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-14'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='insn_count' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='op_count' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-17'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='segbase' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='table_len' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='table_data' type-id='type-id-6' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-18'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='segbase' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='table_len' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='table_data' type-id='type-id-19' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int16_t' type-id='type-id-20' id='type-id-21'/>
+    <typedef-decl name='__int32_t' type-id='type-id-22' id='type-id-23'/>
+    <typedef-decl name='__int8_t' type-id='type-id-1' id='type-id-24'/>
+    <typedef-decl name='int16_t' type-id='type-id-21' id='type-id-10'/>
+    <typedef-decl name='int32_t' type-id='type-id-23' id='type-id-3'/>
+    <typedef-decl name='int8_t' type-id='type-id-24' id='type-id-9'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-4' id='type-id-25'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-8' id='type-id-26'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-11' id='type-id-27'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-14' id='type-id-28'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-17' id='type-id-29'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-18' id='type-id-30'/>
+    <union-decl name='__anonymous_union__' size-in-bits='160' is-anonymous='yes' visibility='default' id='type-id-7'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-29' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-26' size-in-bits='96' id='type-id-16'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-31' id='type-id-32'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-4' size-in-bits='32' id='type-id-5'/>
+    <pointer-type-def type-id='type-id-25' size-in-bits='32' id='type-id-33'/>
+    <pointer-type-def type-id='type-id-14' size-in-bits='32' id='type-id-15'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='32' id='type-id-13'/>
+    <function-decl name='_Ux86_dwarf_search_unwind_table' mangled-name='_Ux86_dwarf_search_unwind_table' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_dwarf_search_unwind_table'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-33' name='di'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <parameter type-id='type-id-22' name='need_unwind_info'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-type size-in-bits='32' id='type-id-37'>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-40'>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/dwarf/Gfind_unwind_table.c' language='LANG_C99'>
+    <class-decl name='elf_dyn_info' size-in-bits='896' is-struct='yes' visibility='default' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='di_cache' type-id='type-id-25' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='di_debug' type-id='type-id-25' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-42' size-in-bits='32' id='type-id-44'/>
+    <function-decl name='_Ux86_dwarf_find_unwind_table' mangled-name='_Ux86_dwarf_find_unwind_table' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_dwarf_find_unwind_table'>
+      <parameter type-id='type-id-44' name='edi'/>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-45' name='path'/>
+      <parameter type-id='type-id-6' name='segbase'/>
+      <parameter type-id='type-id-6' name='mapoff'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/dwarf/Gget_proc_info_in_range.c' language='LANG_C99'>
+    <function-decl name='_Ux86_get_proc_info_in_range' mangled-name='_Ux86_get_proc_info_in_range' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_proc_info_in_range'>
+      <parameter type-id='type-id-6' name='start_ip'/>
+      <parameter type-id='type-id-6' name='end_ip'/>
+      <parameter type-id='type-id-6' name='eh_frame_table'/>
+      <parameter type-id='type-id-6' name='eh_frame_table_len'/>
+      <parameter type-id='type-id-6' name='exidx_frame_table'/>
+      <parameter type-id='type-id-6' name='exidx_frame_table_len'/>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <parameter type-id='type-id-22' name='need_unwind_info'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/dwarf/global.c' language='LANG_C99'>
+    <class-decl name='mempool' size-in-bits='352' is-struct='yes' visibility='default' id='type-id-46'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='obj_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='chunk_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='reserve' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='num_free' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='free_list' type-id='type-id-48' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='object' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-49'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-48' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-49' size-in-bits='32' id='type-id-48'/>
+    <var-decl name='dwarf_reg_state_pool' type-id='type-id-46' visibility='default'/>
+    <var-decl name='dwarf_cie_info_pool' type-id='type-id-46' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Gdestroy_addr_space.c' language='LANG_C99'>
+    <function-decl name='_Ux86_destroy_addr_space' mangled-name='_Ux86_destroy_addr_space' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_destroy_addr_space'>
+      <parameter type-id='type-id-34' name='as'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Gget_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-51' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-52' size-in-bits='32' id='type-id-53'/>
+    <function-decl name='_Ux86_get_accessors' mangled-name='_Ux86_get_accessors' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_accessors'>
+      <parameter type-id='type-id-34' name='as'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Gget_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_Ux86_get_elf_filename_by_ip' mangled-name='_Ux86_get_elf_filename_by_ip' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_elf_filename_by_ip'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-19' name='offp'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Ux86_get_elf_filename' mangled-name='_Ux86_get_elf_filename' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_elf_filename'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-19' name='offp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Gget_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_get_fpreg' mangled-name='_Ux86_get_fpreg' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_fpreg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-56' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Gget_proc_info_by_ip.c' language='LANG_C99'>
+    <function-decl name='_Ux86_get_proc_info_by_ip' mangled-name='_Ux86_get_proc_info_by_ip' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_proc_info_by_ip'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <parameter type-id='type-id-36' name='as_arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Gget_proc_name.c' language='LANG_C99'>
+    <function-decl name='_Ux86_get_proc_name_by_ip' mangled-name='_Ux86_get_proc_name_by_ip' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_proc_name_by_ip'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-19' name='offp'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Ux86_get_proc_name' mangled-name='_Ux86_get_proc_name' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_proc_name'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-19' name='offp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Gget_reg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_get_reg' mangled-name='_Ux86_get_reg' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_reg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-19' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Gset_cache_size.c' language='LANG_C99'>
+    <function-decl name='_Ux86_set_cache_size' mangled-name='_Ux86_set_cache_size' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_set_cache_size'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-39' name='size'/>
+      <parameter type-id='type-id-22' name='flag'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Gset_caching_policy.c' language='LANG_C99'>
+    <function-decl name='_Ux86_set_caching_policy' mangled-name='_Ux86_set_caching_policy' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_set_caching_policy'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-57' name='policy'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Gset_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_set_fpreg' mangled-name='_Ux86_set_fpreg' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_set_fpreg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-58' name='val'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Gset_iterate_phdr_function.c' language='LANG_C99'>
+    <function-decl name='_Ux86_set_iterate_phdr_function' mangled-name='_Ux86_set_iterate_phdr_function' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_set_iterate_phdr_function'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-59' name='function'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Gset_reg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_set_reg' mangled-name='_Ux86_set_reg' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_set_reg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-6' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/flush_cache.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='152' id='type-id-61'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-31' id='type-id-62'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='192' id='type-id-63'>
+      <subrange length='24' lower-bound='0' upper-bound='23' type-id='type-id-31' id='type-id-64'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-65' size-in-bits='12288' id='type-id-66'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-31' id='type-id-67'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-68' size-in-bits='102400' id='type-id-69'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-31' id='type-id-67'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-57' id='type-id-70'>
+      <underlying-type type-id='type-id-71'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='short int' size-in-bits='16' id='type-id-20'/>
+    <class-decl name='Elf32_Phdr' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-72' visibility='default' id='type-id-73'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_offset' type-id='type-id-75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_vaddr' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='p_paddr' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_filesz' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='p_memsz' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_flags' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='p_align' type-id='type-id-74' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_slist' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-77'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__next' type-id='type-id-78' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-79'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__kind' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__nusers' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='' type-id='type-id-80' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-81'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='dlpi_name' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_phdr' type-id='type-id-82' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='dlpi_phnum' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_adds' type-id='type-id-84' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_subs' type-id='type-id-84' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-36' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-85'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='coll_chain' type-id='type-id-86' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='hint' type-id='type-id-86' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='valid' type-id='type-id-86' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='65'>
+        <var-decl name='signal_frame' type-id='type-id-86' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='768' is-struct='yes' visibility='default' id='type-id-87'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='val' type-id='type-id-88' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='800' is-struct='yes' visibility='default' id='type-id-89'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='reg' type-id='type-id-90' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='119168' is-struct='yes' visibility='default' id='type-id-91'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='rr_head' type-id='type-id-86' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='208'>
+        <var-decl name='log_size' type-id='type-id-86' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='prev_log_size' type-id='type-id-86' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='hash' type-id='type-id-92' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='generation' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='buckets' type-id='type-id-93' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='links' type-id='type-id-94' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='default_hash' type-id='type-id-95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4480'>
+        <var-decl name='default_buckets' type-id='type-id-69' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='106880'>
+        <var-decl name='default_links' type-id='type-id-66' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='352' is-struct='yes' visibility='default' id='type-id-51'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-96' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='put_unwind_info' type-id='type-id-97' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-98' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='access_mem' type-id='type-id-99' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='access_reg' type-id='type-id-100' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='access_fpreg' type-id='type-id-101' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='resume' type-id='type-id-102' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='get_proc_name' type-id='type-id-103' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='get_elf_filename' type-id='type-id-103' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-105' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='119712' is-struct='yes' visibility='default' id='type-id-106'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='caching_policy' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='cache_generation' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dyn_generation' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='global_cache' type-id='type-id-91' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='119680'>
+        <var-decl name='debug_frames' type-id='type-id-107' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='4064' is-struct='yes' visibility='default' id='type-id-108'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-109' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-110'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='end' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='load_offset' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='debug_frame' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='debug_frame_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='index' type-id='type-id-111' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='index_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='next' type-id='type-id-107' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-112'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='end_ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='lsda' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='handler' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='gp' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='flags' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='format' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='unwind_info_size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='unwind_info' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='extra' type-id='type-id-113' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-113' visibility='default' id='type-id-114'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-115' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__3' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-116'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__espins' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='__eelision' type-id='type-id-20' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__1' size-in-bits='80' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-117'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='b' type-id='type-id-118' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__2' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-119'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='b' type-id='type-id-120' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-121'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='b' type-id='type-id-122' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf32_Addr' type-id='type-id-12' id='type-id-76'/>
+    <typedef-decl name='Elf32_Half' type-id='type-id-123' id='type-id-83'/>
+    <typedef-decl name='Elf32_Off' type-id='type-id-12' id='type-id-75'/>
+    <typedef-decl name='Elf32_Phdr' type-id='type-id-73' id='type-id-72'/>
+    <typedef-decl name='Elf32_Word' type-id='type-id-12' id='type-id-74'/>
+    <typedef-decl name='__pthread_slist_t' type-id='type-id-77' id='type-id-124'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-86' id='type-id-125'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-126' id='type-id-127'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-85' id='type-id-65'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-87' id='type-id-90'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-89' id='type-id-68'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-128' id='type-id-47'/>
+    <typedef-decl name='uint16_t' type-id='type-id-125' id='type-id-123'/>
+    <typedef-decl name='uint8_t' type-id='type-id-127' id='type-id-115'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-129' id='type-id-34'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-70' id='type-id-57'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-108' id='type-id-130'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-131' id='type-id-58'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-132' id='type-id-41'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-133' id='type-id-59'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-112' id='type-id-134'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-22' id='type-id-135'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-136' id='type-id-131'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-114' id='type-id-113'/>
+    <array-type-def dimensions='1' type-id='type-id-115' size-in-bits='80' id='type-id-118'>
+      <subrange length='10' lower-bound='0' upper-bound='9' type-id='type-id-31' id='type-id-137'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-115' size-in-bits='128' id='type-id-120'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-31' id='type-id-138'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-115' size-in-bits='32' id='type-id-122'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-31' id='type-id-139'/>
+    </array-type-def>
+    <union-decl name='pthread_mutex_t' size-in-bits='192' naming-typedef-id='type-id-47' visibility='default' id='type-id-128'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-79' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-140' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='unw_tdep_fpreg_t' size-in-bits='128' naming-typedef-id='type-id-131' visibility='default' id='type-id-136'>
+      <data-member access='public'>
+        <var-decl name='val32' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='val80' type-id='type-id-117' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='val128' type-id='type-id-119' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__1' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-80'>
+      <data-member access='public'>
+        <var-decl name='__elision_data' type-id='type-id-116' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__list' type-id='type-id-124' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-71'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-126'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-84'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-86'/>
+    <array-type-def dimensions='1' type-id='type-id-86' size-in-bits='4096' id='type-id-95'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-31' id='type-id-141'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='4064' id='type-id-109'>
+      <subrange length='127' lower-bound='0' upper-bound='126' type-id='type-id-31' id='type-id-142'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='608' id='type-id-88'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-31' id='type-id-62'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-77' size-in-bits='32' id='type-id-78'/>
+    <qualified-type-def type-id='type-id-72' const='yes' id='type-id-143'/>
+    <pointer-type-def type-id='type-id-143' size-in-bits='32' id='type-id-82'/>
+    <qualified-type-def type-id='type-id-60' const='yes' id='type-id-144'/>
+    <pointer-type-def type-id='type-id-144' size-in-bits='32' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-81' size-in-bits='32' id='type-id-38'/>
+    <pointer-type-def type-id='type-id-65' size-in-bits='32' id='type-id-94'/>
+    <pointer-type-def type-id='type-id-68' size-in-bits='32' id='type-id-93'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='32' id='type-id-132'/>
+    <pointer-type-def type-id='type-id-145' size-in-bits='32' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-146' size-in-bits='32' id='type-id-100'/>
+    <pointer-type-def type-id='type-id-147' size-in-bits='32' id='type-id-103'/>
+    <pointer-type-def type-id='type-id-148' size-in-bits='32' id='type-id-96'/>
+    <pointer-type-def type-id='type-id-149' size-in-bits='32' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-150' size-in-bits='32' id='type-id-104'/>
+    <pointer-type-def type-id='type-id-151' size-in-bits='32' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-152' size-in-bits='32' id='type-id-98'/>
+    <pointer-type-def type-id='type-id-40' size-in-bits='32' id='type-id-133'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='32' id='type-id-111'/>
+    <pointer-type-def type-id='type-id-153' size-in-bits='32' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-86' size-in-bits='32' id='type-id-92'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='32' id='type-id-129'/>
+    <pointer-type-def type-id='type-id-130' size-in-bits='32' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='32' id='type-id-107'/>
+    <pointer-type-def type-id='type-id-58' size-in-bits='32' id='type-id-56'/>
+    <pointer-type-def type-id='type-id-134' size-in-bits='32' id='type-id-35'/>
+    <pointer-type-def type-id='type-id-6' size-in-bits='32' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-154' size-in-bits='32' id='type-id-97'/>
+    <function-decl name='_Ux86_flush_cache' mangled-name='_Ux86_flush_cache' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_flush_cache'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='lo'/>
+      <parameter type-id='type-id-6' name='hi'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+    <function-type size-in-bits='32' id='type-id-145'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-135'/>
+      <parameter type-id='type-id-56'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-146'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-135'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-147'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-54'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-148'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-149'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-150'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-151'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-55'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-152'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-153'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-6'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-154'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-50'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='32' id='type-id-140'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-155' visibility='default' id='type-id-156'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-157' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-156' id='type-id-155'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-158' id='type-id-159'/>
+    <typedef-decl name='sigset_t' type-id='type-id-155' id='type-id-158'/>
+    <array-type-def dimensions='1' type-id='type-id-160' size-in-bits='1024' id='type-id-157'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-31' id='type-id-161'/>
+    </array-type-def>
+    <var-decl name='_UIx86_full_mask' type-id='type-id-159' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-140' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/strerror.c' language='LANG_C99'>
+    <function-decl name='_Ux86_strerror' mangled-name='_Ux86_strerror' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_strerror'>
+      <parameter type-id='type-id-22' name='err_code'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/os-linux.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-60'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
+    <class-decl name='elf_image' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pid_t' type-id='type-id-22' id='type-id-162'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-31' id='type-id-163'/>
+    <typedef-decl name='pid_t' type-id='type-id-162' id='type-id-164'/>
+    <typedef-decl name='size_t' type-id='type-id-31' id='type-id-39'/>
+    <typedef-decl name='uint32_t' type-id='type-id-163' id='type-id-12'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-12' id='type-id-6'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-31'/>
+    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-160'/>
+    <pointer-type-def type-id='type-id-60' size-in-bits='32' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='32' id='type-id-165'/>
+    <pointer-type-def type-id='type-id-160' size-in-bits='32' id='type-id-166'/>
+    <function-decl name='_Ux86_get_elf_image' mangled-name='_Ux86_get_elf_image' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_elf_image'>
+      <parameter type-id='type-id-165' name='ei'/>
+      <parameter type-id='type-id-164' name='pid'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-166' name='segbase'/>
+      <parameter type-id='type-id-166' name='mapoff'/>
+      <parameter type-id='type-id-54' name='path'/>
+      <parameter type-id='type-id-39' name='pathlen'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Ux86_get_exe_image_path' mangled-name='_Ux86_get_exe_image_path' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_exe_image_path'>
+      <parameter type-id='type-id-54' name='path'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-50' id='type-id-36'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Gapply_reg_state.c' language='LANG_C99'>
+    <function-decl name='_Ux86_apply_reg_state' mangled-name='_Ux86_apply_reg_state' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_apply_reg_state'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-36' name='reg_states_data'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Gcreate_addr_space.c' language='LANG_C99'>
+    <function-decl name='_Ux86_create_addr_space' mangled-name='_Ux86_create_addr_space' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_create_addr_space'>
+      <parameter type-id='type-id-53' name='a'/>
+      <parameter type-id='type-id-22' name='byte_order'/>
+      <return type-id='type-id-34'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Gget_proc_info.c' language='LANG_C99'>
+    <function-decl name='_Ux86_get_proc_info' mangled-name='_Ux86_get_proc_info' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_proc_info'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Gget_save_loc.c' language='LANG_C99'>
+    <enum-decl name='unw_save_loc_type' id='type-id-167'>
+      <underlying-type type-id='type-id-71'/>
+      <enumerator name='UNW_SLT_NONE' value='0'/>
+      <enumerator name='UNW_SLT_MEMORY' value='1'/>
+      <enumerator name='UNW_SLT_REG' value='2'/>
+    </enum-decl>
+    <class-decl name='unw_save_loc' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-168'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-169' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='u' type-id='type-id-170' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='extra' type-id='type-id-171' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_save_loc' size-in-bits='8' is-struct='yes' visibility='default' id='type-id-172'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-115' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_save_loc_t' type-id='type-id-168' id='type-id-173'/>
+    <typedef-decl name='unw_save_loc_type_t' type-id='type-id-167' id='type-id-169'/>
+    <typedef-decl name='unw_tdep_save_loc_t' type-id='type-id-172' id='type-id-171'/>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-170'>
+      <data-member access='public'>
+        <var-decl name='addr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='regnum' type-id='type-id-135' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-173' size-in-bits='32' id='type-id-174'/>
+    <function-decl name='_Ux86_get_save_loc' mangled-name='_Ux86_get_save_loc' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_save_loc'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='reg'/>
+      <parameter type-id='type-id-174' name='sloc'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Gglobal.c' language='LANG_C99'>
+    <type-decl name='atomic_bool' size-in-bits='8' id='type-id-175'/>
+    <array-type-def dimensions='1' type-id='type-id-176' size-in-bits='152' id='type-id-177'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-31' id='type-id-62'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-115' const='yes' id='type-id-176'/>
+    <var-decl name='_Ux86_dwarf_to_unw_regnum_map' type-id='type-id-177' visibility='default'/>
+    <var-decl name='_Ux86_init_done' type-id='type-id-175' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Ginit.c' language='LANG_C99'>
+    <var-decl name='_Ux86_local_addr_space' type-id='type-id-34' mangled-name='_Ux86_local_addr_space' visibility='default' elf-symbol-id='_Ux86_local_addr_space'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Ginit_local.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-178' size-in-bits='640' id='type-id-179'>
+      <subrange length='8' lower-bound='0' upper-bound='7' type-id='type-id-31' id='type-id-180'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-181' size-in-bits='608' id='type-id-182'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-31' id='type-id-62'/>
+    </array-type-def>
+    <class-decl name='_libc_fpreg' size-in-bits='80' is-struct='yes' visibility='default' id='type-id-178'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='significand' type-id='type-id-183' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='exponent' type-id='type-id-86' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_libc_fpstate' size-in-bits='896' is-struct='yes' visibility='default' id='type-id-184'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cw' type-id='type-id-160' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='sw' type-id='type-id-160' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tag' type-id='type-id-160' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='ipoff' type-id='type-id-160' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='cssel' type-id='type-id-160' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='dataoff' type-id='type-id-160' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='datasel' type-id='type-id-160' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='_st' type-id='type-id-179' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='status' type-id='type-id-160' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='mcontext_t' size-in-bits='704' is-struct='yes' naming-typedef-id='type-id-185' visibility='default' id='type-id-186'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gregs' type-id='type-id-187' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='fpregs' type-id='type-id-188' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='oldmask' type-id='type-id-160' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='cr2' type-id='type-id-160' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='stack_t' size-in-bits='96' is-struct='yes' naming-typedef-id='type-id-189' visibility='default' id='type-id-190'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ss_sp' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='ss_flags' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ss_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucontext_t' size-in-bits='2912' is-struct='yes' visibility='default' id='type-id-191'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uc_flags' type-id='type-id-160' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='uc_link' type-id='type-id-192' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uc_stack' type-id='type-id-189' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='uc_mcontext' type-id='type-id-185' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='uc_sigmask' type-id='type-id-158' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1888'>
+        <var-decl name='__fpregs_mem' type-id='type-id-184' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2784'>
+        <var-decl name='__ssp' type-id='type-id-193' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='fpregset_t' type-id='type-id-194' id='type-id-188'/>
+    <typedef-decl name='greg_t' type-id='type-id-22' id='type-id-181'/>
+    <typedef-decl name='gregset_t' type-id='type-id-182' id='type-id-187'/>
+    <typedef-decl name='mcontext_t' type-id='type-id-186' id='type-id-185'/>
+    <typedef-decl name='stack_t' type-id='type-id-190' id='type-id-189'/>
+    <typedef-decl name='ucontext_t' type-id='type-id-191' id='type-id-195'/>
+    <array-type-def dimensions='1' type-id='type-id-160' size-in-bits='128' id='type-id-193'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-31' id='type-id-139'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-86' size-in-bits='64' id='type-id-183'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-31' id='type-id-139'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-184' size-in-bits='32' id='type-id-194'/>
+    <pointer-type-def type-id='type-id-191' size-in-bits='32' id='type-id-192'/>
+    <pointer-type-def type-id='type-id-195' size-in-bits='32' id='type-id-196'/>
+    <function-decl name='_Ux86_init_local' mangled-name='_Ux86_init_local' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_init_local'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-196' name='uc'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Ux86_init_local2' mangled-name='_Ux86_init_local2' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_init_local2'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-196' name='uc'/>
+      <parameter type-id='type-id-22' name='flag'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Ginit_remote.c' language='LANG_C99'>
+    <function-decl name='_Ux86_init_remote' mangled-name='_Ux86_init_remote' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_init_remote'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-36' name='as_arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Gos-linux.c' language='LANG_C99'>
+    <function-decl name='_Ux86_is_signal_frame' mangled-name='_Ux86_is_signal_frame' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_is_signal_frame'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Greg_states_iterate.c' language='LANG_C99'>
+    <typedef-decl name='unw_reg_states_callback' type-id='type-id-197' id='type-id-198'/>
+    <pointer-type-def type-id='type-id-199' size-in-bits='32' id='type-id-197'/>
+    <function-decl name='_Ux86_reg_states_iterate' mangled-name='_Ux86_reg_states_iterate' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_reg_states_iterate'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-198' name='cb'/>
+      <parameter type-id='type-id-36' name='token'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-type size-in-bits='32' id='type-id-199'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Gresume.c' language='LANG_C99'>
+    <function-decl name='_Ux86_resume' mangled-name='_Ux86_resume' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_resume'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Gstep.c' language='LANG_C99'>
+    <function-decl name='_Ux86_step' mangled-name='_Ux86_step' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_step'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/is_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_is_fpreg' mangled-name='_Ux86_is_fpreg' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_is_fpreg'>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/regname.c' language='LANG_C99'>
+    <function-decl name='_Ux86_regname' mangled-name='_Ux86_regname' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_regname'>
+      <parameter type-id='type-id-135' name='reg'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/x86/linux-gnu/libunwind.abi
+++ b/src/abi/x86/linux-gnu/libunwind.abi
@@ -1,0 +1,1259 @@
+<abi-corpus version='2.2' architecture='elf-intel-80386' soname='libunwind.so.8'>
+  <elf-needed>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_ULx86_apply_reg_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_create_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_destroy_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_dwarf_find_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_dwarf_search_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_get_elf_filename_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_get_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_get_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_get_proc_info_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_get_proc_info_in_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_get_proc_name_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_get_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_get_save_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_init_local' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_init_local2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_init_remote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_is_signal_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_reg_states_iterate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_set_cache_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_set_caching_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_set_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_set_iterate_phdr_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_set_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_cancel' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_register' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_flush_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_accessors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_elf_image' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_get_exe_image_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_getcontext' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='backtrace' type='func-type' binding='weak-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_backtrace' type='func-type' binding='global-binding' visibility='default-visibility' alias='backtrace' is-defined='yes'/>
+    <elf-symbol name='unw_backtrace2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_ULx86_local_addr_space' size='4' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='32' path='../../src/dwarf/Lfind_proc_info-lsb.c' language='LANG_C99'>
+    <class-decl name='table_entry' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-1'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip_offset' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fde_offset' type-id='type-id-2' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <function-decl name='_ULx86_dwarf_search_unwind_table' mangled-name='_ULx86_dwarf_search_unwind_table' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_dwarf_search_unwind_table'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-5' name='di'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-7' name='need_unwind_info'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-type size-in-bits='32' id='type-id-9'>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-12'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/dwarf/Lfind_unwind_table.c' language='LANG_C99'>
+    <class-decl name='elf_dyn_info' size-in-bits='896' is-struct='yes' visibility='default' id='type-id-14'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='di_cache' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='di_debug' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-14' size-in-bits='32' id='type-id-17'/>
+    <function-decl name='_ULx86_dwarf_find_unwind_table' mangled-name='_ULx86_dwarf_find_unwind_table' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_dwarf_find_unwind_table'>
+      <parameter type-id='type-id-17' name='edi'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-18' name='path'/>
+      <parameter type-id='type-id-4' name='segbase'/>
+      <parameter type-id='type-id-4' name='mapoff'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/dwarf/Lget_proc_info_in_range.c' language='LANG_C99'>
+    <function-decl name='_ULx86_get_proc_info_in_range' mangled-name='_ULx86_get_proc_info_in_range' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_get_proc_info_in_range'>
+      <parameter type-id='type-id-4' name='start_ip'/>
+      <parameter type-id='type-id-4' name='end_ip'/>
+      <parameter type-id='type-id-4' name='eh_frame_table'/>
+      <parameter type-id='type-id-4' name='eh_frame_table_len'/>
+      <parameter type-id='type-id-4' name='exidx_frame_table'/>
+      <parameter type-id='type-id-4' name='exidx_frame_table_len'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-7' name='need_unwind_info'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/dwarf/global.c' language='LANG_C99'>
+    <class-decl name='mempool' size-in-bits='352' is-struct='yes' visibility='default' id='type-id-19'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='obj_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='chunk_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='reserve' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='num_free' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='free_list' type-id='type-id-21' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='object' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-22'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-21' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-22' size-in-bits='32' id='type-id-21'/>
+    <var-decl name='dwarf_reg_state_pool' type-id='type-id-19' visibility='default'/>
+    <var-decl name='dwarf_cie_info_pool' type-id='type-id-19' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Ldestroy_addr_space.c' language='LANG_C99'>
+    <function-decl name='_ULx86_destroy_addr_space' mangled-name='_ULx86_destroy_addr_space' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_destroy_addr_space'>
+      <parameter type-id='type-id-3' name='as'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Lget_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-24' id='type-id-25'/>
+    <pointer-type-def type-id='type-id-25' size-in-bits='32' id='type-id-26'/>
+    <function-decl name='_Ux86_get_accessors' mangled-name='_Ux86_get_accessors' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_accessors'>
+      <parameter type-id='type-id-3' name='as'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Lget_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_ULx86_get_elf_filename_by_ip' mangled-name='_ULx86_get_elf_filename_by_ip' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_get_elf_filename_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULx86_get_elf_filename' mangled-name='_ULx86_get_elf_filename' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_get_elf_filename'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Lget_fpreg.c' language='LANG_C99'>
+    <function-decl name='_ULx86_get_fpreg' mangled-name='_ULx86_get_fpreg' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_get_fpreg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-30' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Lget_proc_info_by_ip.c' language='LANG_C99'>
+    <function-decl name='_ULx86_get_proc_info_by_ip' mangled-name='_ULx86_get_proc_info_by_ip' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_get_proc_info_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-8' name='as_arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Lget_proc_name.c' language='LANG_C99'>
+    <function-decl name='_ULx86_get_proc_name_by_ip' mangled-name='_ULx86_get_proc_name_by_ip' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_get_proc_name_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULx86_get_proc_name' mangled-name='_ULx86_get_proc_name' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_get_proc_name'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Lget_reg.c' language='LANG_C99'>
+    <function-decl name='_ULx86_get_reg' mangled-name='_ULx86_get_reg' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_get_reg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-28' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Lset_cache_size.c' language='LANG_C99'>
+    <function-decl name='_ULx86_set_cache_size' mangled-name='_ULx86_set_cache_size' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_set_cache_size'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-11' name='size'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Lset_caching_policy.c' language='LANG_C99'>
+    <function-decl name='_ULx86_set_caching_policy' mangled-name='_ULx86_set_caching_policy' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_set_caching_policy'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-31' name='policy'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Lset_fpreg.c' language='LANG_C99'>
+    <function-decl name='_ULx86_set_fpreg' mangled-name='_ULx86_set_fpreg' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_set_fpreg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-32' name='val'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Lset_iterate_phdr_function.c' language='LANG_C99'>
+    <function-decl name='_ULx86_set_iterate_phdr_function' mangled-name='_ULx86_set_iterate_phdr_function' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_set_iterate_phdr_function'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-33' name='function'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/Lset_reg.c' language='LANG_C99'>
+    <function-decl name='_ULx86_set_reg' mangled-name='_ULx86_set_reg' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_set_reg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-4' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/backtrace.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-34' size-in-bits='640' id='type-id-35'>
+      <subrange length='8' lower-bound='0' upper-bound='7' type-id='type-id-36' id='type-id-37'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='608' id='type-id-39'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-36' id='type-id-40'/>
+    </array-type-def>
+    <class-decl name='_libc_fpreg' size-in-bits='80' is-struct='yes' visibility='default' id='type-id-34'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='significand' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='exponent' type-id='type-id-42' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_libc_fpstate' size-in-bits='896' is-struct='yes' visibility='default' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cw' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='sw' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tag' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='ipoff' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='cssel' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='dataoff' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='datasel' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='_st' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='status' type-id='type-id-44' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='mcontext_t' size-in-bits='704' is-struct='yes' naming-typedef-id='type-id-45' visibility='default' id='type-id-46'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gregs' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='fpregs' type-id='type-id-48' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='oldmask' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='cr2' type-id='type-id-44' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='stack_t' size-in-bits='96' is-struct='yes' naming-typedef-id='type-id-49' visibility='default' id='type-id-50'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ss_sp' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='ss_flags' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ss_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucontext_t' size-in-bits='2912' is-struct='yes' visibility='default' id='type-id-51'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uc_flags' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='uc_link' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uc_stack' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='uc_mcontext' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='uc_sigmask' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1888'>
+        <var-decl name='__fpregs_mem' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2784'>
+        <var-decl name='__ssp' type-id='type-id-54' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='fpregset_t' type-id='type-id-55' id='type-id-48'/>
+    <typedef-decl name='greg_t' type-id='type-id-7' id='type-id-38'/>
+    <typedef-decl name='gregset_t' type-id='type-id-39' id='type-id-47'/>
+    <typedef-decl name='mcontext_t' type-id='type-id-46' id='type-id-45'/>
+    <typedef-decl name='stack_t' type-id='type-id-50' id='type-id-49'/>
+    <typedef-decl name='ucontext_t' type-id='type-id-51' id='type-id-56'/>
+    <typedef-decl name='unw_context_t' type-id='type-id-57' id='type-id-58'/>
+    <typedef-decl name='unw_tdep_context_t' type-id='type-id-56' id='type-id-57'/>
+    <array-type-def dimensions='1' type-id='type-id-44' size-in-bits='128' id='type-id-54'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-36' id='type-id-59'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-42' size-in-bits='64' id='type-id-41'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-36' id='type-id-59'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-43' size-in-bits='32' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-51' size-in-bits='32' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-58' size-in-bits='32' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='32' id='type-id-61'/>
+    <function-decl name='unw_backtrace' mangled-name='unw_backtrace' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='unw_backtrace'>
+      <parameter type-id='type-id-61' name='buffer'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='unw_backtrace2' mangled-name='unw_backtrace2' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='unw_backtrace2'>
+      <parameter type-id='type-id-61' name='buffer'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <parameter type-id='type-id-60' name='uc2'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/dyn-cancel.c' language='LANG_C99'>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-62'/>
+    <class-decl name='unw_dyn_info' size-in-bits='416' is-struct='yes' visibility='default' id='type-id-63'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='prev' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='start_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='end_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='gp' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='format' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pad' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='load_offset' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='u' type-id='type-id-65' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-66'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-67' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-67' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='160' is-struct='yes' visibility='default' id='type-id-69'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='handler' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='flags' type-id='type-id-70' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='pad0' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='regions' type-id='type-id-71' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-72'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-73' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='insn_count' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='op_count' type-id='type-id-70' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op' type-id='type-id-74' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-75'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='segbase' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='table_len' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='table_data' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-76'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='segbase' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='table_len' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='table_data' type-id='type-id-28' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int16_t' type-id='type-id-77' id='type-id-78'/>
+    <typedef-decl name='__int32_t' type-id='type-id-7' id='type-id-79'/>
+    <typedef-decl name='__int8_t' type-id='type-id-62' id='type-id-80'/>
+    <typedef-decl name='int16_t' type-id='type-id-78' id='type-id-68'/>
+    <typedef-decl name='int32_t' type-id='type-id-79' id='type-id-2'/>
+    <typedef-decl name='int8_t' type-id='type-id-80' id='type-id-67'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-63' id='type-id-16'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-66' id='type-id-81'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-69' id='type-id-82'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-72' id='type-id-83'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-75' id='type-id-84'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-76' id='type-id-85'/>
+    <union-decl name='__anonymous_union__' size-in-bits='160' is-anonymous='yes' visibility='default' id='type-id-65'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-82' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-85' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-84' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-81' size-in-bits='96' id='type-id-74'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-36' id='type-id-86'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-63' size-in-bits='32' id='type-id-64'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='32' id='type-id-5'/>
+    <pointer-type-def type-id='type-id-72' size-in-bits='32' id='type-id-73'/>
+    <pointer-type-def type-id='type-id-83' size-in-bits='32' id='type-id-71'/>
+    <function-decl name='_U_dyn_cancel' mangled-name='_U_dyn_cancel' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_U_dyn_cancel'>
+      <parameter type-id='type-id-5' name='di'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/dyn-info-list.c' language='LANG_C99'>
+    <class-decl name='unw_dyn_info_list' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-87'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='version' type-id='type-id-70' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='generation' type-id='type-id-70' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='first' type-id='type-id-5' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_dyn_info_list_t' type-id='type-id-87' id='type-id-88'/>
+    <var-decl name='_U_dyn_info_list' type-id='type-id-88' visibility='default'/>
+    <function-decl name='_U_dyn_info_list_addr' mangled-name='_U_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_U_dyn_info_list_addr'>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/dyn-register.c' language='LANG_C99'>
+    <var-decl name='_U_dyn_info_list_lock' type-id='type-id-20' visibility='default'/>
+    <function-decl name='_U_dyn_register' mangled-name='_U_dyn_register' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_U_dyn_register'>
+      <parameter type-id='type-id-5' name='di'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/flush_cache.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-89' size-in-bits='152' id='type-id-90'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-36' id='type-id-40'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-89' size-in-bits='192' id='type-id-91'>
+      <subrange length='24' lower-bound='0' upper-bound='23' type-id='type-id-36' id='type-id-92'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-93' size-in-bits='12288' id='type-id-94'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-36' id='type-id-95'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-96' size-in-bits='102400' id='type-id-97'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-36' id='type-id-95'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-31' id='type-id-98'>
+      <underlying-type type-id='type-id-99'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='short int' size-in-bits='16' id='type-id-77'/>
+    <class-decl name='Elf32_Phdr' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-100' visibility='default' id='type-id-101'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-102' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_offset' type-id='type-id-103' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_vaddr' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='p_paddr' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_filesz' type-id='type-id-102' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='p_memsz' type-id='type-id-102' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_flags' type-id='type-id-102' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='p_align' type-id='type-id-102' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_slist' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-105'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__next' type-id='type-id-106' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-107'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__kind' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__nusers' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='' type-id='type-id-108' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-109'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='dlpi_name' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_phdr' type-id='type-id-110' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='dlpi_phnum' type-id='type-id-111' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_adds' type-id='type-id-112' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_subs' type-id='type-id-112' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-113'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='coll_chain' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='hint' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='valid' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='65'>
+        <var-decl name='signal_frame' type-id='type-id-42' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='768' is-struct='yes' visibility='default' id='type-id-114'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-90' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='val' type-id='type-id-115' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='800' is-struct='yes' visibility='default' id='type-id-116'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='reg' type-id='type-id-117' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='119168' is-struct='yes' visibility='default' id='type-id-118'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='rr_head' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='208'>
+        <var-decl name='log_size' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='prev_log_size' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='hash' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='generation' type-id='type-id-70' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='buckets' type-id='type-id-120' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='links' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='default_hash' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4480'>
+        <var-decl name='default_buckets' type-id='type-id-97' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='106880'>
+        <var-decl name='default_links' type-id='type-id-94' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='352' is-struct='yes' visibility='default' id='type-id-24'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-123' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='put_unwind_info' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-125' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='access_mem' type-id='type-id-126' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='access_reg' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='access_fpreg' type-id='type-id-128' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='resume' type-id='type-id-129' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='get_proc_name' type-id='type-id-130' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='get_elf_filename' type-id='type-id-130' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-132' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='119712' is-struct='yes' visibility='default' id='type-id-133'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='caching_policy' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='cache_generation' type-id='type-id-70' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dyn_generation' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='global_cache' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='119680'>
+        <var-decl name='debug_frames' type-id='type-id-134' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='4064' is-struct='yes' visibility='default' id='type-id-135'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-136' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-137'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='end' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='load_offset' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='debug_frame' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='debug_frame_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='index' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='index_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='next' type-id='type-id-134' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-139'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='end_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='lsda' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='handler' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='gp' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='flags' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='format' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='unwind_info_size' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='unwind_info' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='extra' type-id='type-id-140' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-140' visibility='default' id='type-id-141'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-142' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__3' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-143'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__espins' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='__eelision' type-id='type-id-77' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__1' size-in-bits='80' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-144'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='b' type-id='type-id-145' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__2' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-146'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='b' type-id='type-id-147' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-148'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='b' type-id='type-id-149' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf32_Addr' type-id='type-id-70' id='type-id-104'/>
+    <typedef-decl name='Elf32_Half' type-id='type-id-150' id='type-id-111'/>
+    <typedef-decl name='Elf32_Off' type-id='type-id-70' id='type-id-103'/>
+    <typedef-decl name='Elf32_Phdr' type-id='type-id-101' id='type-id-100'/>
+    <typedef-decl name='Elf32_Word' type-id='type-id-70' id='type-id-102'/>
+    <typedef-decl name='__pthread_slist_t' type-id='type-id-105' id='type-id-151'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-42' id='type-id-152'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-153' id='type-id-154'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-113' id='type-id-93'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-114' id='type-id-117'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-116' id='type-id-96'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-155' id='type-id-20'/>
+    <typedef-decl name='uint16_t' type-id='type-id-152' id='type-id-150'/>
+    <typedef-decl name='uint8_t' type-id='type-id-154' id='type-id-142'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-156' id='type-id-3'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-98' id='type-id-31'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-135' id='type-id-157'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-158' id='type-id-32'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-159' id='type-id-13'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-160' id='type-id-33'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-139' id='type-id-161'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-7' id='type-id-162'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-163' id='type-id-158'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-141' id='type-id-140'/>
+    <array-type-def dimensions='1' type-id='type-id-142' size-in-bits='80' id='type-id-145'>
+      <subrange length='10' lower-bound='0' upper-bound='9' type-id='type-id-36' id='type-id-164'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-142' size-in-bits='128' id='type-id-147'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-36' id='type-id-165'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-142' size-in-bits='32' id='type-id-149'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-36' id='type-id-59'/>
+    </array-type-def>
+    <union-decl name='pthread_mutex_t' size-in-bits='192' naming-typedef-id='type-id-20' visibility='default' id='type-id-155'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-107' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-91' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-166' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='unw_tdep_fpreg_t' size-in-bits='128' naming-typedef-id='type-id-158' visibility='default' id='type-id-163'>
+      <data-member access='public'>
+        <var-decl name='val32' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='val80' type-id='type-id-144' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='val128' type-id='type-id-146' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__1' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-108'>
+      <data-member access='public'>
+        <var-decl name='__elision_data' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__list' type-id='type-id-151' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-99'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-153'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-112'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-42'/>
+    <array-type-def dimensions='1' type-id='type-id-42' size-in-bits='4096' id='type-id-122'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-36' id='type-id-167'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-4' size-in-bits='4064' id='type-id-136'>
+      <subrange length='127' lower-bound='0' upper-bound='126' type-id='type-id-36' id='type-id-168'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-4' size-in-bits='608' id='type-id-115'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-36' id='type-id-40'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-105' size-in-bits='32' id='type-id-106'/>
+    <qualified-type-def type-id='type-id-100' const='yes' id='type-id-169'/>
+    <pointer-type-def type-id='type-id-169' size-in-bits='32' id='type-id-110'/>
+    <qualified-type-def type-id='type-id-89' const='yes' id='type-id-170'/>
+    <pointer-type-def type-id='type-id-170' size-in-bits='32' id='type-id-18'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='32' id='type-id-10'/>
+    <pointer-type-def type-id='type-id-93' size-in-bits='32' id='type-id-121'/>
+    <pointer-type-def type-id='type-id-96' size-in-bits='32' id='type-id-120'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='32' id='type-id-159'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='32' id='type-id-128'/>
+    <pointer-type-def type-id='type-id-172' size-in-bits='32' id='type-id-127'/>
+    <pointer-type-def type-id='type-id-173' size-in-bits='32' id='type-id-130'/>
+    <pointer-type-def type-id='type-id-174' size-in-bits='32' id='type-id-123'/>
+    <pointer-type-def type-id='type-id-175' size-in-bits='32' id='type-id-126'/>
+    <pointer-type-def type-id='type-id-176' size-in-bits='32' id='type-id-131'/>
+    <pointer-type-def type-id='type-id-177' size-in-bits='32' id='type-id-129'/>
+    <pointer-type-def type-id='type-id-178' size-in-bits='32' id='type-id-125'/>
+    <pointer-type-def type-id='type-id-12' size-in-bits='32' id='type-id-160'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='32' id='type-id-138'/>
+    <pointer-type-def type-id='type-id-179' size-in-bits='32' id='type-id-132'/>
+    <pointer-type-def type-id='type-id-42' size-in-bits='32' id='type-id-119'/>
+    <pointer-type-def type-id='type-id-133' size-in-bits='32' id='type-id-156'/>
+    <pointer-type-def type-id='type-id-157' size-in-bits='32' id='type-id-29'/>
+    <pointer-type-def type-id='type-id-137' size-in-bits='32' id='type-id-134'/>
+    <pointer-type-def type-id='type-id-32' size-in-bits='32' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-161' size-in-bits='32' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-4' size-in-bits='32' id='type-id-28'/>
+    <pointer-type-def type-id='type-id-180' size-in-bits='32' id='type-id-124'/>
+    <function-decl name='_Ux86_flush_cache' mangled-name='_Ux86_flush_cache' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_flush_cache'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='lo'/>
+      <parameter type-id='type-id-4' name='hi'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-type size-in-bits='32' id='type-id-171'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-162'/>
+      <parameter type-id='type-id-30'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-172'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-162'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-173'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-174'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-175'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-176'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-177'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-178'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-179'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-4'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-180'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='32' id='type-id-166'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-181' visibility='default' id='type-id-182'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-183' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-182' id='type-id-181'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-53' id='type-id-184'/>
+    <typedef-decl name='sigset_t' type-id='type-id-181' id='type-id-53'/>
+    <array-type-def dimensions='1' type-id='type-id-44' size-in-bits='1024' id='type-id-183'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-36' id='type-id-185'/>
+    </array-type-def>
+    <var-decl name='_UIx86_full_mask' type-id='type-id-184' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-166' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/mi/strerror.c' language='LANG_C99'>
+    <function-decl name='_Ux86_strerror' mangled-name='_Ux86_strerror' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_strerror'>
+      <parameter type-id='type-id-7' name='err_code'/>
+      <return type-id='type-id-18'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/os-linux.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-89'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-7'/>
+    <class-decl name='elf_image' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-15'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pid_t' type-id='type-id-7' id='type-id-186'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-36' id='type-id-187'/>
+    <typedef-decl name='pid_t' type-id='type-id-186' id='type-id-188'/>
+    <typedef-decl name='size_t' type-id='type-id-36' id='type-id-11'/>
+    <typedef-decl name='uint32_t' type-id='type-id-187' id='type-id-70'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-70' id='type-id-4'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-36'/>
+    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-44'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='32' id='type-id-27'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='32' id='type-id-189'/>
+    <pointer-type-def type-id='type-id-44' size-in-bits='32' id='type-id-190'/>
+    <function-decl name='_Ux86_get_elf_image' mangled-name='_Ux86_get_elf_image' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_elf_image'>
+      <parameter type-id='type-id-189' name='ei'/>
+      <parameter type-id='type-id-188' name='pid'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-190' name='segbase'/>
+      <parameter type-id='type-id-190' name='mapoff'/>
+      <parameter type-id='type-id-27' name='path'/>
+      <parameter type-id='type-id-11' name='pathlen'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_Ux86_get_exe_image_path' mangled-name='_Ux86_get_exe_image_path' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_get_exe_image_path'>
+      <parameter type-id='type-id-27' name='path'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-23'/>
+    <pointer-type-def type-id='type-id-23' id='type-id-8'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Lapply_reg_state.c' language='LANG_C99'>
+    <function-decl name='_ULx86_apply_reg_state' mangled-name='_ULx86_apply_reg_state' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_apply_reg_state'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-8' name='reg_states_data'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Lcreate_addr_space.c' language='LANG_C99'>
+    <function-decl name='_ULx86_create_addr_space' mangled-name='_ULx86_create_addr_space' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_create_addr_space'>
+      <parameter type-id='type-id-26' name='a'/>
+      <parameter type-id='type-id-7' name='byte_order'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Lget_proc_info.c' language='LANG_C99'>
+    <function-decl name='_ULx86_get_proc_info' mangled-name='_ULx86_get_proc_info' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_get_proc_info'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Lget_save_loc.c' language='LANG_C99'>
+    <enum-decl name='unw_save_loc_type' id='type-id-191'>
+      <underlying-type type-id='type-id-99'/>
+      <enumerator name='UNW_SLT_NONE' value='0'/>
+      <enumerator name='UNW_SLT_MEMORY' value='1'/>
+      <enumerator name='UNW_SLT_REG' value='2'/>
+    </enum-decl>
+    <class-decl name='unw_save_loc' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-192'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-193' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='u' type-id='type-id-194' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='extra' type-id='type-id-195' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_save_loc' size-in-bits='8' is-struct='yes' visibility='default' id='type-id-196'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-142' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_save_loc_t' type-id='type-id-192' id='type-id-197'/>
+    <typedef-decl name='unw_save_loc_type_t' type-id='type-id-191' id='type-id-193'/>
+    <typedef-decl name='unw_tdep_save_loc_t' type-id='type-id-196' id='type-id-195'/>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-194'>
+      <data-member access='public'>
+        <var-decl name='addr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='regnum' type-id='type-id-162' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-197' size-in-bits='32' id='type-id-198'/>
+    <function-decl name='_ULx86_get_save_loc' mangled-name='_ULx86_get_save_loc' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_get_save_loc'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='reg'/>
+      <parameter type-id='type-id-198' name='sloc'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Lglobal.c' language='LANG_C99'>
+    <type-decl name='atomic_bool' size-in-bits='8' id='type-id-199'/>
+    <array-type-def dimensions='1' type-id='type-id-200' size-in-bits='152' id='type-id-201'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-36' id='type-id-40'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-142' const='yes' id='type-id-200'/>
+    <var-decl name='_ULx86_dwarf_to_unw_regnum_map' type-id='type-id-201' visibility='default'/>
+    <var-decl name='_ULx86_init_done' type-id='type-id-199' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Linit.c' language='LANG_C99'>
+    <var-decl name='_ULx86_local_addr_space' type-id='type-id-3' mangled-name='_ULx86_local_addr_space' visibility='default' elf-symbol-id='_ULx86_local_addr_space'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Linit_local.c' language='LANG_C99'>
+    <pointer-type-def type-id='type-id-56' size-in-bits='32' id='type-id-202'/>
+    <function-decl name='_ULx86_init_local' mangled-name='_ULx86_init_local' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_init_local'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-202' name='uc'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULx86_init_local2' mangled-name='_ULx86_init_local2' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_init_local2'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-202' name='uc'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Linit_remote.c' language='LANG_C99'>
+    <function-decl name='_ULx86_init_remote' mangled-name='_ULx86_init_remote' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_init_remote'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-8' name='as_arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Los-linux.c' language='LANG_C99'>
+    <function-decl name='_ULx86_is_signal_frame' mangled-name='_ULx86_is_signal_frame' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_is_signal_frame'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Lreg_states_iterate.c' language='LANG_C99'>
+    <typedef-decl name='unw_reg_states_callback' type-id='type-id-203' id='type-id-204'/>
+    <pointer-type-def type-id='type-id-205' size-in-bits='32' id='type-id-203'/>
+    <function-decl name='_ULx86_reg_states_iterate' mangled-name='_ULx86_reg_states_iterate' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_reg_states_iterate'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-204' name='cb'/>
+      <parameter type-id='type-id-8' name='token'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-type size-in-bits='32' id='type-id-205'>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Lresume.c' language='LANG_C99'>
+    <function-decl name='_ULx86_resume' mangled-name='_ULx86_resume' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_resume'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/Lstep.c' language='LANG_C99'>
+    <function-decl name='_ULx86_step' mangled-name='_ULx86_step' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_ULx86_step'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/is_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_is_fpreg' mangled-name='_Ux86_is_fpreg' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_is_fpreg'>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='../../src/x86/regname.c' language='LANG_C99'>
+    <function-decl name='_Ux86_regname' mangled-name='_Ux86_regname' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='_Ux86_regname'>
+      <parameter type-id='type-id-162' name='reg'/>
+      <return type-id='type-id-18'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/x86_64/linux-gnu/libunwind-coredump.abi
+++ b/src/abi/x86_64/linux-gnu/libunwind-coredump.abi
@@ -1,0 +1,1040 @@
+<abi-corpus version='2.2' architecture='elf-amd-x86_64' soname='libunwind-coredump.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-x86_64.so.8'/>
+    <dependency name='liblzma.so.5'/>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_UCD_access_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_access_mem' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_access_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_find_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_cursig' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_mapinfo' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_num_threads' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_pid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_threadinfo' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_put_unwind_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_select_thread' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_UCD_accessors' size='88' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_access_mem.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-1'/>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='152' id='type-id-2'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-3' id='type-id-4'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='320' id='type-id-5'>
+      <subrange length='40' lower-bound='0' upper-bound='39' type-id='type-id-3' id='type-id-6'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='16384' id='type-id-8'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-9'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-10' size-in-bits='188416' id='type-id-11'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-9'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-12' id='type-id-13'>
+      <underlying-type type-id='type-id-14'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-15'/>
+    <type-decl name='long double' size-in-bits='128' id='type-id-16'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-17'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-18'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-19' visibility='default' id='type-id-20'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-21' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-21' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-24' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-25'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-26' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-27'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='__elision' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-29' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-30'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-32' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-36' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-37'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-39' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='1408' is-struct='yes' visibility='default' id='type-id-40'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='val' type-id='type-id-41' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='1472' is-struct='yes' visibility='default' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-43' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='209536' is-struct='yes' visibility='default' id='type-id-44'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='rr_head' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='log_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='prev_log_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='hash' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='generation' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='buckets' type-id='type-id-48' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='links' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='default_hash' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4736'>
+        <var-decl name='default_buckets' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='193152'>
+        <var-decl name='default_links' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-51'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-61' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='210560' is-struct='yes' visibility='default' id='type-id-62'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='caching_policy' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='cache_generation' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='dyn_generation' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='global_cache' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='210496'>
+        <var-decl name='debug_frames' type-id='type-id-64' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='type-id-65'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-66' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-67'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-69' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-64' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-70'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-71' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-71' visibility='default' id='type-id-72'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-73' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-74' id='type-id-23'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-75' id='type-id-33'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-74' id='type-id-22'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-20' id='type-id-19'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-47' id='type-id-21'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-74' id='type-id-24'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-25' id='type-id-29'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-39' id='type-id-76'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-28' id='type-id-77'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-3' id='type-id-78'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-79' id='type-id-80'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-37' id='type-id-7'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-40' id='type-id-43'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-42' id='type-id-10'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-81' id='type-id-45'/>
+    <typedef-decl name='size_t' type-id='type-id-3' id='type-id-35'/>
+    <typedef-decl name='uint16_t' type-id='type-id-76' id='type-id-75'/>
+    <typedef-decl name='uint32_t' type-id='type-id-77' id='type-id-47'/>
+    <typedef-decl name='uint64_t' type-id='type-id-78' id='type-id-74'/>
+    <typedef-decl name='uint8_t' type-id='type-id-80' id='type-id-73'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-82' id='type-id-83'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-13' id='type-id-12'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-65' id='type-id-84'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-85' id='type-id-86'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-87' id='type-id-88'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-89' id='type-id-63'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-70' id='type-id-90'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-15' id='type-id-91'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-16' id='type-id-85'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-72' id='type-id-71'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-74' id='type-id-38'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-45' visibility='default' id='type-id-81'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-5' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-17' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-14'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-79'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-28'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-3'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-34'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-39'/>
+    <array-type-def dimensions='1' type-id='type-id-39' size-in-bits='4096' id='type-id-50'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-3' id='type-id-92'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='8128' id='type-id-66'>
+      <subrange length='127' lower-bound='0' upper-bound='126' type-id='type-id-3' id='type-id-93'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='1216' id='type-id-41'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-3' id='type-id-4'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-26'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-68'/>
+    <qualified-type-def type-id='type-id-19' const='yes' id='type-id-94'/>
+    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-32'/>
+    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-95'/>
+    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-31'/>
+    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-96'/>
+    <pointer-type-def type-id='type-id-7' size-in-bits='64' id='type-id-49'/>
+    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-97' size-in-bits='64' id='type-id-87'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-57'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-56'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-59'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-89'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-61'/>
+    <pointer-type-def type-id='type-id-39' size-in-bits='64' id='type-id-46'/>
+    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-82'/>
+    <pointer-type-def type-id='type-id-84' size-in-bits='64' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-67' size-in-bits='64' id='type-id-64'/>
+    <pointer-type-def type-id='type-id-86' size-in-bits='64' id='type-id-109'/>
+    <pointer-type-def type-id='type-id-90' size-in-bits='64' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-111'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-53'/>
+    <class-decl name='table_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-69'/>
+    <function-decl name='_UCD_access_mem' mangled-name='_UCD_access_mem' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_mem'>
+      <parameter type-id='type-id-83' name='as'/>
+      <parameter type-id='type-id-38' name='addr'/>
+      <parameter type-id='type-id-111' name='val'/>
+      <parameter type-id='type-id-15' name='write'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-114' id='type-id-36'/>
+    <function-type size-in-bits='64' id='type-id-97'>
+      <parameter type-id='type-id-96'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-106'>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-98'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-91'/>
+      <parameter type-id='type-id-109'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-99'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-91'/>
+      <parameter type-id='type-id-111'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-100'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-68'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-111'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-101'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-102'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-111'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-103'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-111'/>
+      <parameter type-id='type-id-111'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-104'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-105'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-111'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-107'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-38'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-112'>
+      <parameter type-id='type-id-83'/>
+      <parameter type-id='type-id-110'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-114'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_access_reg_linux.c' language='LANG_C99'>
+    <function-decl name='_UCD_access_reg' mangled-name='_UCD_access_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_reg'>
+      <parameter type-id='type-id-83' name='as'/>
+      <parameter type-id='type-id-91' name='regnum'/>
+      <parameter type-id='type-id-111' name='valp'/>
+      <parameter type-id='type-id-15' name='write'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-51' id='type-id-115'/>
+    <var-decl name='_UCD_accessors' type-id='type-id-115' mangled-name='_UCD_accessors' visibility='default' elf-symbol-id='_UCD_accessors'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_create.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='1728' id='type-id-117'>
+      <subrange length='27' lower-bound='0' upper-bound='26' type-id='type-id-3' id='type-id-118'/>
+    </array-type-def>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-119'/>
+    <class-decl name='UCD_info' size-in-bits='2304' is-struct='yes' visibility='default' id='type-id-120'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='big_endian' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='coredump_fd' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coredump_filename' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='phdrs' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='phdrs_count' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ucd_file_table' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='note_phdr' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='prstatus' type-id='type-id-123' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='fpregset' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='n_threads' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='threads' type-id='type-id-125' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='edi' type-id='type-id-126' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='UCD_thread_info' size-in-bits='6784' is-struct='yes' visibility='default' id='type-id-127'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='prstatus' type-id='type-id-128' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2688'>
+        <var-decl name='fpregset' type-id='type-id-129' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='coredump_phdr' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-130'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_filesz' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_memsz' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_align' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_backing_file_index' type-id='type-id-132' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-126'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-133' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-134' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-133'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-35' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_prstatus' size-in-bits='2688' is-struct='yes' visibility='default' id='type-id-135'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pr_info' type-id='type-id-136' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='pr_cursig' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pr_sigpend' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pr_sighold' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pr_pid' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='pr_ppid' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pr_pgrp' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pr_sid' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='pr_utime' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='pr_stime' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='pr_cutime' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='pr_cstime' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='pr_reg' type-id='type-id-139' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2624'>
+        <var-decl name='pr_fpvalid' type-id='type-id-15' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_siginfo' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-136'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='si_signo' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='si_code' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='si_errno' type-id='type-id-15' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='timeval' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-138'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tv_sec' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tv_usec' type-id='type-id-141' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucd_file_s' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-142'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='filename' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fd' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='size' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='image' type-id='type-id-144' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucd_file_table_s' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-145'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uft_count' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uft_size' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uft_files' type-id='type-id-146' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-147'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-149' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-149' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-150' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-151'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-152' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-152' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-153' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-149' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-38' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-154'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-149' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-155' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-156'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-157' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-149' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-158' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-159'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-38' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-160'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-111' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='user_fpregs_struct' size-in-bits='4096' is-struct='yes' visibility='default' id='type-id-161'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cwd' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='swd' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='ftw' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='fop' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='rip' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='rdp' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mxcsr' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='mxcr_mask' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='st_space' type-id='type-id-162' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='xmm_space' type-id='type-id-163' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3328'>
+        <var-decl name='padding' type-id='type-id-164' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='UCD_proc_status_t' type-id='type-id-135' id='type-id-128'/>
+    <typedef-decl name='__int16_t' type-id='type-id-18' id='type-id-165'/>
+    <typedef-decl name='__int32_t' type-id='type-id-15' id='type-id-166'/>
+    <typedef-decl name='__int8_t' type-id='type-id-119' id='type-id-167'/>
+    <typedef-decl name='__off_t' type-id='type-id-17' id='type-id-168'/>
+    <typedef-decl name='__pid_t' type-id='type-id-15' id='type-id-137'/>
+    <typedef-decl name='__suseconds_t' type-id='type-id-17' id='type-id-141'/>
+    <typedef-decl name='__time_t' type-id='type-id-17' id='type-id-140'/>
+    <typedef-decl name='coredump_phdr_t' type-id='type-id-130' id='type-id-169'/>
+    <typedef-decl name='elf_fpregset_t' type-id='type-id-161' id='type-id-129'/>
+    <typedef-decl name='elf_greg_t' type-id='type-id-34' id='type-id-116'/>
+    <typedef-decl name='elf_gregset_t' type-id='type-id-117' id='type-id-139'/>
+    <typedef-decl name='int16_t' type-id='type-id-165' id='type-id-153'/>
+    <typedef-decl name='int32_t' type-id='type-id-166' id='type-id-149'/>
+    <typedef-decl name='int8_t' type-id='type-id-167' id='type-id-152'/>
+    <typedef-decl name='off_t' type-id='type-id-168' id='type-id-143'/>
+    <typedef-decl name='pid_t' type-id='type-id-137' id='type-id-170'/>
+    <typedef-decl name='ucd_file_index_t' type-id='type-id-15' id='type-id-132'/>
+    <typedef-decl name='ucd_file_t' type-id='type-id-142' id='type-id-171'/>
+    <typedef-decl name='ucd_file_table_t' type-id='type-id-145' id='type-id-122'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-147' id='type-id-134'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-151' id='type-id-172'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-154' id='type-id-173'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-156' id='type-id-174'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-159' id='type-id-175'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-160' id='type-id-176'/>
+    <typedef-decl name='uoff_t' type-id='type-id-74' id='type-id-131'/>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-150'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-173' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-176' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-175' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='768' id='type-id-164'>
+      <subrange length='24' lower-bound='0' upper-bound='23' type-id='type-id-3' id='type-id-177'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='1024' id='type-id-162'>
+      <subrange length='32' lower-bound='0' upper-bound='31' type-id='type-id-3' id='type-id-178'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='2048' id='type-id-163'>
+      <subrange length='64' lower-bound='0' upper-bound='63' type-id='type-id-3' id='type-id-179'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-172' size-in-bits='128' id='type-id-158'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-3' id='type-id-180'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-120' size-in-bits='64' id='type-id-181'/>
+    <pointer-type-def type-id='type-id-128' size-in-bits='64' id='type-id-123'/>
+    <pointer-type-def type-id='type-id-127' size-in-bits='64' id='type-id-125'/>
+    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-121'/>
+    <pointer-type-def type-id='type-id-129' size-in-bits='64' id='type-id-124'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-146'/>
+    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-144'/>
+    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-148'/>
+    <pointer-type-def type-id='type-id-156' size-in-bits='64' id='type-id-157'/>
+    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-155'/>
+    <function-decl name='_UCD_create' mangled-name='_UCD_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_create'>
+      <parameter type-id='type-id-31' name='filename'/>
+      <return type-id='type-id-181'/>
+    </function-decl>
+    <function-decl name='_UCD_get_num_threads' mangled-name='_UCD_get_num_threads' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_num_threads'>
+      <parameter type-id='type-id-181' name='ui'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='_UCD_select_thread' mangled-name='_UCD_select_thread' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_select_thread'>
+      <parameter type-id='type-id-181' name='ui'/>
+      <parameter type-id='type-id-15' name='n'/>
+      <return type-id='type-id-114'/>
+    </function-decl>
+    <function-decl name='_UCD_get_pid' mangled-name='_UCD_get_pid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_pid'>
+      <parameter type-id='type-id-181' name='ui'/>
+      <return type-id='type-id-170'/>
+    </function-decl>
+    <function-decl name='_UCD_get_cursig' mangled-name='_UCD_get_cursig' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_cursig'>
+      <parameter type-id='type-id-181' name='ui'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_destroy.c' language='LANG_C99'>
+    <function-decl name='_UCD_destroy' mangled-name='_UCD_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_destroy'>
+      <parameter type-id='type-id-181' name='ui'/>
+      <return type-id='type-id-114'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_find_proc_info.c' language='LANG_C99'>
+    <function-decl name='_UCD_find_proc_info' mangled-name='_UCD_find_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_find_proc_info'>
+      <parameter type-id='type-id-83' name='as'/>
+      <parameter type-id='type-id-38' name='ip'/>
+      <parameter type-id='type-id-110' name='pi'/>
+      <parameter type-id='type-id-15' name='need_unwind_info'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_elf_filename' mangled-name='_UCD_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_elf_filename'>
+      <parameter type-id='type-id-83' name='as'/>
+      <parameter type-id='type-id-38' name='ip'/>
+      <parameter type-id='type-id-68' name='buf'/>
+      <parameter type-id='type-id-35' name='buf_len'/>
+      <parameter type-id='type-id-111' name='offp'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_mapinfo_linux.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_mapinfo' mangled-name='_UCD_get_mapinfo' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_mapinfo'>
+      <parameter type-id='type-id-181' name='ui'/>
+      <parameter type-id='type-id-121' name='phdrs'/>
+      <parameter type-id='type-id-28' name='phdr_size'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_proc_name.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_proc_name' mangled-name='_UCD_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_proc_name'>
+      <parameter type-id='type-id-83' name='as'/>
+      <parameter type-id='type-id-38' name='ip'/>
+      <parameter type-id='type-id-68' name='buf'/>
+      <parameter type-id='type-id-35' name='buf_len'/>
+      <parameter type-id='type-id-111' name='offp'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_threadinfo_prstatus.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_threadinfo' mangled-name='_UCD_get_threadinfo' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_threadinfo'>
+      <parameter type-id='type-id-181' name='ui'/>
+      <parameter type-id='type-id-121' name='phdrs'/>
+      <parameter type-id='type-id-28' name='phdr_size'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_access_fpreg.c' language='LANG_C99'>
+    <function-decl name='_UCD_access_fpreg' mangled-name='_UCD_access_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_fpreg'>
+      <parameter type-id='type-id-83' name='as'/>
+      <parameter type-id='type-id-91' name='reg'/>
+      <parameter type-id='type-id-109' name='val'/>
+      <parameter type-id='type-id-15' name='write'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_get_dyn_info_list_addr.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_dyn_info_list_addr' mangled-name='_UCD_get_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_dyn_info_list_addr'>
+      <parameter type-id='type-id-83' name='as'/>
+      <parameter type-id='type-id-111' name='dil_addr'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_put_unwind_info.c' language='LANG_C99'>
+    <function-decl name='_UCD_put_unwind_info' mangled-name='_UCD_put_unwind_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_put_unwind_info'>
+      <parameter type-id='type-id-83' name='as'/>
+      <parameter type-id='type-id-110' name='pi'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-114'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_resume.c' language='LANG_C99'>
+    <function-decl name='_UCD_resume' mangled-name='_UCD_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_resume'>
+      <parameter type-id='type-id-83' name='as'/>
+      <parameter type-id='type-id-108' name='c'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-182' visibility='default' id='type-id-183'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-184' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-183' id='type-id-182'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-185' id='type-id-186'/>
+    <typedef-decl name='sigset_t' type-id='type-id-182' id='type-id-185'/>
+    <array-type-def dimensions='1' type-id='type-id-3' size-in-bits='1024' id='type-id-184'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-3' id='type-id-187'/>
+    </array-type-def>
+    <var-decl name='_UIx86_64_full_mask' type-id='type-id-186' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-17' visibility='default'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/x86_64/linux-gnu/libunwind-ptrace.abi
+++ b/src/abi/x86_64/linux-gnu/libunwind-ptrace.abi
@@ -1,0 +1,628 @@
+<abi-corpus version='2.2' architecture='elf-amd-x86_64' soname='libunwind-ptrace.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-x86_64.so.8'/>
+    <dependency name='liblzma.so.5'/>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_UPT_access_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_access_mem' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_access_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_find_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_put_unwind_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_UPT_accessors' size='88' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UPT_reg_offset' size='68' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-2' visibility='default' id='type-id-3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-3' id='type-id-2'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-5' id='type-id-6'/>
+    <typedef-decl name='sigset_t' type-id='type-id-2' id='type-id-5'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-7'/>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='1024' id='type-id-4'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-7' id='type-id-8'/>
+    </array-type-def>
+    <var-decl name='_UIx86_64_full_mask' type-id='type-id-6' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-1' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_access_fpreg.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-9'/>
+    <array-type-def dimensions='1' type-id='type-id-9' size-in-bits='152' id='type-id-10'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-7' id='type-id-11'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-9' size-in-bits='320' id='type-id-12'>
+      <subrange length='40' lower-bound='0' upper-bound='39' type-id='type-id-7' id='type-id-13'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-14' size-in-bits='16384' id='type-id-15'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-7' id='type-id-16'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-17' size-in-bits='188416' id='type-id-18'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-7' id='type-id-16'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-19' id='type-id-20'>
+      <underlying-type type-id='type-id-21'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
+    <type-decl name='long double' size-in-bits='128' id='type-id-23'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-24'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-25' visibility='default' id='type-id-26'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-30' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-31'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-32' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-32' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-33'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='__elision' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-35' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-36'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-42' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-45' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='1408' is-struct='yes' visibility='default' id='type-id-46'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='val' type-id='type-id-47' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='1472' is-struct='yes' visibility='default' id='type-id-48'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-49' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='209536' is-struct='yes' visibility='default' id='type-id-50'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='rr_head' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='log_size' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='prev_log_size' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='hash' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='generation' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='buckets' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='links' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='default_hash' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4736'>
+        <var-decl name='default_buckets' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='193152'>
+        <var-decl name='default_links' type-id='type-id-15' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-57'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-66' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-67' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='210560' is-struct='yes' visibility='default' id='type-id-68'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-69' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='caching_policy' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='cache_generation' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='dyn_generation' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='global_cache' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='210496'>
+        <var-decl name='debug_frames' type-id='type-id-70' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='type-id-71'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-72' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-73'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-70' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-76'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-77' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-77' visibility='default' id='type-id-78'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-79' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-80' id='type-id-29'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-81' id='type-id-39'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-80' id='type-id-28'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-26' id='type-id-25'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-53' id='type-id-27'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-80' id='type-id-30'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-31' id='type-id-35'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-45' id='type-id-82'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-34' id='type-id-83'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-7' id='type-id-84'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-85' id='type-id-86'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-43' id='type-id-14'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-46' id='type-id-49'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-48' id='type-id-17'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-87' id='type-id-51'/>
+    <typedef-decl name='size_t' type-id='type-id-7' id='type-id-41'/>
+    <typedef-decl name='uint16_t' type-id='type-id-82' id='type-id-81'/>
+    <typedef-decl name='uint32_t' type-id='type-id-83' id='type-id-53'/>
+    <typedef-decl name='uint64_t' type-id='type-id-84' id='type-id-80'/>
+    <typedef-decl name='uint8_t' type-id='type-id-86' id='type-id-79'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-88' id='type-id-89'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-20' id='type-id-19'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-71' id='type-id-90'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-91' id='type-id-92'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-93' id='type-id-94'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-95' id='type-id-69'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-76' id='type-id-96'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-22' id='type-id-97'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-23' id='type-id-91'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-78' id='type-id-77'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-80' id='type-id-44'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-51' visibility='default' id='type-id-87'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-1' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-21'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-85'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-34'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-40'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-45'/>
+    <array-type-def dimensions='1' type-id='type-id-45' size-in-bits='4096' id='type-id-56'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-7' id='type-id-98'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-44' size-in-bits='8128' id='type-id-72'>
+      <subrange length='127' lower-bound='0' upper-bound='126' type-id='type-id-7' id='type-id-99'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-44' size-in-bits='1216' id='type-id-47'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-7' id='type-id-11'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-32'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-74'/>
+    <qualified-type-def type-id='type-id-25' const='yes' id='type-id-100'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-38'/>
+    <qualified-type-def type-id='type-id-9' const='yes' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-37'/>
+    <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-93'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-63'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-62'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-65'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-61'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-66'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-64'/>
+    <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-95'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-45' size-in-bits='64' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-88'/>
+    <pointer-type-def type-id='type-id-90' size-in-bits='64' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-70'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-115'/>
+    <pointer-type-def type-id='type-id-96' size-in-bits='64' id='type-id-116'/>
+    <pointer-type-def type-id='type-id-44' size-in-bits='64' id='type-id-117'/>
+    <pointer-type-def type-id='type-id-118' size-in-bits='64' id='type-id-59'/>
+    <class-decl name='table_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-119'/>
+    <pointer-type-def type-id='type-id-119' size-in-bits='64' id='type-id-75'/>
+    <function-decl name='_UPT_access_fpreg' mangled-name='_UPT_access_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_access_fpreg'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-97' name='reg'/>
+      <parameter type-id='type-id-115' name='val'/>
+      <parameter type-id='type-id-22' name='write'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-120'/>
+    <pointer-type-def type-id='type-id-120' id='type-id-42'/>
+    <function-type size-in-bits='64' id='type-id-103'>
+      <parameter type-id='type-id-102'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-112'>
+      <parameter type-id='type-id-94'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-104'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-97'/>
+      <parameter type-id='type-id-115'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-105'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-97'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-106'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-107'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-108'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-109'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-110'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-111'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-113'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-44'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-118'>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-120'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_access_mem.c' language='LANG_C99'>
+    <function-decl name='_UPT_access_mem' mangled-name='_UPT_access_mem' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_access_mem'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-44' name='addr'/>
+      <parameter type-id='type-id-117' name='val'/>
+      <parameter type-id='type-id-22' name='write'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_access_reg.c' language='LANG_C99'>
+    <function-decl name='_UPT_access_reg' mangled-name='_UPT_access_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_access_reg'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-97' name='reg'/>
+      <parameter type-id='type-id-117' name='val'/>
+      <parameter type-id='type-id-22' name='write'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-57' id='type-id-121'/>
+    <var-decl name='_UPT_accessors' type-id='type-id-121' mangled-name='_UPT_accessors' visibility='default' elf-symbol-id='_UPT_accessors'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_create.c' language='LANG_C99'>
+    <typedef-decl name='__pid_t' type-id='type-id-22' id='type-id-122'/>
+    <typedef-decl name='pid_t' type-id='type-id-122' id='type-id-123'/>
+    <function-decl name='_UPT_create' mangled-name='_UPT_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_create'>
+      <parameter type-id='type-id-123' name='pid'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_destroy.c' language='LANG_C99'>
+    <function-decl name='_UPT_destroy' mangled-name='_UPT_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_destroy'>
+      <parameter type-id='type-id-42' name='ptr'/>
+      <return type-id='type-id-120'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_find_proc_info.c' language='LANG_C99'>
+    <function-decl name='_UPT_find_proc_info' mangled-name='_UPT_find_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_find_proc_info'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-44' name='ip'/>
+      <parameter type-id='type-id-116' name='pi'/>
+      <parameter type-id='type-id-22' name='need_unwind_info'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_get_dyn_info_list_addr.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_dyn_info_list_addr' mangled-name='_UPT_get_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_get_dyn_info_list_addr'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-117' name='dil_addr'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_get_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_elf_filename' mangled-name='_UPT_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_get_elf_filename'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-44' name='ip'/>
+      <parameter type-id='type-id-74' name='buf'/>
+      <parameter type-id='type-id-41' name='buf_len'/>
+      <parameter type-id='type-id-117' name='offp'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_get_proc_name.c' language='LANG_C99'>
+    <function-decl name='_UPT_get_proc_name' mangled-name='_UPT_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_get_proc_name'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-44' name='ip'/>
+      <parameter type-id='type-id-74' name='buf'/>
+      <parameter type-id='type-id-41' name='buf_len'/>
+      <parameter type-id='type-id-117' name='offp'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_put_unwind_info.c' language='LANG_C99'>
+    <function-decl name='_UPT_put_unwind_info' mangled-name='_UPT_put_unwind_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_put_unwind_info'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-116' name='pi'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-120'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_reg_offset.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-124' size-in-bits='544' id='type-id-125'>
+      <subrange length='17' lower-bound='0' upper-bound='16' type-id='type-id-7' id='type-id-126'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-22' const='yes' id='type-id-124'/>
+    <var-decl name='_UPT_reg_offset' type-id='type-id-125' mangled-name='_UPT_reg_offset' visibility='default' elf-symbol-id='_UPT_reg_offset'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/ptrace/_UPT_resume.c' language='LANG_C99'>
+    <function-decl name='_UPT_resume' mangled-name='_UPT_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UPT_resume'>
+      <parameter type-id='type-id-89' name='as'/>
+      <parameter type-id='type-id-114' name='c'/>
+      <parameter type-id='type-id-42' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/x86_64/linux-gnu/libunwind-setjmp.abi
+++ b/src/abi/x86_64/linux-gnu/libunwind-setjmp.abi
@@ -1,0 +1,28 @@
+<abi-corpus version='2.2' architecture='elf-amd-x86_64' soname='libunwind-setjmp.so.0'>
+  <elf-needed>
+    <dependency name='liblzma.so.5'/>
+    <dependency name='libunwind-x86_64.so.8'/>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_UI_longjmp_cont' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UI_siglongjmp_cont' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-2' visibility='default' id='type-id-3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-3' id='type-id-2'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-5' id='type-id-6'/>
+    <typedef-decl name='sigset_t' type-id='type-id-2' id='type-id-5'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-7'/>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='1024' id='type-id-4'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-7' id='type-id-8'/>
+    </array-type-def>
+    <var-decl name='_UIx86_64_full_mask' type-id='type-id-6' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-1' visibility='default'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/x86_64/linux-gnu/libunwind-x86_64.abi
+++ b/src/abi/x86_64/linux-gnu/libunwind-x86_64.abi
@@ -1,0 +1,1195 @@
+<abi-corpus version='2.2' architecture='elf-amd-x86_64' soname='libunwind-x86_64.so.8'>
+  <elf-needed>
+    <dependency name='liblzma.so.5'/>
+    <dependency name='libunwind.so.8'/>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-x86-64.so.2'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_Ux86_64_apply_reg_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_create_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_destroy_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_dwarf_find_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_dwarf_search_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_flush_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_accessors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_elf_filename_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_elf_image' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_exe_image_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_proc_info_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_proc_info_in_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_proc_name_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_save_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_init_local' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_init_local2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_init_remote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_is_signal_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_reg_states_iterate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_set_cache_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_set_caching_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_set_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_set_iterate_phdr_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_set_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_Ux86_64_local_addr_space' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/dwarf/Gfind_proc_info-lsb.c' language='LANG_C99'>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-1'/>
+    <class-decl name='table_entry' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-2'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip_offset' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fde_offset' type-id='type-id-3' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-4'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-5' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-5' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-8'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-6' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-11'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-13' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-14'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-17'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-6' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-18'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-19' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int16_t' type-id='type-id-20' id='type-id-21'/>
+    <typedef-decl name='__int32_t' type-id='type-id-22' id='type-id-23'/>
+    <typedef-decl name='__int8_t' type-id='type-id-1' id='type-id-24'/>
+    <typedef-decl name='int16_t' type-id='type-id-21' id='type-id-10'/>
+    <typedef-decl name='int32_t' type-id='type-id-23' id='type-id-3'/>
+    <typedef-decl name='int8_t' type-id='type-id-24' id='type-id-9'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-4' id='type-id-25'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-8' id='type-id-26'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-11' id='type-id-27'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-14' id='type-id-28'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-17' id='type-id-29'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-18' id='type-id-30'/>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-7'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-29' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-26' size-in-bits='128' id='type-id-16'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-31' id='type-id-32'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-5'/>
+    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-33'/>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-15'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-13'/>
+    <function-decl name='_Ux86_64_dwarf_search_unwind_table' mangled-name='_Ux86_64_dwarf_search_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_dwarf_search_unwind_table'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-33' name='di'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <parameter type-id='type-id-22' name='need_unwind_info'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-37'>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-40'>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Gfind_unwind_table.c' language='LANG_C99'>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-25' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-25' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-42' size-in-bits='64' id='type-id-44'/>
+    <function-decl name='_Ux86_64_dwarf_find_unwind_table' mangled-name='_Ux86_64_dwarf_find_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_dwarf_find_unwind_table'>
+      <parameter type-id='type-id-44' name='edi'/>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-45' name='path'/>
+      <parameter type-id='type-id-6' name='segbase'/>
+      <parameter type-id='type-id-6' name='mapoff'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Gget_proc_info_in_range.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_get_proc_info_in_range' mangled-name='_Ux86_64_get_proc_info_in_range' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_proc_info_in_range'>
+      <parameter type-id='type-id-6' name='start_ip'/>
+      <parameter type-id='type-id-6' name='end_ip'/>
+      <parameter type-id='type-id-6' name='eh_frame_table'/>
+      <parameter type-id='type-id-6' name='eh_frame_table_len'/>
+      <parameter type-id='type-id-6' name='exidx_frame_table'/>
+      <parameter type-id='type-id-6' name='exidx_frame_table_len'/>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <parameter type-id='type-id-22' name='need_unwind_info'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/global.c' language='LANG_C99'>
+    <class-decl name='mempool' size-in-bits='640' is-struct='yes' visibility='default' id='type-id-46'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='obj_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='chunk_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='reserve' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='num_free' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='free_list' type-id='type-id-48' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='object' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-49'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-48' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-49' size-in-bits='64' id='type-id-48'/>
+    <var-decl name='dwarf_reg_state_pool' type-id='type-id-46' visibility='default'/>
+    <var-decl name='dwarf_cie_info_pool' type-id='type-id-46' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gdestroy_addr_space.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_destroy_addr_space' mangled-name='_Ux86_64_destroy_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_destroy_addr_space'>
+      <parameter type-id='type-id-34' name='as'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-51' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-52' size-in-bits='64' id='type-id-53'/>
+    <function-decl name='_Ux86_64_get_accessors' mangled-name='_Ux86_64_get_accessors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_accessors'>
+      <parameter type-id='type-id-34' name='as'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_get_elf_filename_by_ip' mangled-name='_Ux86_64_get_elf_filename_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_elf_filename_by_ip'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-19' name='offp'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_get_elf_filename' mangled-name='_Ux86_64_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_elf_filename'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-19' name='offp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_get_fpreg' mangled-name='_Ux86_64_get_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_fpreg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-56' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_proc_info_by_ip.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_get_proc_info_by_ip' mangled-name='_Ux86_64_get_proc_info_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_proc_info_by_ip'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <parameter type-id='type-id-36' name='as_arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_proc_name.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_get_proc_name_by_ip' mangled-name='_Ux86_64_get_proc_name_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_proc_name_by_ip'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-19' name='offp'/>
+      <parameter type-id='type-id-36' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_get_proc_name' mangled-name='_Ux86_64_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_proc_name'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-54' name='buf'/>
+      <parameter type-id='type-id-39' name='buf_len'/>
+      <parameter type-id='type-id-19' name='offp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_reg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_get_reg' mangled-name='_Ux86_64_get_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_reg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-19' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_cache_size.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_set_cache_size' mangled-name='_Ux86_64_set_cache_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_set_cache_size'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-39' name='size'/>
+      <parameter type-id='type-id-22' name='flag'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_caching_policy.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_set_caching_policy' mangled-name='_Ux86_64_set_caching_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_set_caching_policy'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-57' name='policy'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_set_fpreg' mangled-name='_Ux86_64_set_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_set_fpreg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-58' name='val'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_iterate_phdr_function.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_set_iterate_phdr_function' mangled-name='_Ux86_64_set_iterate_phdr_function' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_set_iterate_phdr_function'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-59' name='function'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_reg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_set_reg' mangled-name='_Ux86_64_set_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_set_reg'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-6' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/flush_cache.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='152' id='type-id-61'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-31' id='type-id-62'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-60' size-in-bits='320' id='type-id-63'>
+      <subrange length='40' lower-bound='0' upper-bound='39' type-id='type-id-31' id='type-id-64'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-65' size-in-bits='16384' id='type-id-66'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-31' id='type-id-67'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-68' size-in-bits='188416' id='type-id-69'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-31' id='type-id-67'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-57' id='type-id-70'>
+      <underlying-type type-id='type-id-71'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='long double' size-in-bits='128' id='type-id-72'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-20'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-73' visibility='default' id='type-id-74'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-75' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-78' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-79'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-80' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-80' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-81'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-82' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-82' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='__elision' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-83' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-84'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-85' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-86' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-36' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-88'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-89' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='1408' is-struct='yes' visibility='default' id='type-id-90'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='val' type-id='type-id-91' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='1472' is-struct='yes' visibility='default' id='type-id-92'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-93' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='209536' is-struct='yes' visibility='default' id='type-id-94'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='rr_head' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='log_size' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='prev_log_size' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='hash' type-id='type-id-95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='generation' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='buckets' type-id='type-id-96' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='links' type-id='type-id-97' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='default_hash' type-id='type-id-98' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4736'>
+        <var-decl name='default_buckets' type-id='type-id-69' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='193152'>
+        <var-decl name='default_links' type-id='type-id-66' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-51'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-99' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-100' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-101' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-102' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-103' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-105' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-106' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-106' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-107' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-108' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='210560' is-struct='yes' visibility='default' id='type-id-109'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='caching_policy' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='cache_generation' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='dyn_generation' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='global_cache' type-id='type-id-94' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='210496'>
+        <var-decl name='debug_frames' type-id='type-id-110' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='type-id-111'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-112' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-113'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-114' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-110' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-115'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-116' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-116' visibility='default' id='type-id-117'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-118' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-119' id='type-id-77'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-120' id='type-id-86'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-119' id='type-id-76'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-74' id='type-id-73'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-12' id='type-id-75'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-119' id='type-id-78'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-79' id='type-id-83'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-89' id='type-id-121'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-82' id='type-id-122'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-123' id='type-id-124'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-88' id='type-id-65'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-90' id='type-id-93'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-92' id='type-id-68'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-125' id='type-id-47'/>
+    <typedef-decl name='uint16_t' type-id='type-id-121' id='type-id-120'/>
+    <typedef-decl name='uint32_t' type-id='type-id-122' id='type-id-12'/>
+    <typedef-decl name='uint8_t' type-id='type-id-124' id='type-id-118'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-126' id='type-id-34'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-70' id='type-id-57'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-111' id='type-id-127'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-128' id='type-id-58'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-129' id='type-id-41'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-130' id='type-id-59'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-115' id='type-id-131'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-22' id='type-id-132'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-72' id='type-id-128'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-117' id='type-id-116'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-47' visibility='default' id='type-id-125'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-81' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-133' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-71'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-123'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-82'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-87'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-89'/>
+    <array-type-def dimensions='1' type-id='type-id-89' size-in-bits='4096' id='type-id-98'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-31' id='type-id-134'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='8128' id='type-id-112'>
+      <subrange length='127' lower-bound='0' upper-bound='126' type-id='type-id-31' id='type-id-135'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='1216' id='type-id-91'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-31' id='type-id-62'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-80'/>
+    <qualified-type-def type-id='type-id-73' const='yes' id='type-id-136'/>
+    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-85'/>
+    <qualified-type-def type-id='type-id-60' const='yes' id='type-id-137'/>
+    <pointer-type-def type-id='type-id-137' size-in-bits='64' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-84' size-in-bits='64' id='type-id-38'/>
+    <pointer-type-def type-id='type-id-65' size-in-bits='64' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-96'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-129'/>
+    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-104'/>
+    <pointer-type-def type-id='type-id-139' size-in-bits='64' id='type-id-103'/>
+    <pointer-type-def type-id='type-id-140' size-in-bits='64' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-141' size-in-bits='64' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-143' size-in-bits='64' id='type-id-107'/>
+    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-40' size-in-bits='64' id='type-id-130'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-146' size-in-bits='64' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-95'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-126'/>
+    <pointer-type-def type-id='type-id-127' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-58' size-in-bits='64' id='type-id-56'/>
+    <pointer-type-def type-id='type-id-131' size-in-bits='64' id='type-id-35'/>
+    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-100'/>
+    <function-decl name='_Ux86_64_flush_cache' mangled-name='_Ux86_64_flush_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_flush_cache'>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-6' name='lo'/>
+      <parameter type-id='type-id-6' name='hi'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-138'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-132'/>
+      <parameter type-id='type-id-56'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-139'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-132'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-140'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-54'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-141'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-142'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-143'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-144'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-55'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-145'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-146'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-6'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-147'>
+      <parameter type-id='type-id-34'/>
+      <parameter type-id='type-id-35'/>
+      <parameter type-id='type-id-36'/>
+      <return type-id='type-id-50'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-133'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-148' visibility='default' id='type-id-149'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-150' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-149' id='type-id-148'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-151' id='type-id-152'/>
+    <typedef-decl name='sigset_t' type-id='type-id-148' id='type-id-151'/>
+    <array-type-def dimensions='1' type-id='type-id-31' size-in-bits='1024' id='type-id-150'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-31' id='type-id-153'/>
+    </array-type-def>
+    <var-decl name='_UIx86_64_full_mask' type-id='type-id-152' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-133' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/strerror.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_strerror' mangled-name='_Ux86_64_strerror' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_strerror'>
+      <parameter type-id='type-id-22' name='err_code'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/os-linux.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-60'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pid_t' type-id='type-id-22' id='type-id-154'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-31' id='type-id-155'/>
+    <typedef-decl name='pid_t' type-id='type-id-154' id='type-id-156'/>
+    <typedef-decl name='size_t' type-id='type-id-31' id='type-id-39'/>
+    <typedef-decl name='uint64_t' type-id='type-id-155' id='type-id-119'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-119' id='type-id-6'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-31'/>
+    <pointer-type-def type-id='type-id-60' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-157'/>
+    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-158'/>
+    <function-decl name='_Ux86_64_get_elf_image' mangled-name='_Ux86_64_get_elf_image' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_elf_image'>
+      <parameter type-id='type-id-157' name='ei'/>
+      <parameter type-id='type-id-156' name='pid'/>
+      <parameter type-id='type-id-6' name='ip'/>
+      <parameter type-id='type-id-158' name='segbase'/>
+      <parameter type-id='type-id-158' name='mapoff'/>
+      <parameter type-id='type-id-54' name='path'/>
+      <parameter type-id='type-id-39' name='pathlen'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_get_exe_image_path' mangled-name='_Ux86_64_get_exe_image_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_exe_image_path'>
+      <parameter type-id='type-id-54' name='path'/>
+      <return type-id='type-id-50'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-50' id='type-id-36'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gapply_reg_state.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_apply_reg_state' mangled-name='_Ux86_64_apply_reg_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_apply_reg_state'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-36' name='reg_states_data'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gcreate_addr_space.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_create_addr_space' mangled-name='_Ux86_64_create_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_create_addr_space'>
+      <parameter type-id='type-id-53' name='a'/>
+      <parameter type-id='type-id-22' name='byte_order'/>
+      <return type-id='type-id-34'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gget_proc_info.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_get_proc_info' mangled-name='_Ux86_64_get_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_proc_info'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-35' name='pi'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gget_save_loc.c' language='LANG_C99'>
+    <enum-decl name='unw_save_loc_type' id='type-id-159'>
+      <underlying-type type-id='type-id-71'/>
+      <enumerator name='UNW_SLT_NONE' value='0'/>
+      <enumerator name='UNW_SLT_MEMORY' value='1'/>
+      <enumerator name='UNW_SLT_REG' value='2'/>
+    </enum-decl>
+    <class-decl name='unw_save_loc' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-160'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-161' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='u' type-id='type-id-162' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='extra' type-id='type-id-163' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_save_loc' size-in-bits='8' is-struct='yes' visibility='default' id='type-id-164'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-118' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_save_loc_t' type-id='type-id-160' id='type-id-165'/>
+    <typedef-decl name='unw_save_loc_type_t' type-id='type-id-159' id='type-id-161'/>
+    <typedef-decl name='unw_tdep_save_loc_t' type-id='type-id-164' id='type-id-163'/>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-162'>
+      <data-member access='public'>
+        <var-decl name='addr' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='regnum' type-id='type-id-132' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-165' size-in-bits='64' id='type-id-166'/>
+    <function-decl name='_Ux86_64_get_save_loc' mangled-name='_Ux86_64_get_save_loc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_save_loc'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-22' name='reg'/>
+      <parameter type-id='type-id-166' name='sloc'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gglobal.c' language='LANG_C99'>
+    <type-decl name='atomic_bool' size-in-bits='8' id='type-id-167'/>
+    <array-type-def dimensions='1' type-id='type-id-168' size-in-bits='136' id='type-id-169'>
+      <subrange length='17' lower-bound='0' upper-bound='16' type-id='type-id-31' id='type-id-170'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-118' const='yes' id='type-id-168'/>
+    <var-decl name='_Ux86_64_dwarf_to_unw_regnum_map' type-id='type-id-169' visibility='default'/>
+    <var-decl name='_Ux86_64_init_done' type-id='type-id-167' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Ginit.c' language='LANG_C99'>
+    <var-decl name='_Ux86_64_local_addr_space' type-id='type-id-34' mangled-name='_Ux86_64_local_addr_space' visibility='default' elf-symbol-id='_Ux86_64_local_addr_space'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Ginit_local.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-122' size-in-bits='768' id='type-id-171'>
+      <subrange length='24' lower-bound='0' upper-bound='23' type-id='type-id-31' id='type-id-172'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-122' size-in-bits='128' id='type-id-173'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-31' id='type-id-174'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-175' size-in-bits='1024' id='type-id-176'>
+      <subrange length='8' lower-bound='0' upper-bound='7' type-id='type-id-31' id='type-id-177'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-178' size-in-bits='2048' id='type-id-179'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-31' id='type-id-153'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-180' size-in-bits='1472' id='type-id-181'>
+      <subrange length='23' lower-bound='0' upper-bound='22' type-id='type-id-31' id='type-id-182'/>
+    </array-type-def>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-183'/>
+    <class-decl name='_libc_fpstate' size-in-bits='4096' is-struct='yes' visibility='default' id='type-id-184'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cwd' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='swd' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='ftw' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='fop' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='rip' type-id='type-id-155' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='rdp' type-id='type-id-155' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mxcsr' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='mxcr_mask' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_st' type-id='type-id-176' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='_xmm' type-id='type-id-179' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3328'>
+        <var-decl name='__glibc_reserved1' type-id='type-id-171' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_libc_fpxreg' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-175'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='significand' type-id='type-id-185' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='exponent' type-id='type-id-89' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='__glibc_reserved1' type-id='type-id-186' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_libc_xmmreg' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-178'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='element' type-id='type-id-173' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='mcontext_t' size-in-bits='2048' is-struct='yes' naming-typedef-id='type-id-187' visibility='default' id='type-id-188'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gregs' type-id='type-id-189' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='fpregs' type-id='type-id-190' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='__reserved1' type-id='type-id-191' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='stack_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-192' visibility='default' id='type-id-193'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ss_sp' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ss_flags' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ss_size' type-id='type-id-39' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucontext_t' size-in-bits='7744' is-struct='yes' visibility='default' id='type-id-194'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uc_flags' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uc_link' type-id='type-id-195' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uc_stack' type-id='type-id-192' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='uc_mcontext' type-id='type-id-187' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2368'>
+        <var-decl name='uc_sigmask' type-id='type-id-151' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3392'>
+        <var-decl name='__fpregs_mem' type-id='type-id-184' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='7488'>
+        <var-decl name='__ssp' type-id='type-id-196' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='fpregset_t' type-id='type-id-197' id='type-id-190'/>
+    <typedef-decl name='greg_t' type-id='type-id-183' id='type-id-180'/>
+    <typedef-decl name='gregset_t' type-id='type-id-181' id='type-id-189'/>
+    <typedef-decl name='mcontext_t' type-id='type-id-188' id='type-id-187'/>
+    <typedef-decl name='stack_t' type-id='type-id-193' id='type-id-192'/>
+    <typedef-decl name='ucontext_t' type-id='type-id-194' id='type-id-198'/>
+    <array-type-def dimensions='1' type-id='type-id-87' size-in-bits='256' id='type-id-196'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-31' id='type-id-174'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-87' size-in-bits='512' id='type-id-191'>
+      <subrange length='8' lower-bound='0' upper-bound='7' type-id='type-id-31' id='type-id-177'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-89' size-in-bits='48' id='type-id-186'>
+      <subrange length='3' lower-bound='0' upper-bound='2' type-id='type-id-31' id='type-id-199'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-89' size-in-bits='64' id='type-id-185'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-31' id='type-id-174'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-184' size-in-bits='64' id='type-id-197'/>
+    <pointer-type-def type-id='type-id-194' size-in-bits='64' id='type-id-195'/>
+    <pointer-type-def type-id='type-id-198' size-in-bits='64' id='type-id-200'/>
+    <function-decl name='_Ux86_64_init_local' mangled-name='_Ux86_64_init_local' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_init_local'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-200' name='uc'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_init_local2' mangled-name='_Ux86_64_init_local2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_init_local2'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-200' name='uc'/>
+      <parameter type-id='type-id-22' name='flag'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Ginit_remote.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_init_remote' mangled-name='_Ux86_64_init_remote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_init_remote'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-34' name='as'/>
+      <parameter type-id='type-id-36' name='as_arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gos-linux.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_is_signal_frame' mangled-name='_Ux86_64_is_signal_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_is_signal_frame'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Greg_states_iterate.c' language='LANG_C99'>
+    <typedef-decl name='unw_reg_states_callback' type-id='type-id-201' id='type-id-202'/>
+    <pointer-type-def type-id='type-id-203' size-in-bits='64' id='type-id-201'/>
+    <function-decl name='_Ux86_64_reg_states_iterate' mangled-name='_Ux86_64_reg_states_iterate' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_reg_states_iterate'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <parameter type-id='type-id-202' name='cb'/>
+      <parameter type-id='type-id-36' name='token'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-203'>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-36'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gresume.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_resume' mangled-name='_Ux86_64_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_resume'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gstep.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_step' mangled-name='_Ux86_64_step' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_step'>
+      <parameter type-id='type-id-55' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/is_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_is_fpreg' mangled-name='_Ux86_64_is_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_is_fpreg'>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/regname.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_regname' mangled-name='_Ux86_64_regname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_regname'>
+      <parameter type-id='type-id-132' name='reg'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/x86_64/linux-gnu/libunwind.abi
+++ b/src/abi/x86_64/linux-gnu/libunwind.abi
@@ -1,0 +1,1251 @@
+<abi-corpus version='2.2' architecture='elf-amd-x86_64' soname='libunwind.so.8'>
+  <elf-needed>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-x86-64.so.2'/>
+    <dependency name='liblzma.so.5'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_ULx86_64_apply_reg_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_create_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_destroy_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_dwarf_find_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_dwarf_search_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_elf_filename_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_proc_info_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_proc_info_in_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_proc_name_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_save_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_init_local' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_init_local2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_init_remote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_is_signal_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_reg_states_iterate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_set_cache_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_set_caching_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_set_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_set_iterate_phdr_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_set_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_cancel' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_register' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_flush_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_accessors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_elf_image' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_exe_image_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_getcontext' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_setcontext' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='backtrace' type='func-type' binding='weak-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_backtrace' type='func-type' binding='global-binding' visibility='default-visibility' alias='backtrace' is-defined='yes'/>
+    <elf-symbol name='unw_backtrace2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_ULx86_64_local_addr_space' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/dwarf/Lfind_proc_info-lsb.c' language='LANG_C99'>
+    <class-decl name='table_entry' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-1'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip_offset' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fde_offset' type-id='type-id-2' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <function-decl name='_ULx86_64_dwarf_search_unwind_table' mangled-name='_ULx86_64_dwarf_search_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_dwarf_search_unwind_table'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-5' name='di'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-7' name='need_unwind_info'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-9'>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-12'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Lfind_unwind_table.c' language='LANG_C99'>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-14'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-17'/>
+    <function-decl name='_ULx86_64_dwarf_find_unwind_table' mangled-name='_ULx86_64_dwarf_find_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_dwarf_find_unwind_table'>
+      <parameter type-id='type-id-17' name='edi'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-18' name='path'/>
+      <parameter type-id='type-id-4' name='segbase'/>
+      <parameter type-id='type-id-4' name='mapoff'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Lget_proc_info_in_range.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_get_proc_info_in_range' mangled-name='_ULx86_64_get_proc_info_in_range' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_proc_info_in_range'>
+      <parameter type-id='type-id-4' name='start_ip'/>
+      <parameter type-id='type-id-4' name='end_ip'/>
+      <parameter type-id='type-id-4' name='eh_frame_table'/>
+      <parameter type-id='type-id-4' name='eh_frame_table_len'/>
+      <parameter type-id='type-id-4' name='exidx_frame_table'/>
+      <parameter type-id='type-id-4' name='exidx_frame_table_len'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-7' name='need_unwind_info'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/global.c' language='LANG_C99'>
+    <class-decl name='mempool' size-in-bits='640' is-struct='yes' visibility='default' id='type-id-19'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='obj_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='chunk_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='reserve' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='num_free' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='free_list' type-id='type-id-21' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='object' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-22'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-21' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-21'/>
+    <var-decl name='dwarf_reg_state_pool' type-id='type-id-19' visibility='default'/>
+    <var-decl name='dwarf_cie_info_pool' type-id='type-id-19' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Ldestroy_addr_space.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_destroy_addr_space' mangled-name='_ULx86_64_destroy_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_destroy_addr_space'>
+      <parameter type-id='type-id-3' name='as'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-24' id='type-id-25'/>
+    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-26'/>
+    <function-decl name='_Ux86_64_get_accessors' mangled-name='_Ux86_64_get_accessors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_accessors'>
+      <parameter type-id='type-id-3' name='as'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_get_elf_filename_by_ip' mangled-name='_ULx86_64_get_elf_filename_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_elf_filename_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULx86_64_get_elf_filename' mangled-name='_ULx86_64_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_elf_filename'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_fpreg.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_get_fpreg' mangled-name='_ULx86_64_get_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_fpreg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-30' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_proc_info_by_ip.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_get_proc_info_by_ip' mangled-name='_ULx86_64_get_proc_info_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_proc_info_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-8' name='as_arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_proc_name.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_get_proc_name_by_ip' mangled-name='_ULx86_64_get_proc_name_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_proc_name_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULx86_64_get_proc_name' mangled-name='_ULx86_64_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_proc_name'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_reg.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_get_reg' mangled-name='_ULx86_64_get_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_reg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-28' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_cache_size.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_set_cache_size' mangled-name='_ULx86_64_set_cache_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_set_cache_size'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-11' name='size'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_caching_policy.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_set_caching_policy' mangled-name='_ULx86_64_set_caching_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_set_caching_policy'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-31' name='policy'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_fpreg.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_set_fpreg' mangled-name='_ULx86_64_set_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_set_fpreg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-32' name='val'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_iterate_phdr_function.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_set_iterate_phdr_function' mangled-name='_ULx86_64_set_iterate_phdr_function' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_set_iterate_phdr_function'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-33' name='function'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_reg.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_set_reg' mangled-name='_ULx86_64_set_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_set_reg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-4' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/backtrace.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-34' size-in-bits='768' id='type-id-35'>
+      <subrange length='24' lower-bound='0' upper-bound='23' type-id='type-id-36' id='type-id-37'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-34' size-in-bits='128' id='type-id-38'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-36' id='type-id-39'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-40' size-in-bits='1024' id='type-id-41'>
+      <subrange length='8' lower-bound='0' upper-bound='7' type-id='type-id-36' id='type-id-42'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-43' size-in-bits='2048' id='type-id-44'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-36' id='type-id-45'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-46' size-in-bits='1472' id='type-id-47'>
+      <subrange length='23' lower-bound='0' upper-bound='22' type-id='type-id-36' id='type-id-48'/>
+    </array-type-def>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-49'/>
+    <class-decl name='_libc_fpstate' size-in-bits='4096' is-struct='yes' visibility='default' id='type-id-50'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cwd' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='swd' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='ftw' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='fop' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='rip' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='rdp' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mxcsr' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='mxcr_mask' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_st' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='_xmm' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3328'>
+        <var-decl name='__glibc_reserved1' type-id='type-id-35' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_libc_fpxreg' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-40'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='significand' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='exponent' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='__glibc_reserved1' type-id='type-id-55' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_libc_xmmreg' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='element' type-id='type-id-38' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='mcontext_t' size-in-bits='2048' is-struct='yes' naming-typedef-id='type-id-56' visibility='default' id='type-id-57'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gregs' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='fpregs' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='__reserved1' type-id='type-id-60' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='stack_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-61' visibility='default' id='type-id-62'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ss_sp' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ss_flags' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ss_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucontext_t' size-in-bits='7744' is-struct='yes' visibility='default' id='type-id-63'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uc_flags' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uc_link' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uc_stack' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='uc_mcontext' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2368'>
+        <var-decl name='uc_sigmask' type-id='type-id-65' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='3392'>
+        <var-decl name='__fpregs_mem' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='7488'>
+        <var-decl name='__ssp' type-id='type-id-66' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='fpregset_t' type-id='type-id-67' id='type-id-59'/>
+    <typedef-decl name='greg_t' type-id='type-id-49' id='type-id-46'/>
+    <typedef-decl name='gregset_t' type-id='type-id-47' id='type-id-58'/>
+    <typedef-decl name='mcontext_t' type-id='type-id-57' id='type-id-56'/>
+    <typedef-decl name='stack_t' type-id='type-id-62' id='type-id-61'/>
+    <typedef-decl name='ucontext_t' type-id='type-id-63' id='type-id-68'/>
+    <typedef-decl name='unw_context_t' type-id='type-id-69' id='type-id-70'/>
+    <typedef-decl name='unw_tdep_context_t' type-id='type-id-68' id='type-id-69'/>
+    <array-type-def dimensions='1' type-id='type-id-71' size-in-bits='256' id='type-id-66'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-36' id='type-id-39'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-71' size-in-bits='512' id='type-id-60'>
+      <subrange length='8' lower-bound='0' upper-bound='7' type-id='type-id-36' id='type-id-42'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-54' size-in-bits='48' id='type-id-55'>
+      <subrange length='3' lower-bound='0' upper-bound='2' type-id='type-id-36' id='type-id-72'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-54' size-in-bits='64' id='type-id-53'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-36' id='type-id-39'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-50' size-in-bits='64' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='64' id='type-id-64'/>
+    <pointer-type-def type-id='type-id-70' size-in-bits='64' id='type-id-73'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-74'/>
+    <function-decl name='unw_backtrace' mangled-name='unw_backtrace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_backtrace'>
+      <parameter type-id='type-id-74' name='buffer'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='unw_backtrace2' mangled-name='unw_backtrace2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_backtrace2'>
+      <parameter type-id='type-id-74' name='buffer'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <parameter type-id='type-id-73' name='uc2'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-cancel.c' language='LANG_C99'>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-75'/>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-76'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-78' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-79'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-80' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-80' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-81' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-82'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-84' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-85'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-86' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-87' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-88'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-89'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-28' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int16_t' type-id='type-id-90' id='type-id-91'/>
+    <typedef-decl name='__int32_t' type-id='type-id-7' id='type-id-92'/>
+    <typedef-decl name='__int8_t' type-id='type-id-75' id='type-id-93'/>
+    <typedef-decl name='int16_t' type-id='type-id-91' id='type-id-81'/>
+    <typedef-decl name='int32_t' type-id='type-id-92' id='type-id-2'/>
+    <typedef-decl name='int8_t' type-id='type-id-93' id='type-id-80'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-76' id='type-id-16'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-79' id='type-id-94'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-82' id='type-id-95'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-85' id='type-id-96'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-88' id='type-id-97'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-89' id='type-id-98'/>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-78'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-95' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-98' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-97' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-94' size-in-bits='128' id='type-id-87'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-36' id='type-id-99'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-76' size-in-bits='64' id='type-id-77'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-5'/>
+    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-96' size-in-bits='64' id='type-id-84'/>
+    <function-decl name='_U_dyn_cancel' mangled-name='_U_dyn_cancel' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_cancel'>
+      <parameter type-id='type-id-5' name='di'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-info-list.c' language='LANG_C99'>
+    <class-decl name='unw_dyn_info_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-100'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='version' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='generation' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='first' type-id='type-id-5' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_dyn_info_list_t' type-id='type-id-100' id='type-id-101'/>
+    <var-decl name='_U_dyn_info_list' type-id='type-id-101' visibility='default'/>
+    <function-decl name='_U_dyn_info_list_addr' mangled-name='_U_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_info_list_addr'>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-register.c' language='LANG_C99'>
+    <var-decl name='_U_dyn_info_list_lock' type-id='type-id-20' visibility='default'/>
+    <function-decl name='_U_dyn_register' mangled-name='_U_dyn_register' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_register'>
+      <parameter type-id='type-id-5' name='di'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/flush_cache.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-102' size-in-bits='152' id='type-id-103'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-36' id='type-id-104'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-102' size-in-bits='320' id='type-id-105'>
+      <subrange length='40' lower-bound='0' upper-bound='39' type-id='type-id-36' id='type-id-106'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-107' size-in-bits='16384' id='type-id-108'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-36' id='type-id-109'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-110' size-in-bits='188416' id='type-id-111'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-36' id='type-id-109'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-31' id='type-id-112'>
+      <underlying-type type-id='type-id-113'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='long double' size-in-bits='128' id='type-id-114'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-90'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-115' visibility='default' id='type-id-116'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-117' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-117' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-120' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-120' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-120' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_internal_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-121'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__prev' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__next' type-id='type-id-122' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__pthread_mutex_s' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-123'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__lock' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__count' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__owner' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__nusers' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__kind' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='__spins' type-id='type-id-90' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='__elision' type-id='type-id-90' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__list' type-id='type-id-125' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-126'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-128' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='dlpi_adds' type-id='type-id-71' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='dlpi_subs' type-id='type-id-71' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='dlpi_tls_modid' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='dlpi_tls_data' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-129'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-54' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='1408' is-struct='yes' visibility='default' id='type-id-130'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-103' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='val' type-id='type-id-131' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='1472' is-struct='yes' visibility='default' id='type-id-132'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-133' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='209536' is-struct='yes' visibility='default' id='type-id-134'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='rr_head' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='log_size' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='prev_log_size' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='hash' type-id='type-id-135' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='generation' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='buckets' type-id='type-id-136' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='links' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='default_hash' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4736'>
+        <var-decl name='default_buckets' type-id='type-id-111' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='193152'>
+        <var-decl name='default_links' type-id='type-id-108' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-24'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-139' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-142' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-144' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-145' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-146' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-146' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-147' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-148' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='210560' is-struct='yes' visibility='default' id='type-id-149'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='caching_policy' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='cache_generation' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='dyn_generation' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='global_cache' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='210496'>
+        <var-decl name='debug_frames' type-id='type-id-150' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='type-id-151'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-152' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-153'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-150' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-155'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-156' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-156' visibility='default' id='type-id-157'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-158' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-159' id='type-id-119'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-160' id='type-id-128'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-159' id='type-id-118'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-116' id='type-id-115'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-83' id='type-id-117'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-159' id='type-id-120'/>
+    <typedef-decl name='__pthread_list_t' type-id='type-id-121' id='type-id-125'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-54' id='type-id-51'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-124' id='type-id-34'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-161' id='type-id-162'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-129' id='type-id-107'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-130' id='type-id-133'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-132' id='type-id-110'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-163' id='type-id-20'/>
+    <typedef-decl name='uint16_t' type-id='type-id-51' id='type-id-160'/>
+    <typedef-decl name='uint32_t' type-id='type-id-34' id='type-id-83'/>
+    <typedef-decl name='uint8_t' type-id='type-id-162' id='type-id-158'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-164' id='type-id-3'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-112' id='type-id-31'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-151' id='type-id-165'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-166' id='type-id-32'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-167' id='type-id-13'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-168' id='type-id-33'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-155' id='type-id-169'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-7' id='type-id-170'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-114' id='type-id-166'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-157' id='type-id-156'/>
+    <union-decl name='pthread_mutex_t' size-in-bits='320' naming-typedef-id='type-id-20' visibility='default' id='type-id-163'>
+      <data-member access='public'>
+        <var-decl name='__data' type-id='type-id-123' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__size' type-id='type-id-105' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__align' type-id='type-id-171' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-113'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-161'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-124'/>
+    <type-decl name='unsigned long long int' size-in-bits='64' id='type-id-71'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-54'/>
+    <array-type-def dimensions='1' type-id='type-id-54' size-in-bits='4096' id='type-id-138'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-36' id='type-id-172'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-4' size-in-bits='8128' id='type-id-152'>
+      <subrange length='127' lower-bound='0' upper-bound='126' type-id='type-id-36' id='type-id-173'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-4' size-in-bits='1216' id='type-id-131'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-36' id='type-id-104'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-121' size-in-bits='64' id='type-id-122'/>
+    <qualified-type-def type-id='type-id-115' const='yes' id='type-id-174'/>
+    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-127'/>
+    <qualified-type-def type-id='type-id-102' const='yes' id='type-id-175'/>
+    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-18'/>
+    <pointer-type-def type-id='type-id-126' size-in-bits='64' id='type-id-10'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-137'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-136'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-167'/>
+    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-144'/>
+    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-143'/>
+    <pointer-type-def type-id='type-id-178' size-in-bits='64' id='type-id-146'/>
+    <pointer-type-def type-id='type-id-179' size-in-bits='64' id='type-id-139'/>
+    <pointer-type-def type-id='type-id-180' size-in-bits='64' id='type-id-142'/>
+    <pointer-type-def type-id='type-id-181' size-in-bits='64' id='type-id-147'/>
+    <pointer-type-def type-id='type-id-182' size-in-bits='64' id='type-id-145'/>
+    <pointer-type-def type-id='type-id-183' size-in-bits='64' id='type-id-141'/>
+    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-168'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-154'/>
+    <pointer-type-def type-id='type-id-184' size-in-bits='64' id='type-id-148'/>
+    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-135'/>
+    <pointer-type-def type-id='type-id-149' size-in-bits='64' id='type-id-164'/>
+    <pointer-type-def type-id='type-id-165' size-in-bits='64' id='type-id-29'/>
+    <pointer-type-def type-id='type-id-153' size-in-bits='64' id='type-id-150'/>
+    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-28'/>
+    <pointer-type-def type-id='type-id-185' size-in-bits='64' id='type-id-140'/>
+    <function-decl name='_Ux86_64_flush_cache' mangled-name='_Ux86_64_flush_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_flush_cache'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='lo'/>
+      <parameter type-id='type-id-4' name='hi'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-176'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-170'/>
+      <parameter type-id='type-id-30'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-177'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-170'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-178'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-179'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-180'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-181'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-182'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-183'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-184'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-4'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-185'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-171'/>
+    <class-decl name='__sigset_t' size-in-bits='1024' is-struct='yes' naming-typedef-id='type-id-186' visibility='default' id='type-id-187'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__val' type-id='type-id-188' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__sigset_t' type-id='type-id-187' id='type-id-186'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-65' id='type-id-189'/>
+    <typedef-decl name='sigset_t' type-id='type-id-186' id='type-id-65'/>
+    <array-type-def dimensions='1' type-id='type-id-36' size-in-bits='1024' id='type-id-188'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-36' id='type-id-45'/>
+    </array-type-def>
+    <var-decl name='_UIx86_64_full_mask' type-id='type-id-189' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-171' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/strerror.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_strerror' mangled-name='_Ux86_64_strerror' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_strerror'>
+      <parameter type-id='type-id-7' name='err_code'/>
+      <return type-id='type-id-18'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/os-linux.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-102'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-7'/>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-15'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__pid_t' type-id='type-id-7' id='type-id-190'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-36' id='type-id-52'/>
+    <typedef-decl name='pid_t' type-id='type-id-190' id='type-id-191'/>
+    <typedef-decl name='size_t' type-id='type-id-36' id='type-id-11'/>
+    <typedef-decl name='uint64_t' type-id='type-id-52' id='type-id-159'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-159' id='type-id-4'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-36'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-27'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-192'/>
+    <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-193'/>
+    <function-decl name='_Ux86_64_get_elf_image' mangled-name='_Ux86_64_get_elf_image' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_elf_image'>
+      <parameter type-id='type-id-192' name='ei'/>
+      <parameter type-id='type-id-191' name='pid'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-193' name='segbase'/>
+      <parameter type-id='type-id-193' name='mapoff'/>
+      <parameter type-id='type-id-27' name='path'/>
+      <parameter type-id='type-id-11' name='pathlen'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_get_exe_image_path' mangled-name='_Ux86_64_get_exe_image_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_exe_image_path'>
+      <parameter type-id='type-id-27' name='path'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-23'/>
+    <pointer-type-def type-id='type-id-23' id='type-id-8'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lapply_reg_state.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_apply_reg_state' mangled-name='_ULx86_64_apply_reg_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_apply_reg_state'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-8' name='reg_states_data'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lcreate_addr_space.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_create_addr_space' mangled-name='_ULx86_64_create_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_create_addr_space'>
+      <parameter type-id='type-id-26' name='a'/>
+      <parameter type-id='type-id-7' name='byte_order'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lget_proc_info.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_get_proc_info' mangled-name='_ULx86_64_get_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_proc_info'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lget_save_loc.c' language='LANG_C99'>
+    <enum-decl name='unw_save_loc_type' id='type-id-194'>
+      <underlying-type type-id='type-id-113'/>
+      <enumerator name='UNW_SLT_NONE' value='0'/>
+      <enumerator name='UNW_SLT_MEMORY' value='1'/>
+      <enumerator name='UNW_SLT_REG' value='2'/>
+    </enum-decl>
+    <class-decl name='unw_save_loc' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-195'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-196' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='u' type-id='type-id-197' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='extra' type-id='type-id-198' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_save_loc' size-in-bits='8' is-struct='yes' visibility='default' id='type-id-199'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-158' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_save_loc_t' type-id='type-id-195' id='type-id-200'/>
+    <typedef-decl name='unw_save_loc_type_t' type-id='type-id-194' id='type-id-196'/>
+    <typedef-decl name='unw_tdep_save_loc_t' type-id='type-id-199' id='type-id-198'/>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-197'>
+      <data-member access='public'>
+        <var-decl name='addr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='regnum' type-id='type-id-170' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-200' size-in-bits='64' id='type-id-201'/>
+    <function-decl name='_ULx86_64_get_save_loc' mangled-name='_ULx86_64_get_save_loc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_save_loc'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='reg'/>
+      <parameter type-id='type-id-201' name='sloc'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lglobal.c' language='LANG_C99'>
+    <type-decl name='atomic_bool' size-in-bits='8' id='type-id-202'/>
+    <array-type-def dimensions='1' type-id='type-id-203' size-in-bits='136' id='type-id-204'>
+      <subrange length='17' lower-bound='0' upper-bound='16' type-id='type-id-36' id='type-id-205'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-158' const='yes' id='type-id-203'/>
+    <var-decl name='_ULx86_64_dwarf_to_unw_regnum_map' type-id='type-id-204' visibility='default'/>
+    <var-decl name='_ULx86_64_init_done' type-id='type-id-202' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Linit.c' language='LANG_C99'>
+    <var-decl name='_ULx86_64_local_addr_space' type-id='type-id-3' mangled-name='_ULx86_64_local_addr_space' visibility='default' elf-symbol-id='_ULx86_64_local_addr_space'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Linit_local.c' language='LANG_C99'>
+    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-206'/>
+    <function-decl name='_ULx86_64_init_local' mangled-name='_ULx86_64_init_local' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_init_local'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-206' name='uc'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULx86_64_init_local2' mangled-name='_ULx86_64_init_local2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_init_local2'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-206' name='uc'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Linit_remote.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_init_remote' mangled-name='_ULx86_64_init_remote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_init_remote'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-8' name='as_arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Los-linux.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_is_signal_frame' mangled-name='_ULx86_64_is_signal_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_is_signal_frame'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lreg_states_iterate.c' language='LANG_C99'>
+    <typedef-decl name='unw_reg_states_callback' type-id='type-id-207' id='type-id-208'/>
+    <pointer-type-def type-id='type-id-209' size-in-bits='64' id='type-id-207'/>
+    <function-decl name='_ULx86_64_reg_states_iterate' mangled-name='_ULx86_64_reg_states_iterate' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_reg_states_iterate'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-208' name='cb'/>
+      <parameter type-id='type-id-8' name='token'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-209'>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lresume.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_resume' mangled-name='_ULx86_64_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_resume'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lstep.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_step' mangled-name='_ULx86_64_step' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_step'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/is_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_is_fpreg' mangled-name='_Ux86_64_is_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_is_fpreg'>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/regname.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_regname' mangled-name='_Ux86_64_regname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_regname'>
+      <parameter type-id='type-id-170' name='reg'/>
+      <return type-id='type-id-18'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/x86_64/nto-qnx7.1.0/libunwind-coredump.abi
+++ b/src/abi/x86_64/nto-qnx7.1.0/libunwind-coredump.abi
@@ -1,0 +1,1531 @@
+<abi-corpus version='2.2' architecture='elf-amd-x86_64' soname='libunwind-coredump.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-x86_64.so.9'/>
+    <dependency name='liblzma.so.5'/>
+    <dependency name='libz.so.2'/>
+    <dependency name='libc.so.5'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_UCD_access_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_access_mem' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_access_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_find_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_cursig' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_mapinfo' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_num_threads' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_pid' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_get_threadinfo' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_put_unwind_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_UCD_select_thread' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_UCD_accessors' size='88' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_access_mem.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-1'/>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='152' id='type-id-2'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-3' id='type-id-4'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='16384' id='type-id-6'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-7'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='188416' id='type-id-9'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-7'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-10' id='type-id-11'>
+      <underlying-type type-id='type-id-12'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-13'/>
+    <type-decl name='long double' size-in-bits='128' id='type-id-14'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-15' visibility='default' id='type-id-16'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-17' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-17' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-20' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_sync' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-21'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__u' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__owner' type-id='type-id-23' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-24'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-25' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-27' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-28'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-30' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='1408' is-struct='yes' visibility='default' id='type-id-31'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='val' type-id='type-id-32' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='1472' is-struct='yes' visibility='default' id='type-id-33'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-34' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='209280' is-struct='yes' visibility='default' id='type-id-35'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-36' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='rr_head' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='log_size' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='prev_log_size' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='hash' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='generation' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='buckets' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='links' type-id='type-id-40' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='default_hash' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4480'>
+        <var-decl name='default_buckets' type-id='type-id-9' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192896'>
+        <var-decl name='default_links' type-id='type-id-6' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-48' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-52' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='210304' is-struct='yes' visibility='default' id='type-id-53'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='caching_policy' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='cache_generation' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='dyn_generation' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='global_cache' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='210240'>
+        <var-decl name='debug_frames' type-id='type-id-55' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='type-id-56'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-57' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-58'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-55' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-62'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-64' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-64' visibility='default' id='type-id-65'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-66' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-67' id='type-id-19'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-68' id='type-id-27'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-67' id='type-id-18'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-16' id='type-id-15'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-38' id='type-id-17'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-67' id='type-id-20'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u16t' type-id='type-id-30' id='type-id-69'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u32t' type-id='type-id-23' id='type-id-70'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u64t' type-id='type-id-3' id='type-id-71'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u8t' type-id='type-id-72' id='type-id-73'/>
+    <typedef-decl name='_Sizet' type-id='type-id-74' id='type-id-75'/>
+    <typedef-decl name='_Uint16t' type-id='type-id-69' id='type-id-76'/>
+    <typedef-decl name='_Uint32t' type-id='type-id-70' id='type-id-77'/>
+    <typedef-decl name='_Uint64t' type-id='type-id-71' id='type-id-74'/>
+    <typedef-decl name='_Uint8t' type-id='type-id-73' id='type-id-78'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-28' id='type-id-5'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-31' id='type-id-34'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-33' id='type-id-8'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-21' id='type-id-36'/>
+    <typedef-decl name='size_t' type-id='type-id-75' id='type-id-60'/>
+    <typedef-decl name='uint16_t' type-id='type-id-76' id='type-id-68'/>
+    <typedef-decl name='uint32_t' type-id='type-id-77' id='type-id-38'/>
+    <typedef-decl name='uint64_t' type-id='type-id-74' id='type-id-67'/>
+    <typedef-decl name='uint8_t' type-id='type-id-78' id='type-id-66'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-79' id='type-id-80'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-11' id='type-id-10'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-56' id='type-id-81'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-82' id='type-id-83'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-84' id='type-id-85'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-86' id='type-id-54'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-62' id='type-id-87'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-13' id='type-id-88'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-14' id='type-id-82'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-65' id='type-id-64'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-67' id='type-id-29'/>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-22'>
+      <data-member access='public'>
+        <var-decl name='__count' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__fd' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__clockid' type-id='type-id-13' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-12'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-72'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-23'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-3'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-30'/>
+    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='4096' id='type-id-41'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-3' id='type-id-89'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='8128' id='type-id-57'>
+      <subrange length='127' lower-bound='0' upper-bound='126' type-id='type-id-3' id='type-id-90'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1216' id='type-id-32'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-3' id='type-id-4'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-59'/>
+    <qualified-type-def type-id='type-id-15' const='yes' id='type-id-91'/>
+    <pointer-type-def type-id='type-id-91' size-in-bits='64' id='type-id-26'/>
+    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-92'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='64' id='type-id-25'/>
+    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-93'/>
+    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-40'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-39'/>
+    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-84'/>
+    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-96' size-in-bits='64' id='type-id-47'/>
+    <pointer-type-def type-id='type-id-97' size-in-bits='64' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-43'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='64' id='type-id-46'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-49'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-37'/>
+    <pointer-type-def type-id='type-id-53' size-in-bits='64' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-81' size-in-bits='64' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-58' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-83' size-in-bits='64' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-107'/>
+    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-44'/>
+    <class-decl name='table_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-61'/>
+    <function-decl name='_UCD_access_mem' mangled-name='_UCD_access_mem' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_mem'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-29' name='addr'/>
+      <parameter type-id='type-id-108' name='val'/>
+      <parameter type-id='type-id-13' name='write'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-111'/>
+    <pointer-type-def type-id='type-id-111' id='type-id-63'/>
+    <function-type size-in-bits='64' id='type-id-94'>
+      <parameter type-id='type-id-93'/>
+      <parameter type-id='type-id-60'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-103'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-95'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-106'/>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-96'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-97'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-59'/>
+      <parameter type-id='type-id-60'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-98'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-107'/>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-99'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-100'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-101'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-105'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-102'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-108'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-104'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-29'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-109'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-107'/>
+      <parameter type-id='type-id-63'/>
+      <return type-id='type-id-111'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_access_reg_qnx.c' language='LANG_C99'>
+    <function-decl name='_UCD_access_reg' mangled-name='_UCD_access_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_reg'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-88' name='regnum'/>
+      <parameter type-id='type-id-108' name='valp'/>
+      <parameter type-id='type-id-13' name='write'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-42' id='type-id-112'/>
+    <var-decl name='_UCD_accessors' type-id='type-id-112' mangled-name='_UCD_accessors' visibility='default' elf-symbol-id='_UCD_accessors'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_create.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-77' size-in-bits='64' id='type-id-113'>
+      <subrange length='2' lower-bound='0' upper-bound='1' type-id='type-id-3' id='type-id-114'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-74' size-in-bits='65536' id='type-id-115'>
+      <subrange length='1024' lower-bound='0' upper-bound='1023' type-id='type-id-3' id='type-id-116'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-74' size-in-bits='256' id='type-id-117'>
+      <subrange length='4' lower-bound='0' upper-bound='3' type-id='type-id-3' id='type-id-118'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-74' size-in-bits='448' id='type-id-119'>
+      <subrange length='7' lower-bound='0' upper-bound='6' type-id='type-id-3' id='type-id-120'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-78' size-in-bits='8192' id='type-id-121'>
+      <subrange length='1024' lower-bound='0' upper-bound='1023' type-id='type-id-3' id='type-id-116'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-78' size-in-bits='1024' id='type-id-122'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-7'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-78' size-in-bits='1792' id='type-id-123'>
+      <subrange length='224' lower-bound='0' upper-bound='223' type-id='type-id-3' id='type-id-124'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-78' size-in-bits='4096' id='type-id-125'>
+      <subrange length='512' lower-bound='0' upper-bound='511' type-id='type-id-3' id='type-id-126'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-78' size-in-bits='640' id='type-id-127'>
+      <subrange length='80' lower-bound='0' upper-bound='79' type-id='type-id-3' id='type-id-128'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-78' size-in-bits='64' id='type-id-129'>
+      <subrange length='8' lower-bound='0' upper-bound='7' type-id='type-id-3' id='type-id-130'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-13' size-in-bits='224' id='type-id-131'>
+      <subrange length='7' lower-bound='0' upper-bound='6' type-id='type-id-3' id='type-id-120'/>
+    </array-type-def>
+    <type-decl name='long int' size-in-bits='64' id='type-id-132'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-133'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-134'/>
+    <class-decl name='UCD_info' size-in-bits='2240' is-struct='yes' visibility='default' id='type-id-135'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='big_endian' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='coredump_fd' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coredump_filename' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='phdrs' type-id='type-id-136' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='phdrs_count' type-id='type-id-23' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ucd_file_table' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='note_phdr' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='prstatus' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='n_threads' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='threads' type-id='type-id-139' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='edi' type-id='type-id-140' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='UCD_proc_status_t' size-in-bits='133248' is-struct='yes' naming-typedef-id='type-id-141' visibility='default' id='type-id-142'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='thread' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='greg' type-id='type-id-144' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='67712'>
+        <var-decl name='fpreg' type-id='type-id-145' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='UCD_thread_info' size-in-bits='133248' is-struct='yes' visibility='default' id='type-id-146'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='prstatus' type-id='type-id-141' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_debug_thread_info64' size-in-bits='2176' is-struct='yes' visibility='default' id='type-id-147'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pid' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='tid' type-id='type-id-149' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='flags' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='why' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='112'>
+        <var-decl name='what' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ip' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='sp' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='stkbase' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='tls' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='stksize' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='tid_flags' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='priority' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='456'>
+        <var-decl name='real_priority' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='464'>
+        <var-decl name='policy' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='472'>
+        <var-decl name='state' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='syscall' type-id='type-id-150' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='496'>
+        <var-decl name='last_cpu' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='timeout' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='last_chid' type-id='type-id-151' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='sig_blocked' type-id='type-id-152' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='sig_pending' type-id='type-id-152' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='__info32' type-id='type-id-153' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='blocked' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='start_time' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='sutime' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='extsched' type-id='type-id-129' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='nsec_since_block' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='' type-id='type-id-155' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1920'>
+        <var-decl name='reserved2' type-id='type-id-117' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_siginfo' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-156'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='si_signo' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='si_code' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='si_errno' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__data' type-id='type-id-157' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_siginfo32' size-in-bits='320' is-struct='yes' visibility='default' id='type-id-158'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='si_signo' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='si_code' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='si_errno' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__data' type-id='type-id-159' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_siginfo64' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-160'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='si_signo' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='si_code' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='si_errno' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__data' type-id='type-id-161' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='coredump_phdr' size-in-bits='448' is-struct='yes' visibility='default' id='type-id-162'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-163' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-163' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_filesz' type-id='type-id-163' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_memsz' type-id='type-id-163' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_align' type-id='type-id-163' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_backing_file_index' type-id='type-id-164' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-140'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-165' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-166' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-166' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-165'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-60' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='fpu_extention_savearea_64' size-in-bits='6400' is-struct='yes' visibility='default' id='type-id-167'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='other' type-id='type-id-125' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4096'>
+        <var-decl name='xstate_bv' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4160'>
+        <var-decl name='xstate_undef' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4608'>
+        <var-decl name='xstate_info' type-id='type-id-123' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='fsave_area_64' size-in-bits='864' is-struct='yes' visibility='default' id='type-id-168'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fpu_control_word' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fpu_status_word' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fpu_tag_word' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='fpu_ip' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='fpu_cs' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='fpu_op' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='fpu_ds' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='st_regs' type-id='type-id-127' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='fxsave_area_64' size-in-bits='4096' is-struct='yes' visibility='default' id='type-id-169'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fpu_control_word' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='fpu_status_word' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fpu_tag_word' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='fpu_operand' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fpu_rip' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='fpu_rdp' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mxcsr' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='mxcsr_mask' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='st_regs' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='xmm_regs' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='reserved2' type-id='type-id-123' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='sigset_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-152' visibility='default' id='type-id-170'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__bits' type-id='type-id-113' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucd_file_s' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-171'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='filename' type-id='type-id-25' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fd' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='size' type-id='type-id-172' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='image' type-id='type-id-173' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='ucd_file_table_s' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-174'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uft_count' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uft_size' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uft_files' type-id='type-id-175' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-176'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-177' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-177' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-178' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-178' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-179' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-180'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-181' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-181' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-182' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-178' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-29' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-183'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-178' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-184' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-185'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-186' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-178' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-187' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-188'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-29' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-189'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-108' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='x86_64_cpu_registers' size-in-bits='1280' is-struct='yes' visibility='default' id='type-id-190'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='rdi' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='rsi' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='rdx' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='r10' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='r8' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='r9' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='rax' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='rbx' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='rbp' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='rcx' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='r11' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='r12' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='r13' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='r14' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='r15' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='rip' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='cs' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='rsvd1' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='rflags' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='rsp' type-id='type-id-74' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='ss' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1248'>
+        <var-decl name='rsvd2' type-id='type-id-77' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__8' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-191'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='chid' type-id='type-id-151' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__6' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-192'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='id' type-id='type-id-193' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='sync' type-id='type-id-194' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__10' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-195'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='size' type-id='type-id-196' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__7' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-197'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='nd' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='pid' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coid' type-id='type-id-151' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='chid' type-id='type-id-151' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='scoid' type-id='type-id-151' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='flags' type-id='type-id-77' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__3' size-in-bits='96' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-198'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__utime' type-id='type-id-199' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__status' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__stime' type-id='type-id-199' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__4' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-200'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__fltno' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__fltip' type-id='type-id-201' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__addr' type-id='type-id-201' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='__bdslot' type-id='type-id-13' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__16' size-in-bits='256' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-202'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__fltno' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__fltip' type-id='type-id-194' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__addr' type-id='type-id-194' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__bdslot' type-id='type-id-13' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__20' size-in-bits='256' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-203'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__fltno' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__fltip' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='__addr' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='__bdslot' type-id='type-id-13' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__1' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-204'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__pid' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__pdata' type-id='type-id-205' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__13' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-206'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__pid' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__pdata' type-id='type-id-207' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__17' size-in-bits='192' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-208'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__pid' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__pdata' type-id='type-id-209' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__12' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-210'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='child' type-id='type-id-148' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__9' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-211'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pid' type-id='type-id-148' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='flags' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='vaddr' type-id='type-id-194' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__5' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-212'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tid' type-id='type-id-149' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__2' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-213'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__uid' type-id='type-id-214' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__value' type-id='type-id-215' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__14' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-216'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__uid' type-id='type-id-214' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__value' type-id='type-id-217' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__18' size-in-bits='128' is-struct='yes' is-anonymous='yes' visibility='default' id='type-id-218'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__uid' type-id='type-id-214' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='__value' type-id='type-id-219' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='UCD_proc_status_t' type-id='type-id-142' id='type-id-141'/>
+    <typedef-decl name='X86_64_CPU_REGISTERS' type-id='type-id-190' id='type-id-220'/>
+    <typedef-decl name='X86_64_FPU_REGISTERS' type-id='type-id-221' id='type-id-222'/>
+    <typedef-decl name='X86_64_FXSAVE_REGISTERS' type-id='type-id-169' id='type-id-223'/>
+    <typedef-decl name='X86_64_NDP_REGISTERS' type-id='type-id-168' id='type-id-224'/>
+    <typedef-decl name='X86_64_XSAVE_REGISTERS' type-id='type-id-167' id='type-id-225'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_16t' type-id='type-id-133' id='type-id-226'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_32t' type-id='type-id-13' id='type-id-227'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_64t' type-id='type-id-132' id='type-id-228'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_8t' type-id='type-id-134' id='type-id-229'/>
+    <typedef-decl name='_Int16t' type-id='type-id-226' id='type-id-150'/>
+    <typedef-decl name='_Int32t' type-id='type-id-227' id='type-id-151'/>
+    <typedef-decl name='_Int64t' type-id='type-id-228' id='type-id-230'/>
+    <typedef-decl name='_Int8t' type-id='type-id-229' id='type-id-231'/>
+    <typedef-decl name='_Intptr64t' type-id='type-id-230' id='type-id-193'/>
+    <typedef-decl name='_Offt' type-id='type-id-230' id='type-id-232'/>
+    <typedef-decl name='_Size64t' type-id='type-id-74' id='type-id-196'/>
+    <typedef-decl name='_Uintptr32t' type-id='type-id-77' id='type-id-201'/>
+    <typedef-decl name='_Uintptr64t' type-id='type-id-74' id='type-id-194'/>
+    <typedef-decl name='__siginfo32_t' type-id='type-id-158' id='type-id-153'/>
+    <typedef-decl name='__siginfo64_t' type-id='type-id-160' id='type-id-233'/>
+    <typedef-decl name='clock_t' type-id='type-id-77' id='type-id-199'/>
+    <typedef-decl name='coredump_phdr_t' type-id='type-id-162' id='type-id-234'/>
+    <typedef-decl name='debug_fpreg_t' type-id='type-id-235' id='type-id-236'/>
+    <typedef-decl name='debug_greg_t' type-id='type-id-237' id='type-id-238'/>
+    <typedef-decl name='debug_thread64_t' type-id='type-id-147' id='type-id-239'/>
+    <typedef-decl name='debug_thread_t' type-id='type-id-239' id='type-id-240'/>
+    <typedef-decl name='int16_t' type-id='type-id-150' id='type-id-182'/>
+    <typedef-decl name='int32_t' type-id='type-id-151' id='type-id-178'/>
+    <typedef-decl name='int8_t' type-id='type-id-231' id='type-id-181'/>
+    <typedef-decl name='off_t' type-id='type-id-232' id='type-id-172'/>
+    <typedef-decl name='pid_t' type-id='type-id-13' id='type-id-148'/>
+    <typedef-decl name='procfs_fpreg' type-id='type-id-236' id='type-id-145'/>
+    <typedef-decl name='procfs_greg' type-id='type-id-238' id='type-id-144'/>
+    <typedef-decl name='procfs_status' type-id='type-id-240' id='type-id-143'/>
+    <typedef-decl name='pthread_t' type-id='type-id-151' id='type-id-149'/>
+    <typedef-decl name='siginfo_t' type-id='type-id-156' id='type-id-241'/>
+    <typedef-decl name='sigset_t' type-id='type-id-170' id='type-id-152'/>
+    <typedef-decl name='ucd_file_index_t' type-id='type-id-13' id='type-id-164'/>
+    <typedef-decl name='ucd_file_t' type-id='type-id-171' id='type-id-242'/>
+    <typedef-decl name='ucd_file_table_t' type-id='type-id-174' id='type-id-137'/>
+    <typedef-decl name='uid_t' type-id='type-id-13' id='type-id-214'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-176' id='type-id-166'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-180' id='type-id-243'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-183' id='type-id-244'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-185' id='type-id-245'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-188' id='type-id-246'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-189' id='type-id-247'/>
+    <typedef-decl name='uoff_t' type-id='type-id-67' id='type-id-163'/>
+    <union-decl name='__sigval32' size-in-bits='32' visibility='default' id='type-id-215'>
+      <data-member access='public'>
+        <var-decl name='sival_int' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='sival_ptr' type-id='type-id-201' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__sigval64' size-in-bits='64' visibility='default' id='type-id-217'>
+      <data-member access='public'>
+        <var-decl name='sival_int' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='sival_ptr' type-id='type-id-194' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='_debug_fpregs' size-in-bits='65536' visibility='default' id='type-id-235'>
+      <data-member access='public'>
+        <var-decl name='x86_64' type-id='type-id-222' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='padding' type-id='type-id-115' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='_debug_gregs' size-in-bits='65536' visibility='default' id='type-id-237'>
+      <data-member access='public'>
+        <var-decl name='x86_64' type-id='type-id-220' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='padding' type-id='type-id-115' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='sigval' size-in-bits='64' visibility='default' id='type-id-219'>
+      <data-member access='public'>
+        <var-decl name='sival_int' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='sival_ptr' type-id='type-id-63' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='x86_64_fpu_registers' size-in-bits='8192' visibility='default' id='type-id-221'>
+      <data-member access='public'>
+        <var-decl name='fsave_area' type-id='type-id-224' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='fxsave_area' type-id='type-id-223' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='xsave_area' type-id='type-id-225' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='data' type-id='type-id-121' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__3' size-in-bits='384' is-anonymous='yes' visibility='default' id='type-id-155'>
+      <data-member access='public'>
+        <var-decl name='info32' type-id='type-id-153' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='info64' type-id='type-id-233' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='info' type-id='type-id-241' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='224' is-anonymous='yes' visibility='default' id='type-id-159'>
+      <data-member access='public'>
+        <var-decl name='__pad' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__proc' type-id='type-id-204' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__fault' type-id='type-id-200' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__4' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-161'>
+      <data-member access='public'>
+        <var-decl name='__pad' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__proc' type-id='type-id-206' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__fault' type-id='type-id-202' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__6' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-157'>
+      <data-member access='public'>
+        <var-decl name='__pad' type-id='type-id-131' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__proc' type-id='type-id-208' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__fault' type-id='type-id-203' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__2' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-154'>
+      <data-member access='public'>
+        <var-decl name='join' type-id='type-id-212' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='sync' type-id='type-id-192' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='connect' type-id='type-id-197' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='channel' type-id='type-id-191' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='waitpage' type-id='type-id-211' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='stack' type-id='type-id-195' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='thread_event' type-id='type-id-212' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='fork_event' type-id='type-id-210' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='filler' type-id='type-id-117' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__1' size-in-bits='96' is-anonymous='yes' visibility='default' id='type-id-205'>
+      <data-member access='public'>
+        <var-decl name='__kill' type-id='type-id-213' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__chld' type-id='type-id-198' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__5' size-in-bits='128' is-anonymous='yes' visibility='default' id='type-id-207'>
+      <data-member access='public'>
+        <var-decl name='__kill' type-id='type-id-216' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__chld' type-id='type-id-198' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__7' size-in-bits='128' is-anonymous='yes' visibility='default' id='type-id-209'>
+      <data-member access='public'>
+        <var-decl name='__kill' type-id='type-id-218' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__chld' type-id='type-id-198' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__8' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-179'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-244' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-247' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-246' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-243' size-in-bits='128' id='type-id-187'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-3' id='type-id-248'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-249'/>
+    <pointer-type-def type-id='type-id-141' size-in-bits='64' id='type-id-138'/>
+    <pointer-type-def type-id='type-id-146' size-in-bits='64' id='type-id-139'/>
+    <pointer-type-def type-id='type-id-234' size-in-bits='64' id='type-id-136'/>
+    <pointer-type-def type-id='type-id-242' size-in-bits='64' id='type-id-175'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-173'/>
+    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-177'/>
+    <pointer-type-def type-id='type-id-185' size-in-bits='64' id='type-id-186'/>
+    <pointer-type-def type-id='type-id-245' size-in-bits='64' id='type-id-184'/>
+    <function-decl name='_UCD_create' mangled-name='_UCD_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_create'>
+      <parameter type-id='type-id-25' name='filename'/>
+      <return type-id='type-id-249'/>
+    </function-decl>
+    <function-decl name='_UCD_get_num_threads' mangled-name='_UCD_get_num_threads' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_num_threads'>
+      <parameter type-id='type-id-249' name='ui'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='_UCD_select_thread' mangled-name='_UCD_select_thread' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_select_thread'>
+      <parameter type-id='type-id-249' name='ui'/>
+      <parameter type-id='type-id-13' name='n'/>
+      <return type-id='type-id-111'/>
+    </function-decl>
+    <function-decl name='_UCD_get_pid' mangled-name='_UCD_get_pid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_pid'>
+      <parameter type-id='type-id-249' name='ui'/>
+      <return type-id='type-id-148'/>
+    </function-decl>
+    <function-decl name='_UCD_get_cursig' mangled-name='_UCD_get_cursig' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_cursig'>
+      <parameter type-id='type-id-249' name='ui'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_destroy.c' language='LANG_C99'>
+    <function-decl name='_UCD_destroy' mangled-name='_UCD_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_destroy'>
+      <parameter type-id='type-id-249' name='ui'/>
+      <return type-id='type-id-111'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_find_proc_info.c' language='LANG_C99'>
+    <function-decl name='_UCD_find_proc_info' mangled-name='_UCD_find_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_find_proc_info'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-29' name='ip'/>
+      <parameter type-id='type-id-107' name='pi'/>
+      <parameter type-id='type-id-13' name='need_unwind_info'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_elf_filename' mangled-name='_UCD_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_elf_filename'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-29' name='ip'/>
+      <parameter type-id='type-id-59' name='buf'/>
+      <parameter type-id='type-id-60' name='buf_len'/>
+      <parameter type-id='type-id-108' name='offp'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_mapinfo_qnx.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_mapinfo' mangled-name='_UCD_get_mapinfo' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_mapinfo'>
+      <parameter type-id='type-id-249' name='ui'/>
+      <parameter type-id='type-id-136' name='phdrs'/>
+      <parameter type-id='type-id-23' name='phdr_size'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_proc_name.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_proc_name' mangled-name='_UCD_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_proc_name'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-29' name='ip'/>
+      <parameter type-id='type-id-59' name='buf'/>
+      <parameter type-id='type-id-60' name='buf_len'/>
+      <parameter type-id='type-id-108' name='offp'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UCD_get_threadinfo_prstatus.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_threadinfo' mangled-name='_UCD_get_threadinfo' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_threadinfo'>
+      <parameter type-id='type-id-249' name='ui'/>
+      <parameter type-id='type-id-136' name='phdrs'/>
+      <parameter type-id='type-id-23' name='phdr_size'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_access_fpreg.c' language='LANG_C99'>
+    <function-decl name='_UCD_access_fpreg' mangled-name='_UCD_access_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_access_fpreg'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-88' name='reg'/>
+      <parameter type-id='type-id-106' name='val'/>
+      <parameter type-id='type-id-13' name='write'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_get_dyn_info_list_addr.c' language='LANG_C99'>
+    <function-decl name='_UCD_get_dyn_info_list_addr' mangled-name='_UCD_get_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_get_dyn_info_list_addr'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-108' name='dil_addr'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_put_unwind_info.c' language='LANG_C99'>
+    <function-decl name='_UCD_put_unwind_info' mangled-name='_UCD_put_unwind_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_put_unwind_info'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-107' name='pi'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-111'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/coredump/_UPT_resume.c' language='LANG_C99'>
+    <function-decl name='_UCD_resume' mangled-name='_UCD_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_UCD_resume'>
+      <parameter type-id='type-id-80' name='as'/>
+      <parameter type-id='type-id-105' name='c'/>
+      <parameter type-id='type-id-63' name='arg'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <typedef-decl name='intrmask_t' type-id='type-id-152' id='type-id-250'/>
+    <var-decl name='_UIx86_64_full_mask' type-id='type-id-250' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-132' visibility='default'/>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/x86_64/nto-qnx7.1.0/libunwind-nto.abi
+++ b/src/abi/x86_64/nto-qnx7.1.0/libunwind-nto.abi
@@ -1,0 +1,593 @@
+<abi-corpus version='2.2' architecture='elf-amd-x86_64' soname='libunwind-nto.so.0'>
+  <elf-needed>
+    <dependency name='libunwind-x86_64.so.9'/>
+    <dependency name='libunwind.so.9'/>
+    <dependency name='libc.so.5'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_fini' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_init' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_access_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_access_mem' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_access_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_find_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_get_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_get_proc_ip_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_put_unwind_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_nto_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='unw_nto_accessors' size='88' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-1' size-in-bits='64' id='type-id-2'>
+      <subrange length='2' lower-bound='0' upper-bound='1' type-id='type-id-3' id='type-id-4'/>
+    </array-type-def>
+    <type-decl name='long int' size-in-bits='64' id='type-id-5'/>
+    <class-decl name='sigset_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-6' visibility='default' id='type-id-7'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__bits' type-id='type-id-2' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u32t' type-id='type-id-8' id='type-id-9'/>
+    <typedef-decl name='_Uint32t' type-id='type-id-9' id='type-id-1'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-6' id='type-id-10'/>
+    <typedef-decl name='sigset_t' type-id='type-id-7' id='type-id-6'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-8'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-3'/>
+    <var-decl name='_UIx86_64_full_mask' type-id='type-id-10' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-5' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_access_fpreg.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-11'/>
+    <array-type-def dimensions='1' type-id='type-id-11' size-in-bits='152' id='type-id-12'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-3' id='type-id-13'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-14' size-in-bits='16384' id='type-id-15'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-16'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-17' size-in-bits='188416' id='type-id-18'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-3' id='type-id-16'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-19' id='type-id-20'>
+      <underlying-type type-id='type-id-21'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
+    <type-decl name='long double' size-in-bits='128' id='type-id-23'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-24' visibility='default' id='type-id-25'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-26' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-29' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-29' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_sync' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-30'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__u' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__owner' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-32'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-35' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-36'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-38' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='1408' is-struct='yes' visibility='default' id='type-id-39'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-12' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='val' type-id='type-id-40' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='1472' is-struct='yes' visibility='default' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-42' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='209280' is-struct='yes' visibility='default' id='type-id-43'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='rr_head' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='log_size' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='prev_log_size' type-id='type-id-38' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='hash' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='generation' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='buckets' type-id='type-id-47' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='links' type-id='type-id-48' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='default_hash' type-id='type-id-49' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4480'>
+        <var-decl name='default_buckets' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192896'>
+        <var-decl name='default_links' type-id='type-id-15' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-50'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-53' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-56' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-58' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-60' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='210304' is-struct='yes' visibility='default' id='type-id-61'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='caching_policy' type-id='type-id-19' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='cache_generation' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='dyn_generation' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='global_cache' type-id='type-id-43' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='210240'>
+        <var-decl name='debug_frames' type-id='type-id-63' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='type-id-64'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-65' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-66'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-67' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-69' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-63' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-70'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-37' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-71' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-72' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-72' visibility='default' id='type-id-73'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-74' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-75' id='type-id-28'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-76' id='type-id-35'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-75' id='type-id-27'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-25' id='type-id-24'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-46' id='type-id-26'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-75' id='type-id-29'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u16t' type-id='type-id-38' id='type-id-77'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u64t' type-id='type-id-3' id='type-id-78'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u8t' type-id='type-id-79' id='type-id-80'/>
+    <typedef-decl name='_Sizet' type-id='type-id-81' id='type-id-82'/>
+    <typedef-decl name='_Uint16t' type-id='type-id-77' id='type-id-83'/>
+    <typedef-decl name='_Uint64t' type-id='type-id-78' id='type-id-81'/>
+    <typedef-decl name='_Uint8t' type-id='type-id-80' id='type-id-84'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-36' id='type-id-14'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-39' id='type-id-42'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-41' id='type-id-17'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-30' id='type-id-44'/>
+    <typedef-decl name='size_t' type-id='type-id-82' id='type-id-68'/>
+    <typedef-decl name='uint16_t' type-id='type-id-83' id='type-id-76'/>
+    <typedef-decl name='uint32_t' type-id='type-id-1' id='type-id-46'/>
+    <typedef-decl name='uint64_t' type-id='type-id-81' id='type-id-75'/>
+    <typedef-decl name='uint8_t' type-id='type-id-84' id='type-id-74'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-85' id='type-id-86'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-20' id='type-id-19'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-64' id='type-id-87'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-88' id='type-id-89'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-90' id='type-id-91'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-92' id='type-id-62'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-70' id='type-id-93'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-22' id='type-id-94'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-23' id='type-id-88'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-73' id='type-id-72'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-75' id='type-id-37'/>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-31'>
+      <data-member access='public'>
+        <var-decl name='__count' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__fd' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__clockid' type-id='type-id-22' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-21'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-79'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-38'/>
+    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='4096' id='type-id-49'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-3' id='type-id-95'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-37' size-in-bits='8128' id='type-id-65'>
+      <subrange length='127' lower-bound='0' upper-bound='126' type-id='type-id-3' id='type-id-96'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-37' size-in-bits='1216' id='type-id-40'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-3' id='type-id-13'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-67'/>
+    <qualified-type-def type-id='type-id-24' const='yes' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-97' size-in-bits='64' id='type-id-34'/>
+    <qualified-type-def type-id='type-id-11' const='yes' id='type-id-98'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-33'/>
+    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-47'/>
+    <pointer-type-def type-id='type-id-100' size-in-bits='64' id='type-id-90'/>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-56'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-59'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-57'/>
+    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-92'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-61' size-in-bits='64' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-111'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-63'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-93' size-in-bits='64' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-115' size-in-bits='64' id='type-id-52'/>
+    <class-decl name='table_entry' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-116'/>
+    <pointer-type-def type-id='type-id-116' size-in-bits='64' id='type-id-69'/>
+    <function-decl name='unw_nto_access_fpreg' mangled-name='unw_nto_access_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_access_fpreg'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-94' name='regnum'/>
+      <parameter type-id='type-id-112' name='valp'/>
+      <parameter type-id='type-id-22' name='write'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-117'/>
+    <pointer-type-def type-id='type-id-117' id='type-id-71'/>
+    <function-type size-in-bits='64' id='type-id-100'>
+      <parameter type-id='type-id-99'/>
+      <parameter type-id='type-id-68'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-109'>
+      <parameter type-id='type-id-91'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-101'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-94'/>
+      <parameter type-id='type-id-112'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-102'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-94'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-103'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-67'/>
+      <parameter type-id='type-id-68'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-104'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-113'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-105'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-106'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-107'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-111'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-108'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-110'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-37'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-115'>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-113'/>
+      <parameter type-id='type-id-71'/>
+      <return type-id='type-id-117'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_access_mem.c' language='LANG_C99'>
+    <function-decl name='unw_nto_access_mem' mangled-name='unw_nto_access_mem' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_access_mem'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-37' name='addr'/>
+      <parameter type-id='type-id-114' name='valp'/>
+      <parameter type-id='type-id-22' name='write'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_access_reg.c' language='LANG_C99'>
+    <function-decl name='unw_nto_access_reg' mangled-name='unw_nto_access_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_access_reg'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-94' name='regnum'/>
+      <parameter type-id='type-id-114' name='valp'/>
+      <parameter type-id='type-id-22' name='write'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-50' id='type-id-118'/>
+    <var-decl name='unw_nto_accessors' type-id='type-id-118' mangled-name='unw_nto_accessors' visibility='default' elf-symbol-id='unw_nto_accessors'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_create.c' language='LANG_C99'>
+    <typedef-decl name='_GCC_ATTR_ALIGN_32t' type-id='type-id-22' id='type-id-119'/>
+    <typedef-decl name='_Int32t' type-id='type-id-119' id='type-id-120'/>
+    <typedef-decl name='pid_t' type-id='type-id-22' id='type-id-121'/>
+    <typedef-decl name='pthread_t' type-id='type-id-120' id='type-id-122'/>
+    <function-decl name='unw_nto_create' mangled-name='unw_nto_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_create'>
+      <parameter type-id='type-id-121' name='pid'/>
+      <parameter type-id='type-id-122' name='tid'/>
+      <return type-id='type-id-71'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_destroy.c' language='LANG_C99'>
+    <function-decl name='unw_nto_destroy' mangled-name='unw_nto_destroy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_destroy'>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-117'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_find_proc_info.c' language='LANG_C99'>
+    <function-decl name='unw_nto_find_proc_info' mangled-name='unw_nto_find_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_find_proc_info'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-37' name='ip'/>
+      <parameter type-id='type-id-113' name='pi'/>
+      <parameter type-id='type-id-22' name='need_unwind_info'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_get_dyn_info_list_addr.c' language='LANG_C99'>
+    <function-decl name='unw_nto_get_dyn_info_list_addr' mangled-name='unw_nto_get_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_get_dyn_info_list_addr'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-114' name='dilap'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_get_elf_filename.c' language='LANG_C99'>
+    <function-decl name='unw_nto_get_elf_filename' mangled-name='unw_nto_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_get_elf_filename'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-37' name='ip'/>
+      <parameter type-id='type-id-67' name='buf'/>
+      <parameter type-id='type-id-68' name='buf_len'/>
+      <parameter type-id='type-id-114' name='offp'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_get_proc_name.c' language='LANG_C99'>
+    <function-decl name='unw_nto_get_proc_name' mangled-name='unw_nto_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_get_proc_name'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-37' name='ip'/>
+      <parameter type-id='type-id-67' name='buf'/>
+      <parameter type-id='type-id-68' name='buf_len'/>
+      <parameter type-id='type-id-114' name='offp'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='unw_nto_get_proc_ip_range' mangled-name='unw_nto_get_proc_ip_range' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_get_proc_ip_range'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-37' name='ip'/>
+      <parameter type-id='type-id-114' name='start'/>
+      <parameter type-id='type-id-114' name='end'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_put_unwind_info.c' language='LANG_C99'>
+    <function-decl name='unw_nto_put_unwind_info' mangled-name='unw_nto_put_unwind_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_put_unwind_info'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-113' name='pi'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-117'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/nto/unw_nto_resume.c' language='LANG_C99'>
+    <function-decl name='unw_nto_resume' mangled-name='unw_nto_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_nto_resume'>
+      <parameter type-id='type-id-86' name='as'/>
+      <parameter type-id='type-id-111' name='reg'/>
+      <parameter type-id='type-id-71' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/x86_64/nto-qnx7.1.0/libunwind-x86_64.abi
+++ b/src/abi/x86_64/nto-qnx7.1.0/libunwind-x86_64.abi
@@ -1,0 +1,1242 @@
+<abi-corpus version='2.2' architecture='elf-amd-x86_64' soname='libunwind-x86_64.so.9'>
+  <elf-needed>
+    <dependency name='liblzma.so.5'/>
+    <dependency name='libz.so.2'/>
+    <dependency name='libunwind.so.9'/>
+    <dependency name='libc.so.5'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_Ux86_64_apply_reg_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_create_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_destroy_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_dwarf_find_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_dwarf_search_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_flush_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_accessors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_elf_filename_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_elf_image' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_exe_image_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_proc_info_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_proc_info_in_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_proc_name_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_save_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_init_local' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_init_local2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_init_remote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_is_signal_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_reg_states_iterate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_set_cache_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_set_caching_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_set_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_set_iterate_phdr_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_set_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_Ux86_64_local_addr_space' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/dwarf/Gfind_proc_info-lsb.c' language='LANG_C99'>
+    <type-decl name='short int' size-in-bits='16' id='type-id-1'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-2'/>
+    <class-decl name='table_entry' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-3'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip_offset' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fde_offset' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-5'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-6' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-8' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-9'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-10' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-12'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-14' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-15'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-17' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-18'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-19'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-20' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_GCC_ATTR_ALIGN_16t' type-id='type-id-1' id='type-id-21'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_32t' type-id='type-id-22' id='type-id-23'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_8t' type-id='type-id-2' id='type-id-24'/>
+    <typedef-decl name='_Int16t' type-id='type-id-21' id='type-id-25'/>
+    <typedef-decl name='_Int32t' type-id='type-id-23' id='type-id-26'/>
+    <typedef-decl name='_Int8t' type-id='type-id-24' id='type-id-27'/>
+    <typedef-decl name='int16_t' type-id='type-id-25' id='type-id-11'/>
+    <typedef-decl name='int32_t' type-id='type-id-26' id='type-id-4'/>
+    <typedef-decl name='int8_t' type-id='type-id-27' id='type-id-10'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-5' id='type-id-28'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-9' id='type-id-29'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-12' id='type-id-30'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-15' id='type-id-31'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-18' id='type-id-32'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-19' id='type-id-33'/>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-8'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-30' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-32' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='128' id='type-id-17'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-34' id='type-id-35'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-5' size-in-bits='64' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-36'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-16'/>
+    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-14'/>
+    <function-decl name='_Ux86_64_dwarf_search_unwind_table' mangled-name='_Ux86_64_dwarf_search_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_dwarf_search_unwind_table'>
+      <parameter type-id='type-id-37' name='as'/>
+      <parameter type-id='type-id-7' name='ip'/>
+      <parameter type-id='type-id-36' name='di'/>
+      <parameter type-id='type-id-38' name='pi'/>
+      <parameter type-id='type-id-22' name='need_unwind_info'/>
+      <parameter type-id='type-id-39' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-40'>
+      <parameter type-id='type-id-41'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-43'>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Gfind_unwind_table.c' language='LANG_C99'>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-45'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-46' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-28' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-28' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-45' size-in-bits='64' id='type-id-47'/>
+    <function-decl name='_Ux86_64_dwarf_find_unwind_table' mangled-name='_Ux86_64_dwarf_find_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_dwarf_find_unwind_table'>
+      <parameter type-id='type-id-47' name='edi'/>
+      <parameter type-id='type-id-37' name='as'/>
+      <parameter type-id='type-id-48' name='path'/>
+      <parameter type-id='type-id-7' name='segbase'/>
+      <parameter type-id='type-id-7' name='mapoff'/>
+      <parameter type-id='type-id-7' name='ip'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Gget_proc_info_in_range.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_get_proc_info_in_range' mangled-name='_Ux86_64_get_proc_info_in_range' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_proc_info_in_range'>
+      <parameter type-id='type-id-7' name='start_ip'/>
+      <parameter type-id='type-id-7' name='end_ip'/>
+      <parameter type-id='type-id-7' name='eh_frame_table'/>
+      <parameter type-id='type-id-7' name='eh_frame_table_len'/>
+      <parameter type-id='type-id-7' name='exidx_frame_table'/>
+      <parameter type-id='type-id-7' name='exidx_frame_table_len'/>
+      <parameter type-id='type-id-37' name='as'/>
+      <parameter type-id='type-id-7' name='ip'/>
+      <parameter type-id='type-id-38' name='pi'/>
+      <parameter type-id='type-id-22' name='need_unwind_info'/>
+      <parameter type-id='type-id-39' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/global.c' language='LANG_C99'>
+    <class-decl name='mempool' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-49'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='obj_size' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='chunk_size' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='reserve' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='num_free' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='free_list' type-id='type-id-51' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='object' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-52'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-51' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-52' size-in-bits='64' id='type-id-51'/>
+    <var-decl name='dwarf_reg_state_pool' type-id='type-id-49' visibility='default'/>
+    <var-decl name='dwarf_cie_info_pool' type-id='type-id-49' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gdestroy_addr_space.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_destroy_addr_space' mangled-name='_Ux86_64_destroy_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_destroy_addr_space'>
+      <parameter type-id='type-id-37' name='as'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-54' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-55' size-in-bits='64' id='type-id-56'/>
+    <function-decl name='_Ux86_64_get_accessors' mangled-name='_Ux86_64_get_accessors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_accessors'>
+      <parameter type-id='type-id-37' name='as'/>
+      <return type-id='type-id-56'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_get_elf_filename_by_ip' mangled-name='_Ux86_64_get_elf_filename_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_elf_filename_by_ip'>
+      <parameter type-id='type-id-37' name='as'/>
+      <parameter type-id='type-id-7' name='ip'/>
+      <parameter type-id='type-id-57' name='buf'/>
+      <parameter type-id='type-id-42' name='buf_len'/>
+      <parameter type-id='type-id-20' name='offp'/>
+      <parameter type-id='type-id-39' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_get_elf_filename' mangled-name='_Ux86_64_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_elf_filename'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <parameter type-id='type-id-57' name='buf'/>
+      <parameter type-id='type-id-42' name='buf_len'/>
+      <parameter type-id='type-id-20' name='offp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_get_fpreg' mangled-name='_Ux86_64_get_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_fpreg'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-59' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_proc_info_by_ip.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_get_proc_info_by_ip' mangled-name='_Ux86_64_get_proc_info_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_proc_info_by_ip'>
+      <parameter type-id='type-id-37' name='as'/>
+      <parameter type-id='type-id-7' name='ip'/>
+      <parameter type-id='type-id-38' name='pi'/>
+      <parameter type-id='type-id-39' name='as_arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_proc_name.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_get_proc_name_by_ip' mangled-name='_Ux86_64_get_proc_name_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_proc_name_by_ip'>
+      <parameter type-id='type-id-37' name='as'/>
+      <parameter type-id='type-id-7' name='ip'/>
+      <parameter type-id='type-id-57' name='buf'/>
+      <parameter type-id='type-id-42' name='buf_len'/>
+      <parameter type-id='type-id-20' name='offp'/>
+      <parameter type-id='type-id-39' name='arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_get_proc_name' mangled-name='_Ux86_64_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_proc_name'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <parameter type-id='type-id-57' name='buf'/>
+      <parameter type-id='type-id-42' name='buf_len'/>
+      <parameter type-id='type-id-20' name='offp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gget_reg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_get_reg' mangled-name='_Ux86_64_get_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_reg'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-20' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_cache_size.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_set_cache_size' mangled-name='_Ux86_64_set_cache_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_set_cache_size'>
+      <parameter type-id='type-id-37' name='as'/>
+      <parameter type-id='type-id-42' name='size'/>
+      <parameter type-id='type-id-22' name='flag'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_caching_policy.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_set_caching_policy' mangled-name='_Ux86_64_set_caching_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_set_caching_policy'>
+      <parameter type-id='type-id-37' name='as'/>
+      <parameter type-id='type-id-60' name='policy'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_set_fpreg' mangled-name='_Ux86_64_set_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_set_fpreg'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-61' name='val'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_iterate_phdr_function.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_set_iterate_phdr_function' mangled-name='_Ux86_64_set_iterate_phdr_function' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_set_iterate_phdr_function'>
+      <parameter type-id='type-id-37' name='as'/>
+      <parameter type-id='type-id-62' name='function'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Gset_reg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_set_reg' mangled-name='_Ux86_64_set_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_set_reg'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <parameter type-id='type-id-7' name='valp'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/flush_cache.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-63' size-in-bits='152' id='type-id-64'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-34' id='type-id-65'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-66' size-in-bits='16384' id='type-id-67'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-34' id='type-id-68'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-69' size-in-bits='188416' id='type-id-70'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-34' id='type-id-68'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-60' id='type-id-71'>
+      <underlying-type type-id='type-id-72'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='long double' size-in-bits='128' id='type-id-73'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-74' visibility='default' id='type-id-75'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-76' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-79' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-79' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-79' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_sync' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-80'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__u' type-id='type-id-81' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__owner' type-id='type-id-82' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-83'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-78' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-48' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-84' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-85' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-86'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-87' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='1408' is-struct='yes' visibility='default' id='type-id-88'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-64' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='val' type-id='type-id-89' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='1472' is-struct='yes' visibility='default' id='type-id-90'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-91' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='209280' is-struct='yes' visibility='default' id='type-id-92'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='rr_head' type-id='type-id-87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='log_size' type-id='type-id-87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='prev_log_size' type-id='type-id-87' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='hash' type-id='type-id-93' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='generation' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='buckets' type-id='type-id-94' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='links' type-id='type-id-95' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='default_hash' type-id='type-id-96' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4480'>
+        <var-decl name='default_buckets' type-id='type-id-70' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192896'>
+        <var-decl name='default_links' type-id='type-id-67' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-54'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-97' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-98' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-99' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-100' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-101' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-102' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-103' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-104' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-105' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-106' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='210304' is-struct='yes' visibility='default' id='type-id-107'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-54' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-62' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='caching_policy' type-id='type-id-60' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='cache_generation' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='dyn_generation' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='global_cache' type-id='type-id-92' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='210240'>
+        <var-decl name='debug_frames' type-id='type-id-108' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='type-id-109'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-110' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-111'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-57' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-112' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-108' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-113'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-114' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-114' visibility='default' id='type-id-115'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-116' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-117' id='type-id-78'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-118' id='type-id-85'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-117' id='type-id-77'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-75' id='type-id-74'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-13' id='type-id-76'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-117' id='type-id-79'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u16t' type-id='type-id-87' id='type-id-119'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u8t' type-id='type-id-120' id='type-id-121'/>
+    <typedef-decl name='_Uint16t' type-id='type-id-119' id='type-id-122'/>
+    <typedef-decl name='_Uint8t' type-id='type-id-121' id='type-id-123'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-86' id='type-id-66'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-88' id='type-id-91'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-90' id='type-id-69'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-80' id='type-id-50'/>
+    <typedef-decl name='uint16_t' type-id='type-id-122' id='type-id-118'/>
+    <typedef-decl name='uint32_t' type-id='type-id-124' id='type-id-13'/>
+    <typedef-decl name='uint8_t' type-id='type-id-123' id='type-id-116'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-125' id='type-id-37'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-71' id='type-id-60'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-109' id='type-id-126'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-127' id='type-id-61'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-128' id='type-id-44'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-129' id='type-id-62'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-113' id='type-id-130'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-22' id='type-id-131'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-73' id='type-id-127'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-115' id='type-id-114'/>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-81'>
+      <data-member access='public'>
+        <var-decl name='__count' type-id='type-id-82' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__fd' type-id='type-id-22' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__clockid' type-id='type-id-22' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-72'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-120'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-87'/>
+    <array-type-def dimensions='1' type-id='type-id-87' size-in-bits='4096' id='type-id-96'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-34' id='type-id-132'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='8128' id='type-id-110'>
+      <subrange length='127' lower-bound='0' upper-bound='126' type-id='type-id-34' id='type-id-133'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-7' size-in-bits='1216' id='type-id-89'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-34' id='type-id-65'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-74' const='yes' id='type-id-134'/>
+    <pointer-type-def type-id='type-id-134' size-in-bits='64' id='type-id-84'/>
+    <qualified-type-def type-id='type-id-63' const='yes' id='type-id-135'/>
+    <pointer-type-def type-id='type-id-135' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-83' size-in-bits='64' id='type-id-41'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-95'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-94'/>
+    <pointer-type-def type-id='type-id-40' size-in-bits='64' id='type-id-128'/>
+    <pointer-type-def type-id='type-id-136' size-in-bits='64' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-137' size-in-bits='64' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-104'/>
+    <pointer-type-def type-id='type-id-139' size-in-bits='64' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-140' size-in-bits='64' id='type-id-100'/>
+    <pointer-type-def type-id='type-id-141' size-in-bits='64' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-142' size-in-bits='64' id='type-id-103'/>
+    <pointer-type-def type-id='type-id-143' size-in-bits='64' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-129'/>
+    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-144' size-in-bits='64' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-93'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-125'/>
+    <pointer-type-def type-id='type-id-126' size-in-bits='64' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-61' size-in-bits='64' id='type-id-59'/>
+    <pointer-type-def type-id='type-id-130' size-in-bits='64' id='type-id-38'/>
+    <pointer-type-def type-id='type-id-7' size-in-bits='64' id='type-id-20'/>
+    <pointer-type-def type-id='type-id-145' size-in-bits='64' id='type-id-98'/>
+    <function-decl name='_Ux86_64_flush_cache' mangled-name='_Ux86_64_flush_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_flush_cache'>
+      <parameter type-id='type-id-37' name='as'/>
+      <parameter type-id='type-id-7' name='lo'/>
+      <parameter type-id='type-id-7' name='hi'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-136'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-131'/>
+      <parameter type-id='type-id-59'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-137'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-131'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-138'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-139'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-140'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-141'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-142'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-143'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-144'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-145'>
+      <parameter type-id='type-id-37'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-53'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-124' size-in-bits='64' id='type-id-146'>
+      <subrange length='2' lower-bound='0' upper-bound='1' type-id='type-id-34' id='type-id-147'/>
+    </array-type-def>
+    <type-decl name='long int' size-in-bits='64' id='type-id-148'/>
+    <class-decl name='sigset_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-149' visibility='default' id='type-id-150'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__bits' type-id='type-id-146' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u32t' type-id='type-id-82' id='type-id-151'/>
+    <typedef-decl name='_Uint32t' type-id='type-id-151' id='type-id-124'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-149' id='type-id-152'/>
+    <typedef-decl name='sigset_t' type-id='type-id-150' id='type-id-149'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-82'/>
+    <var-decl name='_UIx86_64_full_mask' type-id='type-id-152' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-148' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/strerror.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_strerror' mangled-name='_Ux86_64_strerror' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_strerror'>
+      <parameter type-id='type-id-22' name='err_code'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/os-qnx.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-63'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-46'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-42' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u64t' type-id='type-id-34' id='type-id-153'/>
+    <typedef-decl name='_Sizet' type-id='type-id-154' id='type-id-155'/>
+    <typedef-decl name='_Uint64t' type-id='type-id-153' id='type-id-154'/>
+    <typedef-decl name='pid_t' type-id='type-id-22' id='type-id-156'/>
+    <typedef-decl name='size_t' type-id='type-id-155' id='type-id-42'/>
+    <typedef-decl name='uint64_t' type-id='type-id-154' id='type-id-117'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-117' id='type-id-7'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-34'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='64' id='type-id-57'/>
+    <pointer-type-def type-id='type-id-46' size-in-bits='64' id='type-id-157'/>
+    <pointer-type-def type-id='type-id-34' size-in-bits='64' id='type-id-158'/>
+    <function-decl name='_Ux86_64_get_elf_image' mangled-name='_Ux86_64_get_elf_image' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_elf_image'>
+      <parameter type-id='type-id-157' name='ei'/>
+      <parameter type-id='type-id-156' name='pid'/>
+      <parameter type-id='type-id-7' name='ip'/>
+      <parameter type-id='type-id-158' name='segbase'/>
+      <parameter type-id='type-id-158' name='mapoff'/>
+      <parameter type-id='type-id-57' name='path'/>
+      <parameter type-id='type-id-42' name='pathlen'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_get_exe_image_path' mangled-name='_Ux86_64_get_exe_image_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_exe_image_path'>
+      <parameter type-id='type-id-57' name='path'/>
+      <return type-id='type-id-53'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-53' id='type-id-39'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gapply_reg_state.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_apply_reg_state' mangled-name='_Ux86_64_apply_reg_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_apply_reg_state'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <parameter type-id='type-id-39' name='reg_states_data'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gcreate_addr_space.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_create_addr_space' mangled-name='_Ux86_64_create_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_create_addr_space'>
+      <parameter type-id='type-id-56' name='a'/>
+      <parameter type-id='type-id-22' name='byte_order'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gget_proc_info.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_get_proc_info' mangled-name='_Ux86_64_get_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_proc_info'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <parameter type-id='type-id-38' name='pi'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gget_save_loc.c' language='LANG_C99'>
+    <enum-decl name='unw_save_loc_type' id='type-id-159'>
+      <underlying-type type-id='type-id-72'/>
+      <enumerator name='UNW_SLT_NONE' value='0'/>
+      <enumerator name='UNW_SLT_MEMORY' value='1'/>
+      <enumerator name='UNW_SLT_REG' value='2'/>
+    </enum-decl>
+    <class-decl name='unw_save_loc' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-160'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-161' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='u' type-id='type-id-162' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='extra' type-id='type-id-163' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_save_loc' size-in-bits='8' is-struct='yes' visibility='default' id='type-id-164'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-116' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_save_loc_t' type-id='type-id-160' id='type-id-165'/>
+    <typedef-decl name='unw_save_loc_type_t' type-id='type-id-159' id='type-id-161'/>
+    <typedef-decl name='unw_tdep_save_loc_t' type-id='type-id-164' id='type-id-163'/>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-162'>
+      <data-member access='public'>
+        <var-decl name='addr' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='regnum' type-id='type-id-131' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-165' size-in-bits='64' id='type-id-166'/>
+    <function-decl name='_Ux86_64_get_save_loc' mangled-name='_Ux86_64_get_save_loc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_save_loc'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <parameter type-id='type-id-22' name='reg'/>
+      <parameter type-id='type-id-166' name='sloc'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gglobal.c' language='LANG_C99'>
+    <type-decl name='atomic_bool' size-in-bits='8' id='type-id-167'/>
+    <array-type-def dimensions='1' type-id='type-id-168' size-in-bits='136' id='type-id-169'>
+      <subrange length='17' lower-bound='0' upper-bound='16' type-id='type-id-34' id='type-id-170'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-116' const='yes' id='type-id-168'/>
+    <var-decl name='_Ux86_64_dwarf_to_unw_regnum_map' type-id='type-id-169' visibility='default'/>
+    <var-decl name='_Ux86_64_init_done' type-id='type-id-167' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Ginit.c' language='LANG_C99'>
+    <var-decl name='_Ux86_64_local_addr_space' type-id='type-id-37' mangled-name='_Ux86_64_local_addr_space' visibility='default' elf-symbol-id='_Ux86_64_local_addr_space'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Ginit_local.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-154' size-in-bits='448' id='type-id-171'>
+      <subrange length='7' lower-bound='0' upper-bound='6' type-id='type-id-34' id='type-id-172'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-123' size-in-bits='8192' id='type-id-173'>
+      <subrange length='1024' lower-bound='0' upper-bound='1023' type-id='type-id-34' id='type-id-174'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-123' size-in-bits='1024' id='type-id-175'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-34' id='type-id-68'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-123' size-in-bits='1792' id='type-id-176'>
+      <subrange length='224' lower-bound='0' upper-bound='223' type-id='type-id-34' id='type-id-177'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-123' size-in-bits='4096' id='type-id-178'>
+      <subrange length='512' lower-bound='0' upper-bound='511' type-id='type-id-34' id='type-id-179'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-123' size-in-bits='640' id='type-id-180'>
+      <subrange length='80' lower-bound='0' upper-bound='79' type-id='type-id-34' id='type-id-181'/>
+    </array-type-def>
+    <class-decl name='__ucontext_t' size-in-bits='9792' is-struct='yes' visibility='default' id='type-id-182'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uc_link' type-id='type-id-183' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uc_sigmask' type-id='type-id-149' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uc_stack' type-id='type-id-184' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='uc_mcontext' type-id='type-id-185' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__x86_64_mcontext' size-in-bits='9472' is-struct='yes' visibility='default' id='type-id-186'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cpu' type-id='type-id-187' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='fpu' type-id='type-id-188' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='fpu_extention_savearea_64' size-in-bits='6400' is-struct='yes' visibility='default' id='type-id-189'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='other' type-id='type-id-178' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4096'>
+        <var-decl name='xstate_bv' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4160'>
+        <var-decl name='xstate_undef' type-id='type-id-171' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4608'>
+        <var-decl name='xstate_info' type-id='type-id-176' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='fsave_area_64' size-in-bits='864' is-struct='yes' visibility='default' id='type-id-190'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fpu_control_word' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fpu_status_word' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fpu_tag_word' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='fpu_ip' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='fpu_cs' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='fpu_op' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='fpu_ds' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='st_regs' type-id='type-id-180' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='fxsave_area_64' size-in-bits='4096' is-struct='yes' visibility='default' id='type-id-191'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fpu_control_word' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='fpu_status_word' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fpu_tag_word' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='fpu_operand' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fpu_rip' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='fpu_rdp' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mxcsr' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='mxcsr_mask' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='st_regs' type-id='type-id-175' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='xmm_regs' type-id='type-id-175' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='reserved2' type-id='type-id-176' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='stack_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-184' visibility='default' id='type-id-192'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ss_sp' type-id='type-id-39' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ss_size' type-id='type-id-155' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ss_flags' type-id='type-id-22' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='x86_64_cpu_registers' size-in-bits='1280' is-struct='yes' visibility='default' id='type-id-193'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='rdi' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='rsi' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='rdx' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='r10' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='r8' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='r9' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='rax' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='rbx' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='rbp' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='rcx' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='r11' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='r12' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='r13' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='r14' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='r15' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='rip' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='cs' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='rsvd1' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='rflags' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='rsp' type-id='type-id-154' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='ss' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1248'>
+        <var-decl name='rsvd2' type-id='type-id-124' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='X86_64_CPU_REGISTERS' type-id='type-id-193' id='type-id-187'/>
+    <typedef-decl name='X86_64_FPU_REGISTERS' type-id='type-id-194' id='type-id-188'/>
+    <typedef-decl name='X86_64_FXSAVE_REGISTERS' type-id='type-id-191' id='type-id-195'/>
+    <typedef-decl name='X86_64_NDP_REGISTERS' type-id='type-id-190' id='type-id-196'/>
+    <typedef-decl name='X86_64_XSAVE_REGISTERS' type-id='type-id-189' id='type-id-197'/>
+    <typedef-decl name='mcontext_t' type-id='type-id-186' id='type-id-185'/>
+    <typedef-decl name='stack_t' type-id='type-id-192' id='type-id-184'/>
+    <typedef-decl name='ucontext_t' type-id='type-id-182' id='type-id-198'/>
+    <union-decl name='x86_64_fpu_registers' size-in-bits='8192' visibility='default' id='type-id-194'>
+      <data-member access='public'>
+        <var-decl name='fsave_area' type-id='type-id-196' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='fxsave_area' type-id='type-id-195' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='xsave_area' type-id='type-id-197' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='data' type-id='type-id-173' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-182' size-in-bits='64' id='type-id-183'/>
+    <pointer-type-def type-id='type-id-198' size-in-bits='64' id='type-id-199'/>
+    <function-decl name='_Ux86_64_init_local' mangled-name='_Ux86_64_init_local' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_init_local'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <parameter type-id='type-id-199' name='uc'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_init_local2' mangled-name='_Ux86_64_init_local2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_init_local2'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <parameter type-id='type-id-199' name='uc'/>
+      <parameter type-id='type-id-22' name='flag'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Ginit_remote.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_init_remote' mangled-name='_Ux86_64_init_remote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_init_remote'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <parameter type-id='type-id-37' name='as'/>
+      <parameter type-id='type-id-39' name='as_arg'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gos-qnx.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_is_signal_frame' mangled-name='_Ux86_64_is_signal_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_is_signal_frame'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Greg_states_iterate.c' language='LANG_C99'>
+    <typedef-decl name='unw_reg_states_callback' type-id='type-id-200' id='type-id-201'/>
+    <pointer-type-def type-id='type-id-202' size-in-bits='64' id='type-id-200'/>
+    <function-decl name='_Ux86_64_reg_states_iterate' mangled-name='_Ux86_64_reg_states_iterate' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_reg_states_iterate'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <parameter type-id='type-id-201' name='cb'/>
+      <parameter type-id='type-id-39' name='token'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-202'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-7'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gresume.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_resume' mangled-name='_Ux86_64_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_resume'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Gstep.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_step' mangled-name='_Ux86_64_step' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_step'>
+      <parameter type-id='type-id-58' name='cursor'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/is_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_is_fpreg' mangled-name='_Ux86_64_is_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_is_fpreg'>
+      <parameter type-id='type-id-22' name='regnum'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/regname.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_regname' mangled-name='_Ux86_64_regname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_regname'>
+      <parameter type-id='type-id-131' name='reg'/>
+      <return type-id='type-id-48'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/src/abi/x86_64/nto-qnx7.1.0/libunwind.abi
+++ b/src/abi/x86_64/nto-qnx7.1.0/libunwind.abi
@@ -1,0 +1,1299 @@
+<abi-corpus version='2.2' architecture='elf-amd-x86_64' soname='libunwind.so.9'>
+  <elf-needed>
+    <dependency name='libc.so.5'/>
+    <dependency name='libgcc_s.so.1'/>
+    <dependency name='liblzma.so.5'/>
+    <dependency name='libz.so.2'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='_ULx86_64_apply_reg_state' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_create_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_destroy_addr_space' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_dwarf_find_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_dwarf_search_unwind_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_elf_filename' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_elf_filename_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_proc_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_proc_info_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_proc_info_in_range' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_proc_name' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_proc_name_by_ip' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_get_save_loc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_init_local' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_init_local2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_init_remote' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_is_signal_frame' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_reg_states_iterate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_resume' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_set_cache_size' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_set_caching_policy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_set_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_set_iterate_phdr_function' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_set_reg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_ULx86_64_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_cancel' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_info_list_addr' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_U_dyn_register' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_flush_cache' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_accessors' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_elf_image' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_get_exe_image_path' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_getcontext' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_setcontext' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_64_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='backtrace' type='func-type' binding='weak-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='unw_backtrace' type='func-type' binding='global-binding' visibility='default-visibility' alias='backtrace' is-defined='yes'/>
+    <elf-symbol name='unw_backtrace2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='_ULx86_64_local_addr_space' size='8' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='../../src/dwarf/Lfind_proc_info-lsb.c' language='LANG_C99'>
+    <class-decl name='table_entry' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-1'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip_offset' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fde_offset' type-id='type-id-2' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <function-decl name='_ULx86_64_dwarf_search_unwind_table' mangled-name='_ULx86_64_dwarf_search_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_dwarf_search_unwind_table'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-5' name='di'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-7' name='need_unwind_info'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-9'>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-12'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Lfind_unwind_table.c' language='LANG_C99'>
+    <class-decl name='elf_dyn_info' size-in-bits='1536' is-struct='yes' visibility='default' id='type-id-14'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ei' type-id='type-id-15' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='di_cache' type-id='type-id-16' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='di_debug' type-id='type-id-16' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-17'/>
+    <function-decl name='_ULx86_64_dwarf_find_unwind_table' mangled-name='_ULx86_64_dwarf_find_unwind_table' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_dwarf_find_unwind_table'>
+      <parameter type-id='type-id-17' name='edi'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-18' name='path'/>
+      <parameter type-id='type-id-4' name='segbase'/>
+      <parameter type-id='type-id-4' name='mapoff'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/Lget_proc_info_in_range.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_get_proc_info_in_range' mangled-name='_ULx86_64_get_proc_info_in_range' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_proc_info_in_range'>
+      <parameter type-id='type-id-4' name='start_ip'/>
+      <parameter type-id='type-id-4' name='end_ip'/>
+      <parameter type-id='type-id-4' name='eh_frame_table'/>
+      <parameter type-id='type-id-4' name='eh_frame_table_len'/>
+      <parameter type-id='type-id-4' name='exidx_frame_table'/>
+      <parameter type-id='type-id-4' name='exidx_frame_table_len'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-7' name='need_unwind_info'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/dwarf/global.c' language='LANG_C99'>
+    <class-decl name='mempool' size-in-bits='384' is-struct='yes' visibility='default' id='type-id-19'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='obj_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='chunk_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='reserve' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='num_free' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='free_list' type-id='type-id-21' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='object' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-22'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-21' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-21'/>
+    <var-decl name='dwarf_reg_state_pool' type-id='type-id-19' visibility='default'/>
+    <var-decl name='dwarf_cie_info_pool' type-id='type-id-19' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Ldestroy_addr_space.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_destroy_addr_space' mangled-name='_ULx86_64_destroy_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_destroy_addr_space'>
+      <parameter type-id='type-id-3' name='as'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_accessors.c' language='LANG_C99'>
+    <typedef-decl name='unw_accessors_t' type-id='type-id-24' id='type-id-25'/>
+    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-26'/>
+    <function-decl name='_Ux86_64_get_accessors' mangled-name='_Ux86_64_get_accessors' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_accessors'>
+      <parameter type-id='type-id-3' name='as'/>
+      <return type-id='type-id-26'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_elf_filename.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_get_elf_filename_by_ip' mangled-name='_ULx86_64_get_elf_filename_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_elf_filename_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULx86_64_get_elf_filename' mangled-name='_ULx86_64_get_elf_filename' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_elf_filename'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_fpreg.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_get_fpreg' mangled-name='_ULx86_64_get_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_fpreg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-30' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_proc_info_by_ip.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_get_proc_info_by_ip' mangled-name='_ULx86_64_get_proc_info_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_proc_info_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <parameter type-id='type-id-8' name='as_arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_proc_name.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_get_proc_name_by_ip' mangled-name='_ULx86_64_get_proc_name_by_ip' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_proc_name_by_ip'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <parameter type-id='type-id-8' name='arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULx86_64_get_proc_name' mangled-name='_ULx86_64_get_proc_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_proc_name'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-27' name='buf'/>
+      <parameter type-id='type-id-11' name='buf_len'/>
+      <parameter type-id='type-id-28' name='offp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lget_reg.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_get_reg' mangled-name='_ULx86_64_get_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_reg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-28' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_cache_size.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_set_cache_size' mangled-name='_ULx86_64_set_cache_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_set_cache_size'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-11' name='size'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_caching_policy.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_set_caching_policy' mangled-name='_ULx86_64_set_caching_policy' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_set_caching_policy'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-31' name='policy'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_fpreg.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_set_fpreg' mangled-name='_ULx86_64_set_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_set_fpreg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-32' name='val'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_iterate_phdr_function.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_set_iterate_phdr_function' mangled-name='_ULx86_64_set_iterate_phdr_function' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_set_iterate_phdr_function'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-33' name='function'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/Lset_reg.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_set_reg' mangled-name='_ULx86_64_set_reg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_set_reg'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <parameter type-id='type-id-4' name='valp'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/backtrace.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-34' size-in-bits='448' id='type-id-35'>
+      <subrange length='7' lower-bound='0' upper-bound='6' type-id='type-id-36' id='type-id-37'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='8192' id='type-id-39'>
+      <subrange length='1024' lower-bound='0' upper-bound='1023' type-id='type-id-36' id='type-id-40'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='1024' id='type-id-41'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-36' id='type-id-42'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='1792' id='type-id-43'>
+      <subrange length='224' lower-bound='0' upper-bound='223' type-id='type-id-36' id='type-id-44'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='4096' id='type-id-45'>
+      <subrange length='512' lower-bound='0' upper-bound='511' type-id='type-id-36' id='type-id-46'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='640' id='type-id-47'>
+      <subrange length='80' lower-bound='0' upper-bound='79' type-id='type-id-36' id='type-id-48'/>
+    </array-type-def>
+    <class-decl name='__ucontext_t' size-in-bits='9792' is-struct='yes' visibility='default' id='type-id-49'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='uc_link' type-id='type-id-50' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uc_sigmask' type-id='type-id-51' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='uc_stack' type-id='type-id-52' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='uc_mcontext' type-id='type-id-53' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__x86_64_mcontext' size-in-bits='9472' is-struct='yes' visibility='default' id='type-id-54'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='cpu' type-id='type-id-55' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='fpu' type-id='type-id-56' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='fpu_extention_savearea_64' size-in-bits='6400' is-struct='yes' visibility='default' id='type-id-57'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='other' type-id='type-id-45' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4096'>
+        <var-decl name='xstate_bv' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4160'>
+        <var-decl name='xstate_undef' type-id='type-id-35' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4608'>
+        <var-decl name='xstate_info' type-id='type-id-43' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='fsave_area_64' size-in-bits='864' is-struct='yes' visibility='default' id='type-id-58'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fpu_control_word' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fpu_status_word' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fpu_tag_word' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='fpu_ip' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='fpu_cs' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='fpu_op' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='fpu_ds' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='st_regs' type-id='type-id-47' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='fxsave_area_64' size-in-bits='4096' is-struct='yes' visibility='default' id='type-id-60'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fpu_control_word' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='fpu_status_word' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fpu_tag_word' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='fpu_operand' type-id='type-id-61' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='fpu_rip' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='fpu_rdp' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mxcsr' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='mxcsr_mask' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='st_regs' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='xmm_regs' type-id='type-id-41' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='reserved2' type-id='type-id-43' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='stack_t' size-in-bits='192' is-struct='yes' naming-typedef-id='type-id-52' visibility='default' id='type-id-62'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ss_sp' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ss_size' type-id='type-id-63' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ss_flags' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='x86_64_cpu_registers' size-in-bits='1280' is-struct='yes' visibility='default' id='type-id-64'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='rdi' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='rsi' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='rdx' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='r10' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='r8' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='r9' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='rax' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='rbx' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='rbp' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='rcx' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='r11' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='r12' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='r13' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='r14' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='r15' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='rip' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='cs' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='rsvd1' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='rflags' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='rsp' type-id='type-id-34' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='ss' type-id='type-id-59' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1248'>
+        <var-decl name='rsvd2' type-id='type-id-59' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='X86_64_CPU_REGISTERS' type-id='type-id-64' id='type-id-55'/>
+    <typedef-decl name='X86_64_FPU_REGISTERS' type-id='type-id-65' id='type-id-56'/>
+    <typedef-decl name='X86_64_FXSAVE_REGISTERS' type-id='type-id-60' id='type-id-66'/>
+    <typedef-decl name='X86_64_NDP_REGISTERS' type-id='type-id-58' id='type-id-67'/>
+    <typedef-decl name='X86_64_XSAVE_REGISTERS' type-id='type-id-57' id='type-id-68'/>
+    <typedef-decl name='mcontext_t' type-id='type-id-54' id='type-id-53'/>
+    <typedef-decl name='stack_t' type-id='type-id-62' id='type-id-52'/>
+    <typedef-decl name='ucontext_t' type-id='type-id-49' id='type-id-69'/>
+    <typedef-decl name='unw_context_t' type-id='type-id-70' id='type-id-71'/>
+    <typedef-decl name='unw_tdep_context_t' type-id='type-id-69' id='type-id-70'/>
+    <union-decl name='x86_64_fpu_registers' size-in-bits='8192' visibility='default' id='type-id-65'>
+      <data-member access='public'>
+        <var-decl name='fsave_area' type-id='type-id-67' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='fxsave_area' type-id='type-id-66' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='xsave_area' type-id='type-id-68' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='data' type-id='type-id-39' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-49' size-in-bits='64' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-71' size-in-bits='64' id='type-id-72'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-73'/>
+    <function-decl name='unw_backtrace' mangled-name='unw_backtrace' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_backtrace'>
+      <parameter type-id='type-id-73' name='buffer'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='unw_backtrace2' mangled-name='unw_backtrace2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='unw_backtrace2'>
+      <parameter type-id='type-id-73' name='buffer'/>
+      <parameter type-id='type-id-7' name='size'/>
+      <parameter type-id='type-id-72' name='uc2'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-cancel.c' language='LANG_C99'>
+    <type-decl name='short int' size-in-bits='16' id='type-id-74'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-75'/>
+    <class-decl name='unw_dyn_info' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-76'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='prev' type-id='type-id-77' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='start_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='end_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='pad' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='load_offset' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='u' type-id='type-id-78' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_op' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-79'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tag' type-id='type-id-80' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='qp' type-id='type-id-80' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='reg' type-id='type-id-81' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='when' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='val' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_proc_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-82'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='handler' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='flags' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pad0' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='regions' type-id='type-id-84' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_region_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-85'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next' type-id='type-id-86' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='insn_count' type-id='type-id-2' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='op_count' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='op' type-id='type-id-87' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_remote_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-88'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-4' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_dyn_table_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-89'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='name_ptr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='segbase' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='table_len' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='table_data' type-id='type-id-28' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_GCC_ATTR_ALIGN_16t' type-id='type-id-74' id='type-id-90'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_32t' type-id='type-id-7' id='type-id-91'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_8t' type-id='type-id-75' id='type-id-92'/>
+    <typedef-decl name='_Int16t' type-id='type-id-90' id='type-id-93'/>
+    <typedef-decl name='_Int32t' type-id='type-id-91' id='type-id-94'/>
+    <typedef-decl name='_Int8t' type-id='type-id-92' id='type-id-95'/>
+    <typedef-decl name='int16_t' type-id='type-id-93' id='type-id-81'/>
+    <typedef-decl name='int32_t' type-id='type-id-94' id='type-id-2'/>
+    <typedef-decl name='int8_t' type-id='type-id-95' id='type-id-80'/>
+    <typedef-decl name='unw_dyn_info_t' type-id='type-id-76' id='type-id-16'/>
+    <typedef-decl name='unw_dyn_op_t' type-id='type-id-79' id='type-id-96'/>
+    <typedef-decl name='unw_dyn_proc_info_t' type-id='type-id-82' id='type-id-97'/>
+    <typedef-decl name='unw_dyn_region_info_t' type-id='type-id-85' id='type-id-98'/>
+    <typedef-decl name='unw_dyn_remote_table_info_t' type-id='type-id-88' id='type-id-99'/>
+    <typedef-decl name='unw_dyn_table_info_t' type-id='type-id-89' id='type-id-100'/>
+    <union-decl name='__anonymous_union__' size-in-bits='256' is-anonymous='yes' visibility='default' id='type-id-78'>
+      <data-member access='public'>
+        <var-decl name='pi' type-id='type-id-97' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='ti' type-id='type-id-100' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='rti' type-id='type-id-99' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <array-type-def dimensions='1' type-id='type-id-96' size-in-bits='128' id='type-id-87'>
+      <subrange length='1' lower-bound='0' upper-bound='0' type-id='type-id-36' id='type-id-101'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-76' size-in-bits='64' id='type-id-77'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-5'/>
+    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-84'/>
+    <function-decl name='_U_dyn_cancel' mangled-name='_U_dyn_cancel' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_cancel'>
+      <parameter type-id='type-id-5' name='di'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-info-list.c' language='LANG_C99'>
+    <class-decl name='unw_dyn_info_list' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-102'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='version' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='generation' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='first' type-id='type-id-5' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_dyn_info_list_t' type-id='type-id-102' id='type-id-103'/>
+    <var-decl name='_U_dyn_info_list' type-id='type-id-103' visibility='default'/>
+    <function-decl name='_U_dyn_info_list_addr' mangled-name='_U_dyn_info_list_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_info_list_addr'>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/dyn-register.c' language='LANG_C99'>
+    <var-decl name='_U_dyn_info_list_lock' type-id='type-id-20' visibility='default'/>
+    <function-decl name='_U_dyn_register' mangled-name='_U_dyn_register' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_U_dyn_register'>
+      <parameter type-id='type-id-5' name='di'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/flush_cache.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-104' size-in-bits='152' id='type-id-105'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-36' id='type-id-106'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-107' size-in-bits='16384' id='type-id-108'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-36' id='type-id-42'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-109' size-in-bits='188416' id='type-id-110'>
+      <subrange length='128' lower-bound='0' upper-bound='127' type-id='type-id-36' id='type-id-42'/>
+    </array-type-def>
+    <enum-decl name='unw_caching_policy_t' naming-typedef-id='type-id-31' id='type-id-111'>
+      <underlying-type type-id='type-id-112'/>
+      <enumerator name='UNW_CACHE_NONE' value='0'/>
+      <enumerator name='UNW_CACHE_GLOBAL' value='1'/>
+      <enumerator name='UNW_CACHE_PER_THREAD' value='2'/>
+    </enum-decl>
+    <type-decl name='long double' size-in-bits='128' id='type-id-113'/>
+    <class-decl name='Elf64_Phdr' size-in-bits='448' is-struct='yes' naming-typedef-id='type-id-114' visibility='default' id='type-id-115'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='p_type' type-id='type-id-116' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='p_flags' type-id='type-id-116' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='p_offset' type-id='type-id-117' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='p_vaddr' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='p_paddr' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='p_filesz' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='p_memsz' type-id='type-id-119' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='p_align' type-id='type-id-119' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_sync' size-in-bits='64' is-struct='yes' visibility='default' id='type-id-120'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__u' type-id='type-id-121' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='__owner' type-id='type-id-122' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dl_phdr_info' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-123'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dlpi_addr' type-id='type-id-118' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='dlpi_name' type-id='type-id-18' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='dlpi_phdr' type-id='type-id-124' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='dlpi_phnum' type-id='type-id-125' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_cache_entry' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-126'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='coll_chain' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='hint' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='valid' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='97'>
+        <var-decl name='signal_frame' type-id='type-id-127' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_only_state' size-in-bits='1408' is-struct='yes' visibility='default' id='type-id-128'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='where' type-id='type-id-105' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='val' type-id='type-id-129' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_reg_state' size-in-bits='1472' is-struct='yes' visibility='default' id='type-id-130'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ret_addr_column' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='reg' type-id='type-id-131' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='dwarf_rs_cache' size-in-bits='209280' is-struct='yes' visibility='default' id='type-id-132'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='lock' type-id='type-id-20' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='rr_head' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='log_size' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='prev_log_size' type-id='type-id-127' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='hash' type-id='type-id-133' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='generation' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='buckets' type-id='type-id-134' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='links' type-id='type-id-135' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='default_hash' type-id='type-id-136' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='4480'>
+        <var-decl name='default_buckets' type-id='type-id-110' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192896'>
+        <var-decl name='default_links' type-id='type-id-108' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_accessors' size-in-bits='704' is-struct='yes' visibility='default' id='type-id-24'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='find_proc_info' type-id='type-id-137' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='put_unwind_info' type-id='type-id-138' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='get_dyn_info_list_addr' type-id='type-id-139' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='access_mem' type-id='type-id-140' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='access_reg' type-id='type-id-141' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='access_fpreg' type-id='type-id-142' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='resume' type-id='type-id-143' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='get_proc_name' type-id='type-id-144' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='get_elf_filename' type-id='type-id-144' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='get_proc_ip_range' type-id='type-id-145' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='ptrauth_insn_mask' type-id='type-id-146' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_addr_space' size-in-bits='210304' is-struct='yes' visibility='default' id='type-id-147'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='acc' type-id='type-id-24' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='iterate_phdr_function' type-id='type-id-33' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='caching_policy' type-id='type-id-31' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='cache_generation' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='dyn_generation' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='dyn_info_list_addr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='global_cache' type-id='type-id-132' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='210240'>
+        <var-decl name='debug_frames' type-id='type-id-148' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_cursor' size-in-bits='8128' is-struct='yes' visibility='default' id='type-id-149'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='opaque' type-id='type-id-150' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_debug_frame_list' size-in-bits='512' is-struct='yes' visibility='default' id='type-id-151'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='load_offset' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='debug_frame' type-id='type-id-27' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='debug_frame_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='index' type-id='type-id-152' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='index_size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='next' type-id='type-id-148' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_proc_info' size-in-bits='576' is-struct='yes' visibility='default' id='type-id-153'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='start_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='end_ip' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lsda' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='handler' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gp' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='flags' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='format' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='unwind_info_size' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='unwind_info' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='extra' type-id='type-id-154' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_proc_info_t' size-in-bits='8' is-struct='yes' naming-typedef-id='type-id-154' visibility='default' id='type-id-155'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-156' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Elf64_Addr' type-id='type-id-157' id='type-id-118'/>
+    <typedef-decl name='Elf64_Half' type-id='type-id-158' id='type-id-125'/>
+    <typedef-decl name='Elf64_Off' type-id='type-id-157' id='type-id-117'/>
+    <typedef-decl name='Elf64_Phdr' type-id='type-id-115' id='type-id-114'/>
+    <typedef-decl name='Elf64_Word' type-id='type-id-83' id='type-id-116'/>
+    <typedef-decl name='Elf64_Xword' type-id='type-id-157' id='type-id-119'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u16t' type-id='type-id-127' id='type-id-159'/>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u8t' type-id='type-id-160' id='type-id-161'/>
+    <typedef-decl name='_Uint16t' type-id='type-id-159' id='type-id-61'/>
+    <typedef-decl name='_Uint8t' type-id='type-id-161' id='type-id-38'/>
+    <typedef-decl name='dwarf_reg_cache_entry_t' type-id='type-id-126' id='type-id-107'/>
+    <typedef-decl name='dwarf_reg_only_state_t' type-id='type-id-128' id='type-id-131'/>
+    <typedef-decl name='dwarf_reg_state_t' type-id='type-id-130' id='type-id-109'/>
+    <typedef-decl name='pthread_mutex_t' type-id='type-id-120' id='type-id-20'/>
+    <typedef-decl name='uint16_t' type-id='type-id-61' id='type-id-158'/>
+    <typedef-decl name='uint32_t' type-id='type-id-59' id='type-id-83'/>
+    <typedef-decl name='uint8_t' type-id='type-id-38' id='type-id-156'/>
+    <typedef-decl name='unw_addr_space_t' type-id='type-id-162' id='type-id-3'/>
+    <typedef-decl name='unw_caching_policy_t' type-id='type-id-111' id='type-id-31'/>
+    <typedef-decl name='unw_cursor_t' type-id='type-id-149' id='type-id-163'/>
+    <typedef-decl name='unw_fpreg_t' type-id='type-id-164' id='type-id-32'/>
+    <typedef-decl name='unw_iterate_phdr_callback_t' type-id='type-id-165' id='type-id-13'/>
+    <typedef-decl name='unw_iterate_phdr_func_t' type-id='type-id-166' id='type-id-33'/>
+    <typedef-decl name='unw_proc_info_t' type-id='type-id-153' id='type-id-167'/>
+    <typedef-decl name='unw_regnum_t' type-id='type-id-7' id='type-id-168'/>
+    <typedef-decl name='unw_tdep_fpreg_t' type-id='type-id-113' id='type-id-164'/>
+    <typedef-decl name='unw_tdep_proc_info_t' type-id='type-id-155' id='type-id-154'/>
+    <union-decl name='__anonymous_union__' size-in-bits='32' is-anonymous='yes' visibility='default' id='type-id-121'>
+      <data-member access='public'>
+        <var-decl name='__count' type-id='type-id-122' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__fd' type-id='type-id-7' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='__clockid' type-id='type-id-7' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-112'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-160'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-127'/>
+    <array-type-def dimensions='1' type-id='type-id-127' size-in-bits='4096' id='type-id-136'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-36' id='type-id-169'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-4' size-in-bits='8128' id='type-id-150'>
+      <subrange length='127' lower-bound='0' upper-bound='126' type-id='type-id-36' id='type-id-170'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-4' size-in-bits='1216' id='type-id-129'>
+      <subrange length='19' lower-bound='0' upper-bound='18' type-id='type-id-36' id='type-id-106'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-114' const='yes' id='type-id-171'/>
+    <pointer-type-def type-id='type-id-171' size-in-bits='64' id='type-id-124'/>
+    <qualified-type-def type-id='type-id-104' const='yes' id='type-id-172'/>
+    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-18'/>
+    <pointer-type-def type-id='type-id-123' size-in-bits='64' id='type-id-10'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-135'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-134'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-165'/>
+    <pointer-type-def type-id='type-id-173' size-in-bits='64' id='type-id-142'/>
+    <pointer-type-def type-id='type-id-174' size-in-bits='64' id='type-id-141'/>
+    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-144'/>
+    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-137'/>
+    <pointer-type-def type-id='type-id-177' size-in-bits='64' id='type-id-140'/>
+    <pointer-type-def type-id='type-id-178' size-in-bits='64' id='type-id-145'/>
+    <pointer-type-def type-id='type-id-179' size-in-bits='64' id='type-id-143'/>
+    <pointer-type-def type-id='type-id-180' size-in-bits='64' id='type-id-139'/>
+    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-166'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-152'/>
+    <pointer-type-def type-id='type-id-181' size-in-bits='64' id='type-id-146'/>
+    <pointer-type-def type-id='type-id-127' size-in-bits='64' id='type-id-133'/>
+    <pointer-type-def type-id='type-id-147' size-in-bits='64' id='type-id-162'/>
+    <pointer-type-def type-id='type-id-163' size-in-bits='64' id='type-id-29'/>
+    <pointer-type-def type-id='type-id-151' size-in-bits='64' id='type-id-148'/>
+    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-167' size-in-bits='64' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-28'/>
+    <pointer-type-def type-id='type-id-182' size-in-bits='64' id='type-id-138'/>
+    <function-decl name='_Ux86_64_flush_cache' mangled-name='_Ux86_64_flush_cache' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_flush_cache'>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-4' name='lo'/>
+      <parameter type-id='type-id-4' name='hi'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-173'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-168'/>
+      <parameter type-id='type-id-30'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-174'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-168'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-175'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-27'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-176'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-177'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-178'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-179'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-180'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-181'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-4'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-182'>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-23'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/init.c' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-59' size-in-bits='64' id='type-id-183'>
+      <subrange length='2' lower-bound='0' upper-bound='1' type-id='type-id-36' id='type-id-184'/>
+    </array-type-def>
+    <type-decl name='long int' size-in-bits='64' id='type-id-185'/>
+    <class-decl name='sigset_t' size-in-bits='64' is-struct='yes' naming-typedef-id='type-id-51' visibility='default' id='type-id-186'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='__bits' type-id='type-id-183' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u32t' type-id='type-id-122' id='type-id-187'/>
+    <typedef-decl name='_Uint32t' type-id='type-id-187' id='type-id-59'/>
+    <typedef-decl name='intrmask_t' type-id='type-id-51' id='type-id-188'/>
+    <typedef-decl name='sigset_t' type-id='type-id-186' id='type-id-51'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-122'/>
+    <var-decl name='_UIx86_64_full_mask' type-id='type-id-188' visibility='default'/>
+    <var-decl name='unw_page_size' type-id='type-id-185' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/mi/strerror.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_strerror' mangled-name='_Ux86_64_strerror' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_strerror'>
+      <parameter type-id='type-id-7' name='err_code'/>
+      <return type-id='type-id-18'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/os-qnx.c' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-104'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-7'/>
+    <class-decl name='elf_image' size-in-bits='128' is-struct='yes' visibility='default' id='type-id-15'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='image' type-id='type-id-8' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='size' type-id='type-id-11' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='_GCC_ATTR_ALIGN_u64t' type-id='type-id-36' id='type-id-189'/>
+    <typedef-decl name='_Sizet' type-id='type-id-34' id='type-id-63'/>
+    <typedef-decl name='_Uint64t' type-id='type-id-189' id='type-id-34'/>
+    <typedef-decl name='pid_t' type-id='type-id-7' id='type-id-190'/>
+    <typedef-decl name='size_t' type-id='type-id-63' id='type-id-11'/>
+    <typedef-decl name='uint64_t' type-id='type-id-34' id='type-id-157'/>
+    <typedef-decl name='unw_word_t' type-id='type-id-157' id='type-id-4'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-36'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-27'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-191'/>
+    <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-192'/>
+    <function-decl name='_Ux86_64_get_elf_image' mangled-name='_Ux86_64_get_elf_image' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_elf_image'>
+      <parameter type-id='type-id-191' name='ei'/>
+      <parameter type-id='type-id-190' name='pid'/>
+      <parameter type-id='type-id-4' name='ip'/>
+      <parameter type-id='type-id-192' name='segbase'/>
+      <parameter type-id='type-id-192' name='mapoff'/>
+      <parameter type-id='type-id-27' name='path'/>
+      <parameter type-id='type-id-11' name='pathlen'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_Ux86_64_get_exe_image_path' mangled-name='_Ux86_64_get_exe_image_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_get_exe_image_path'>
+      <parameter type-id='type-id-27' name='path'/>
+      <return type-id='type-id-23'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-23'/>
+    <pointer-type-def type-id='type-id-23' id='type-id-8'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lapply_reg_state.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_apply_reg_state' mangled-name='_ULx86_64_apply_reg_state' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_apply_reg_state'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-8' name='reg_states_data'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lcreate_addr_space.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_create_addr_space' mangled-name='_ULx86_64_create_addr_space' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_create_addr_space'>
+      <parameter type-id='type-id-26' name='a'/>
+      <parameter type-id='type-id-7' name='byte_order'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lget_proc_info.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_get_proc_info' mangled-name='_ULx86_64_get_proc_info' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_proc_info'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-6' name='pi'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lget_save_loc.c' language='LANG_C99'>
+    <enum-decl name='unw_save_loc_type' id='type-id-193'>
+      <underlying-type type-id='type-id-112'/>
+      <enumerator name='UNW_SLT_NONE' value='0'/>
+      <enumerator name='UNW_SLT_MEMORY' value='1'/>
+      <enumerator name='UNW_SLT_REG' value='2'/>
+    </enum-decl>
+    <class-decl name='unw_save_loc' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-194'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-195' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='u' type-id='type-id-196' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='extra' type-id='type-id-197' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='unw_tdep_save_loc' size-in-bits='8' is-struct='yes' visibility='default' id='type-id-198'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='unused' type-id='type-id-156' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='unw_save_loc_t' type-id='type-id-194' id='type-id-199'/>
+    <typedef-decl name='unw_save_loc_type_t' type-id='type-id-193' id='type-id-195'/>
+    <typedef-decl name='unw_tdep_save_loc_t' type-id='type-id-198' id='type-id-197'/>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' id='type-id-196'>
+      <data-member access='public'>
+        <var-decl name='addr' type-id='type-id-4' visibility='default'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='regnum' type-id='type-id-168' visibility='default'/>
+      </data-member>
+    </union-decl>
+    <pointer-type-def type-id='type-id-199' size-in-bits='64' id='type-id-200'/>
+    <function-decl name='_ULx86_64_get_save_loc' mangled-name='_ULx86_64_get_save_loc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_get_save_loc'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-7' name='reg'/>
+      <parameter type-id='type-id-200' name='sloc'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lglobal.c' language='LANG_C99'>
+    <type-decl name='atomic_bool' size-in-bits='8' id='type-id-201'/>
+    <array-type-def dimensions='1' type-id='type-id-202' size-in-bits='136' id='type-id-203'>
+      <subrange length='17' lower-bound='0' upper-bound='16' type-id='type-id-36' id='type-id-204'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-156' const='yes' id='type-id-202'/>
+    <var-decl name='_ULx86_64_dwarf_to_unw_regnum_map' type-id='type-id-203' visibility='default'/>
+    <var-decl name='_ULx86_64_init_done' type-id='type-id-201' visibility='default'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Linit.c' language='LANG_C99'>
+    <var-decl name='_ULx86_64_local_addr_space' type-id='type-id-3' mangled-name='_ULx86_64_local_addr_space' visibility='default' elf-symbol-id='_ULx86_64_local_addr_space'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Linit_local.c' language='LANG_C99'>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-205'/>
+    <function-decl name='_ULx86_64_init_local' mangled-name='_ULx86_64_init_local' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_init_local'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-205' name='uc'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='_ULx86_64_init_local2' mangled-name='_ULx86_64_init_local2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_init_local2'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-205' name='uc'/>
+      <parameter type-id='type-id-7' name='flag'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Linit_remote.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_init_remote' mangled-name='_ULx86_64_init_remote' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_init_remote'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-3' name='as'/>
+      <parameter type-id='type-id-8' name='as_arg'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Los-qnx.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_is_signal_frame' mangled-name='_ULx86_64_is_signal_frame' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_is_signal_frame'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lreg_states_iterate.c' language='LANG_C99'>
+    <typedef-decl name='unw_reg_states_callback' type-id='type-id-206' id='type-id-207'/>
+    <pointer-type-def type-id='type-id-208' size-in-bits='64' id='type-id-206'/>
+    <function-decl name='_ULx86_64_reg_states_iterate' mangled-name='_ULx86_64_reg_states_iterate' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_reg_states_iterate'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <parameter type-id='type-id-207' name='cb'/>
+      <parameter type-id='type-id-8' name='token'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-208'>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-7'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lresume.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_resume' mangled-name='_ULx86_64_resume' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_resume'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/Lstep.c' language='LANG_C99'>
+    <function-decl name='_ULx86_64_step' mangled-name='_ULx86_64_step' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_ULx86_64_step'>
+      <parameter type-id='type-id-29' name='cursor'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/is_fpreg.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_is_fpreg' mangled-name='_Ux86_64_is_fpreg' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_is_fpreg'>
+      <parameter type-id='type-id-7' name='regnum'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='../../src/x86_64/regname.c' language='LANG_C99'>
+    <function-decl name='_Ux86_64_regname' mangled-name='_Ux86_64_regname' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_Ux86_64_regname'>
+      <parameter type-id='type-id-168' name='reg'/>
+      <return type-id='type-id-18'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/tests/run-ptrace-misc
+++ b/tests/run-ptrace-misc
@@ -20,5 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-dir="$(dirname $0)"
-"${dir}/test-ptrace" -c -t "${dir}/test-ptrace-misc"
+bindir=$(pwd)
+"${bindir}/test-ptrace" -c -t "${bindir}/test-ptrace-misc"


### PR DESCRIPTION
Added `make -C src check-abi` target to leverage libabigail 2.0 tools to check for ABI changes.

Add ABI baseline files for aarch64, i686, riscv, s390x, and x86_64 Linux targets and aarch64 and x86_64 QNX SDP 7.1 targets.

Used the check-abi target in the CI-unix github workflow.