### PR TITLE
Add missing defined for osx-arm64 (remote unwind)

### DIFF
--- a/src/aarch64/ucontext_i.h
+++ b/src/aarch64/ucontext_i.h
@@ -23,7 +23,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #ifndef libunwind_src_aarch64_ucontext_i_h
 #define libunwind_src_aarch64_ucontext_i_h
 
-#if defined __FreeBSD__
+#if defined __FreeBSD__ || defined __APPLE__
 
 #define	UC_MCONTEXT_OFF			0x10
 #define	SC_GPR_OFF			0x00


### PR DESCRIPTION
macOS arm64 build was failing with:
```
  In file included from /runtime/src/native/external/libunwind/src/aarch64/Gstep.c:29:
  /runtime/src/native/external/libunwind/src/aarch64/ucontext_i.h:71:3: error: Port me
  # error Port me
    ^
  /runtime/src/native/external/libunwind/src/aarch64/Gstep.c:525:30: error: use of undeclared identifier 'SCF_FORMAT'
        c->sigcontext_format = SCF_FORMAT;
                               ^
  /runtime/src/native/external/libunwind/src/aarch64/Gstep.c:526:48: error: use of undeclared identifier 'UC_MCONTEXT_OFF'
        sc_addr = sp_addr + sizeof (siginfo_t) + UC_MCONTEXT_OFF;
                                                 ^
  /runtime/src/native/external/libunwind/src/aarch64/Gstep.c:546:70: error: use of undeclared identifier 'SC_GPR_OFF'
    c->dwarf.loc[UNW_AARCH64_X0]  = DWARF_MEM_LOC (c->dwarf, sc_addr + SC_GPR_OFF);
```

dotnet-runtime only builds remote-unwind apparatus for maxOS and windows, so these parts need to just compile.