### PR TITLE
coredump: use glibc or musl register names as appropriate on MIPS

### DIFF
--- a/src/coredump/_UCD_access_reg_linux.c
+++ b/src/coredump/_UCD_access_reg_linux.c
@@ -100,38 +100,47 @@ _UCD_access_reg (unw_addr_space_t  as UNUSED,
     };
 #else
 #if defined(UNW_TARGET_MIPS)
+
+/* glibc and musl use different names */
+#ifdef __GLIBC__
+#define EF_REG(x) EF_REG ## x
+#else
+#include <sys/reg.h>
+#define EF_REG(x) EF_R ## x
+#endif
+
   static const uint8_t remap_regs[] =
     {
-      [UNW_MIPS_R0]  = EF_REG0,
-      [UNW_MIPS_R1]  = EF_REG1,
-      [UNW_MIPS_R2]  = EF_REG2,
-      [UNW_MIPS_R3]  = EF_REG3,
-      [UNW_MIPS_R4]  = EF_REG4,
-      [UNW_MIPS_R5]  = EF_REG5,
-      [UNW_MIPS_R6]  = EF_REG6,
-      [UNW_MIPS_R7]  = EF_REG7,
-      [UNW_MIPS_R8]  = EF_REG8,
-      [UNW_MIPS_R9]  = EF_REG9,
-      [UNW_MIPS_R10] = EF_REG10,
-      [UNW_MIPS_R11] = EF_REG11,
-      [UNW_MIPS_R12] = EF_REG12,
-      [UNW_MIPS_R13] = EF_REG13,
-      [UNW_MIPS_R14] = EF_REG14,
-      [UNW_MIPS_R15] = EF_REG15,
-      [UNW_MIPS_R16] = EF_REG16,
-      [UNW_MIPS_R17] = EF_REG17,
-      [UNW_MIPS_R18] = EF_REG18,
-      [UNW_MIPS_R19] = EF_REG19,
-      [UNW_MIPS_R20] = EF_REG20,
-      [UNW_MIPS_R21] = EF_REG21,
-      [UNW_MIPS_R22] = EF_REG22,
-      [UNW_MIPS_R23] = EF_REG23,
-      [UNW_MIPS_R24] = EF_REG24,
-      [UNW_MIPS_R25] = EF_REG25,
-      [UNW_MIPS_R28] = EF_REG28,
-      [UNW_MIPS_R29] = EF_REG29,
-      [UNW_MIPS_R30] = EF_REG30,
-      [UNW_MIPS_R31] = EF_REG31,
+      [UNW_MIPS_R0]  = EF_REG(0),
+      [UNW_MIPS_R1]  = EF_REG(1),
+      [UNW_MIPS_R2]  = EF_REG(2),
+      [UNW_MIPS_R3]  = EF_REG(3),
+      [UNW_MIPS_R4]  = EF_REG(4),
+      [UNW_MIPS_R5]  = EF_REG(5),
+      [UNW_MIPS_R6]  = EF_REG(6),
+      [UNW_MIPS_R7]  = EF_REG(7),
+      [UNW_MIPS_R8]  = EF_REG(8),
+      [UNW_MIPS_R9]  = EF_REG(9),
+      [UNW_MIPS_R10] = EF_REG(10),
+      [UNW_MIPS_R11] = EF_REG(11),
+      [UNW_MIPS_R12] = EF_REG(12),
+      [UNW_MIPS_R13] = EF_REG(13),
+      [UNW_MIPS_R14] = EF_REG(14),
+      [UNW_MIPS_R15] = EF_REG(15),
+      [UNW_MIPS_R16] = EF_REG(16),
+      [UNW_MIPS_R17] = EF_REG(17),
+      [UNW_MIPS_R18] = EF_REG(18),
+      [UNW_MIPS_R19] = EF_REG(19),
+      [UNW_MIPS_R20] = EF_REG(20),
+      [UNW_MIPS_R21] = EF_REG(21),
+      [UNW_MIPS_R22] = EF_REG(22),
+      [UNW_MIPS_R23] = EF_REG(23),
+      [UNW_MIPS_R24] = EF_REG(24),
+      [UNW_MIPS_R25] = EF_REG(25),
+      [UNW_MIPS_R28] = EF_REG(28),
+      [UNW_MIPS_R29] = EF_REG(29),
+      [UNW_MIPS_R30] = EF_REG(30),
+      [UNW_MIPS_R31] = EF_REG(31),
       [UNW_MIPS_PC]  = EF_CP0_EPC,
     };
 #elif defined(UNW_TARGET_S390X)


### PR DESCRIPTION
glibc has register macros of the form EF_REGx, but musl uses EF_Rx.

Handle this by using a macro to use the correct names.

Closes #708.

Marking this as a draft as I've no idea about other platforms and whether glibc vs everything else is acceptable, or if the configure script should be probing to see if `EF_REG0` or `EF_R0` exist.