### PR TITLE
Add missing functions for macOS

### DIFF
--- a/src/remote/mac/missing-functions.c
+++ b/src/remote/mac/missing-functions.c
@@ -74,3 +74,9 @@ UNW_OBJ(handle_signal_frame) (unw_cursor_t *cursor)
 {
   return -UNW_EBADFRAME;
 }
+
+int
+UNW_OBJ(os_step) (struct cursor *c)
+{
+  return 0;
+}


### PR DESCRIPTION
This is needed by dotnet-runtime remote unwind feature.