### PR TITLE
Fix issue #713

### DIFF
--- a/src/dwarf/Gget_proc_info_in_range.c
+++ b/src/dwarf/Gget_proc_info_in_range.c
@@ -62,6 +62,8 @@ unw_get_proc_info_in_range (unw_word_t        start_ip,
         if ((*a->access_mem)(as, eh_frame_table, &data, 0, arg) < 0) {
             return -UNW_EINVAL;
         }
+        /* we are reading only the first 4 `char` members of `struct dwarf_eh_frame_hdr`, which
+         * are guaranteed to fit into the first `sizeof(unw_word_t)` bytes */
         struct dwarf_eh_frame_hdr exhdr;
         memcpy(&exhdr, &data, sizeof(data));
 

--- a/src/dwarf/Gget_proc_info_in_range.c
+++ b/src/dwarf/Gget_proc_info_in_range.c
@@ -58,13 +58,14 @@ unw_get_proc_info_in_range (unw_word_t        start_ip,
     if (eh_frame_table != 0) {
         unw_accessors_t *a = unw_get_accessors_int (as);
 
-        struct dwarf_eh_frame_hdr exhdr;
-        if ((*a->access_mem)(as, eh_frame_table, (unw_word_t*)&exhdr, 0, arg) < 0) {
+        unw_word_t hdr[2];
+        if ((*a->access_mem)(as, eh_frame_table, hdr, 0, arg) < 0) {
             return -UNW_EINVAL;
         }
+        struct dwarf_eh_frame_hdr* exhdr = (struct dwarf_eh_frame_hdr*)hdr;
 
-        if (exhdr.version != DW_EH_VERSION) {
-            Debug (1, "Unexpected version %d\n", exhdr.version);
+        if (exhdr->version != DW_EH_VERSION) {
+            Debug (1, "Unexpected version %d\n", exhdr->version);
             return -UNW_EBADVERSION;
         }
         unw_word_t addr = eh_frame_table + offsetof(struct dwarf_eh_frame_hdr, eh_frame);
@@ -72,12 +73,12 @@ unw_get_proc_info_in_range (unw_word_t        start_ip,
         unw_word_t fde_count;
 
         /* read eh_frame_ptr */
-        if ((ret = dwarf_read_encoded_pointer(as, a, &addr, exhdr.eh_frame_ptr_enc, pi, &eh_frame_start, arg)) < 0) {
+        if ((ret = dwarf_read_encoded_pointer(as, a, &addr, exhdr->eh_frame_ptr_enc, pi, &eh_frame_start, arg)) < 0) {
             return ret;
         }
 
         /* read fde_count */
-        if ((ret = dwarf_read_encoded_pointer(as, a, &addr, exhdr.fde_count_enc, pi, &fde_count, arg)) < 0) {
+        if ((ret = dwarf_read_encoded_pointer(as, a, &addr, exhdr->fde_count_enc, pi, &fde_count, arg)) < 0) {
             return ret;
         }
 
@@ -87,8 +88,8 @@ unw_get_proc_info_in_range (unw_word_t        start_ip,
             return -UNW_ENOINFO;
         }
 
-        if (exhdr.table_enc != (DW_EH_PE_datarel | DW_EH_PE_sdata4)) {
-            Debug (1, "Table encoding not supported %x\n", exhdr.table_enc);
+        if (exhdr->table_enc != (DW_EH_PE_datarel | DW_EH_PE_sdata4)) {
+            Debug (1, "Table encoding not supported %x\n", exhdr->table_enc);
             return -UNW_EINVAL;
         }
 

--- a/src/dwarf/Gget_proc_info_in_range.c
+++ b/src/dwarf/Gget_proc_info_in_range.c
@@ -58,14 +58,15 @@ unw_get_proc_info_in_range (unw_word_t        start_ip,
     if (eh_frame_table != 0) {
         unw_accessors_t *a = unw_get_accessors_int (as);
 
-        unw_word_t hdr[2];
-        if ((*a->access_mem)(as, eh_frame_table, hdr, 0, arg) < 0) {
+        unw_word_t data;
+        if ((*a->access_mem)(as, eh_frame_table, &data, 0, arg) < 0) {
             return -UNW_EINVAL;
         }
-        struct dwarf_eh_frame_hdr* exhdr = (struct dwarf_eh_frame_hdr*)hdr;
+        struct dwarf_eh_frame_hdr exhdr;
+        memcpy(&exhdr, &data, sizeof(data));
 
-        if (exhdr->version != DW_EH_VERSION) {
-            Debug (1, "Unexpected version %d\n", exhdr->version);
+        if (exhdr.version != DW_EH_VERSION) {
+            Debug (1, "Unexpected version %d\n", exhdr.version);
             return -UNW_EBADVERSION;
         }
         unw_word_t addr = eh_frame_table + offsetof(struct dwarf_eh_frame_hdr, eh_frame);
@@ -73,12 +74,12 @@ unw_get_proc_info_in_range (unw_word_t        start_ip,
         unw_word_t fde_count;
 
         /* read eh_frame_ptr */
-        if ((ret = dwarf_read_encoded_pointer(as, a, &addr, exhdr->eh_frame_ptr_enc, pi, &eh_frame_start, arg)) < 0) {
+        if ((ret = dwarf_read_encoded_pointer(as, a, &addr, exhdr.eh_frame_ptr_enc, pi, &eh_frame_start, arg)) < 0) {
             return ret;
         }
 
         /* read fde_count */
-        if ((ret = dwarf_read_encoded_pointer(as, a, &addr, exhdr->fde_count_enc, pi, &fde_count, arg)) < 0) {
+        if ((ret = dwarf_read_encoded_pointer(as, a, &addr, exhdr.fde_count_enc, pi, &fde_count, arg)) < 0) {
             return ret;
         }
 
@@ -88,8 +89,8 @@ unw_get_proc_info_in_range (unw_word_t        start_ip,
             return -UNW_ENOINFO;
         }
 
-        if (exhdr->table_enc != (DW_EH_PE_datarel | DW_EH_PE_sdata4)) {
-            Debug (1, "Table encoding not supported %x\n", exhdr->table_enc);
+        if (exhdr.table_enc != (DW_EH_PE_datarel | DW_EH_PE_sdata4)) {
+            Debug (1, "Table encoding not supported %x\n", exhdr.table_enc);
             return -UNW_EINVAL;
         }
 
@@ -114,3 +115,4 @@ unw_get_proc_info_in_range (unw_word_t        start_ip,
     }
     return UNW_ESUCCESS;
 }
+

--- a/src/dwarf/Gget_proc_info_in_range.c
+++ b/src/dwarf/Gget_proc_info_in_range.c
@@ -58,14 +58,13 @@ unw_get_proc_info_in_range (unw_word_t        start_ip,
     if (eh_frame_table != 0) {
         unw_accessors_t *a = unw_get_accessors_int (as);
 
-        struct dwarf_eh_frame_hdr exhdr1;
-        struct dwarf_eh_frame_hdr* exhdr = &exhdr1;
-        if ((*a->access_mem)(as, eh_frame_table, (unw_word_t*)exhdr, 0, arg) < 0) {
+        struct dwarf_eh_frame_hdr exhdr;
+        if ((*a->access_mem)(as, eh_frame_table, (unw_word_t*)&exhdr, 0, arg) < 0) {
             return -UNW_EINVAL;
         }
 
-        if (exhdr->version != DW_EH_VERSION) {
-            Debug (1, "Unexpected version %d\n", exhdr->version);
+        if (exhdr.version != DW_EH_VERSION) {
+            Debug (1, "Unexpected version %d\n", exhdr.version);
             return -UNW_EBADVERSION;
         }
         unw_word_t addr = eh_frame_table + offsetof(struct dwarf_eh_frame_hdr, eh_frame);
@@ -73,12 +72,12 @@ unw_get_proc_info_in_range (unw_word_t        start_ip,
         unw_word_t fde_count;
 
         /* read eh_frame_ptr */
-        if ((ret = dwarf_read_encoded_pointer(as, a, &addr, exhdr->eh_frame_ptr_enc, pi, &eh_frame_start, arg)) < 0) {
+        if ((ret = dwarf_read_encoded_pointer(as, a, &addr, exhdr.eh_frame_ptr_enc, pi, &eh_frame_start, arg)) < 0) {
             return ret;
         }
 
         /* read fde_count */
-        if ((ret = dwarf_read_encoded_pointer(as, a, &addr, exhdr->fde_count_enc, pi, &fde_count, arg)) < 0) {
+        if ((ret = dwarf_read_encoded_pointer(as, a, &addr, exhdr.fde_count_enc, pi, &fde_count, arg)) < 0) {
             return ret;
         }
 
@@ -88,8 +87,8 @@ unw_get_proc_info_in_range (unw_word_t        start_ip,
             return -UNW_ENOINFO;
         }
 
-        if (exhdr->table_enc != (DW_EH_PE_datarel | DW_EH_PE_sdata4)) {
-            Debug (1, "Table encoding not supported %x\n", exhdr->table_enc);
+        if (exhdr.table_enc != (DW_EH_PE_datarel | DW_EH_PE_sdata4)) {
+            Debug (1, "Table encoding not supported %x\n", exhdr.table_enc);
             return -UNW_EINVAL;
         }
 

--- a/src/dwarf/Gget_proc_info_in_range.c
+++ b/src/dwarf/Gget_proc_info_in_range.c
@@ -58,8 +58,9 @@ unw_get_proc_info_in_range (unw_word_t        start_ip,
     if (eh_frame_table != 0) {
         unw_accessors_t *a = unw_get_accessors_int (as);
 
-        struct dwarf_eh_frame_hdr* exhdr = NULL;
-        if ((*a->access_mem)(as, eh_frame_table, (unw_word_t*)&exhdr, 0, arg) < 0) {
+        struct dwarf_eh_frame_hdr exhdr1;
+        struct dwarf_eh_frame_hdr* exhdr = &exhdr1;
+        if ((*a->access_mem)(as, eh_frame_table, (unw_word_t*)exhdr, 0, arg) < 0) {
             return -UNW_EINVAL;
         }
 


### PR DESCRIPTION
It appears to me that this change in #524 is problematic.

Original:
```c
        unw_word_t hdr;
        if ((*a->access_mem)(as, eh_frame_table, &hdr, 0, arg) < 0) {
            return -UNW_EINVAL;
        }
        struct dwarf_eh_frame_hdr* exhdr = (struct dwarf_eh_frame_hdr*)&hdr;
```

Changed:
```c
        struct dwarf_eh_frame_hdr* exhdr = NULL;
        if ((*a->access_mem)(as, eh_frame_table, (unw_word_t*)&exhdr, 0, arg) < 0) {
            return -UNW_EINVAL;
        }
```

Originally, `exhdr` will always point to the stack, while the latter will point to whatever `access_mem` may write it to, or `NULL` if it doesn't.
 
 The change will make sure `exhdr` still point to the stack, and I leave more spaces on the stack so that it will not overwrite random stack slots.
 