### PR TITLE
Add missing return in _do_pipe2

### DIFF
--- a/src/mi/Gaddress_validator.c
+++ b/src/mi/Gaddress_validator.c
@@ -70,6 +70,7 @@ _do_pipe2 (int pipefd[2])
     }
   _set_pipe_flags(pipefd[0]);
   _set_pipe_flags(pipefd[1]);
+  return 0;
 }
 #endif
 


### PR DESCRIPTION
Found this on linux-x64 when updating dotnet-runtime to v1.8.0.
```
 /runtime/src/native/external/libunwind/src/mi/Gaddress_validator.c:73:1: error: non-void function does not return a value in all control paths [-Werror,-Wreturn-type]
     73 | }
        | ^
  1 error generated.
  make[2]: *** [/runtime/artifacts/obj/external/libunwind/CMakeFiles/libunwind.dir/build.make:872: /runtime/artifacts/obj/external/libunwind/CMakeFiles/libunwind.dir/runtime/src/native/external/libunwind/src/mi/Gaddress_validator.c.o] Error 1
  make[2]: *** Waiting for unfinished jobs....
  [ 41%] Building C object /runtime/artifacts/obj/external/libunwind/CMakeFiles/libunwind.dir/runtime/src/native/external/libunwind/src/x86_64/Ginit
```

(There are other issues in other OS/archs, will post the patches as I figure out the minimal fixes for those..)