### PR TITLE
handle .eh_frame_hdr with no binary search table

### DIFF
--- a/src/dwarf/Gfind_unwind_table.c
+++ b/src/dwarf/Gfind_unwind_table.c
@@ -167,6 +167,10 @@ dwarf_find_unwind_table (struct elf_dyn_info *edi,
                                              &fde_count, NULL)) < 0)
         return -UNW_ENOINFO;
 
+      /* A value of DW_EH_PE_omit indicates the binary search table is not present. */
+      if (hdr->table_enc == DW_EH_PE_omit)
+        return -UNW_ENOINFO;
+
       if (hdr->table_enc != (DW_EH_PE_datarel | DW_EH_PE_sdata4))
         {
     #if 1


### PR DESCRIPTION
as reported on
https://github.com/libunwind/libunwind/issues/161
and https://github.com/benfred/py-spy/issues/398

some binaries contain table_enc=DW_EH_PE_omit which is valid according to https://refspecs.linuxfoundation.org/LSB_1.3.0/gLSB/gLSB/ehframehdr.html

On my environment I read:
```
$ objdump  -s -j .eh_frame_hdr /usr/lib64/libc.so.6

/usr/lib64/libc.so.6:     file format elf64-x86-64

Contents of section .eh_frame_hdr:
 1c37bc 011bffff 08000000                    ........
              ||<--- 0xff = table_enc
```
which causes py-spy to crash with sigabort.
Return an error code instead.