### PR TITLE
Check existence of attribute

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -31,6 +31,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #define COMPILER_H
 
 #ifdef __GNUC__
+#ifndef __has_attribute
+#  define __has_attribute(x) (0)
+#endif
 # define CONST_ATTR     __attribute__((__const__))
 # define UNUSED         __attribute__((unused))
 # define NOINLINE       __attribute__((noinline))
@@ -40,7 +43,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 # if (__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ > 2)
 #  define ALWAYS_INLINE inline __attribute__((always_inline))
 #  define HIDDEN        __attribute__((visibility ("hidden")))
-#  define FALLTHROUGH   __attribute__((fallthrough))
+#  if __has_attribute(fallthrough)
+#    define FALLTHROUGH __attribute__((fallthrough))
+#  else
+#    define FALLTHROUGH
+#  endif
 # else
 #  define ALWAYS_INLINE
 #  define HIDDEN


### PR DESCRIPTION
In FreeBSD leg, dotnet-runtime is still using clang9 for cross-compile and running into the following error:

```
In file included from /__w/1/s/src/native/external/libunwind/src/x86_64/Ltrace.c:4:
/__w/1/s/src/native/external/libunwind/src/x86_64/Gtrace.c:480:7: error: declaration does not declare anything [-Werror,-Wmissing-declarations]
      FALLTHROUGH;
      ^
/__w/1/s/src/native/external/libunwind/include/compiler.h:43:25: note: expanded from macro 'FALLTHROUGH'
#  define FALLTHROUGH   __attribute__((fallthrough))
                        ^
1 error generated.
```