### PR TITLE
Handle musl on PPC32

### DIFF
--- a/src/ppc32/ucontext_i.h
+++ b/src/ppc32/ucontext_i.h
@@ -44,8 +44,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 //#define MQ_IDX                36
 #define LINK_IDX        36
 
+#ifdef __GLIBC__
 #define _UC_MCONTEXT_GPR(x) ( ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[x] - (void *)&dmy_ctxt) )
 #define _UC_MCONTEXT_FPR(x) ( ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[x] - (void *)&dmy_ctxt) )
+#else
+#define _UC_MCONTEXT_GPR(x) ( ((void *)&dmy_ctxt.uc_regs->gregs[x] - (void *)&dmy_ctxt) )
+#define _UC_MCONTEXT_FPR(x) ( ((void *)&dmy_ctxt.uc_regs->fpregs.fpregs[x] - (void *)&dmy_ctxt) )
+#endif
 
 /* These are dummy structures used only for obtaining the offsets of the
    various structure members. */


### PR DESCRIPTION
On Linux, glibc and musl disagree over the layout of the ucontext_t structure.  For more details, see the musl mailing list:

https://www.openwall.com/lists/musl/2018/02/22/1

Add conditionals to handle both the glibc and musl layout of the structures.

Closes #709.