### PR TITLE
[v1.8] Make tests installable

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -116,7 +116,7 @@ jobs:
           set -x
           autoreconf -i
           BUILD=x86_64-linux-gnu
-          ./configure --build=$BUILD --host=${{ matrix.config.host }} --with-testdriver=$(pwd)/scripts/qemu-test-driver --enable-debug
+          ./configure --build=$BUILD --host=${{ matrix.config.host }} --with-testdriver="$(pwd)/libtool execute $(pwd)/scripts/qemu-test-driver" --enable-debug
         env:
           CC: ${{ matrix.config.host }}-gcc-${{ matrix.config.gccver }}
           CXX: ${{ matrix.config.host }}-g++-${{ matrix.config.gccver }}
@@ -129,7 +129,7 @@ jobs:
 
       - name: ABI Check
         run: |
-            cd tests && ./run-check-namespace
+            cd tests && ./check-namespace.sh
 
       - name: Test
         run: |
@@ -137,7 +137,7 @@ jobs:
           sudo bash -c 'echo core.%p.%p > /proc/sys/kernel/core_pattern'
           ulimit -c unlimited
           CROSS_LIB="/usr/${{ matrix.config.host }}"
-          make -j8 check LOG_DRIVER_FLAGS="--qemu-arch ${{ matrix.config.qemu }}" LDFLAGS="-L$CROSS_LIB/lib -static" QEMU_LD_PREFIX="$CROSS_LIB"
+          make check LOG_DRIVER_FLAGS="--qemu-arch ${{ matrix.config.qemu }}" QEMU_LD_PREFIX="$CROSS_LIB"
         env:
           UNW_DEBUG_LEVEL: 4
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,35 @@
-dnl Process this file with autoconf to produce a configure script.
+#
+# configure.ac
+#
+# Process this file with autoconf to produce a configure script.
+AC_COPYRIGHT([
+ This file is part of libunwind.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+])
+
 
 define(pkg_major, 1)
 define(pkg_minor, 8)
 define(pkg_extra, 0)
 define(pkg_maintainer, https://github.com/libunwind/libunwind)
 define(mkvers, $1.$2.$3)
-
 AC_INIT([libunwind],[mkvers(pkg_major, pkg_minor, pkg_extra)],[pkg_maintainer])
 AC_CONFIG_SRCDIR(src/mi/backtrace.c)
 AC_CONFIG_AUX_DIR(config)
@@ -247,7 +271,8 @@ AM_COND_IF([CONFIG_TESTS], [
                  [AS_IF([test "$ac_cv_search_backtrace" != "none required"],
                         [AC_SUBST([BACKTRACELIB],["$ac_cv_search_backtrace"])])])
   LIBS="$old_LIBS"
-  AC_CONFIG_FILES(tests/Makefile tests/check-namespace.sh)
+  AC_CONFIG_FILES([tests/Makefile])
+  AC_CONFIG_FILES([tests/check-namespace.sh], [chmod +x tests/check-namespace.sh])
 ])
 AC_ARG_WITH([testdriver],
             [AS_HELP_STRING([--with-testdriver],

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,13 +1,46 @@
+##
+## tests/Makefile.am
+##
+## Process this file with **automake** to produce a Makefile.in
+##
+
+#
+# This file is part of libunwind.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+# Test binaries and scripts get installed here
+testdir = ${pkglibexecdir}
+
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I$(top_srcdir)/src
 AM_CFLAGS = -fno-optimize-sibling-calls
 
 LOG_DRIVER = $(SHELL) $(UNW_TESTDRIVER)
 
 EXTRA_DIST =	run-ia64-test-dyn1 run-ptrace-mapper run-ptrace-misc	\
-		run-check-namespace run-coredump-unwind \
+		run-coredump-unwind \
 		run-coredump-unwind-mdi check-namespace.sh.in \
+		test-runner.in \
 		Gtest-nomalloc.c
 
+CLEANFILES = test-runner
 MAINTAINERCLEANFILES = Makefile.in
 
 noinst_PROGRAMS_arch =
@@ -19,7 +52,7 @@ check_PROGRAMS_common = test-proc-info test-static-link \
 			test-strerror
 check_SCRIPTS_arch =
 check_SCRIPTS_cdep =
-check_SCRIPTS_common =	run-check-namespace
+check_SCRIPTS_common =	check-namespace.sh
 
 XFAIL_TESTS =
 
@@ -94,9 +127,13 @@ endif
 if SUPPORT_CXX_EXCEPTIONS
  check_PROGRAMS_cdep += Ltest-cxx-exceptions
 endif
-# Temporarily XFAIL this test for riscv64 until #519 is fixed
-if ARCH_RISCV
+if ARCH_PPC32
+  # https://github.com/libunwind/libunwind/issues/561
   XFAIL_TESTS += Ltest-cxx-exceptions
+endif
+
+if ARCH_IA64
+ check_PROGRAMS_cdep += Gtest-dyn1 Ltest-dyn1
 endif
 
 if OS_LINUX
@@ -132,10 +169,6 @@ if !CROSS_BUILD
  TESTS += $(check_SCRIPTS)
 endif
 
-if ARCH_IA64
- check_PROGRAMS_cdep += Gtest-dyn1 Ltest-dyn1
-endif
-
 # Use if arch defines but does not support PTRACE_SINGLESTEP
 # ptrace request used in the tests.
 XFAIL_TESTS_PTRACE_SINGLESTEP = run-ptrace-mapper run-ptrace-misc
@@ -167,6 +200,18 @@ endif
 noinst_PROGRAMS = $(noinst_PROGRAMS_common) $(noinst_PROGRAMS_cdep) \
 	$(noinst_PROGRAMS_arch)
 noinst_HEADERS = ident.h
+
+do_test_subst = sed -e 's,[@]TESTS[@],$(TESTS),g' \
+                    -e 's,[@]XFAIL_TESTS[@],$(XFAIL_TESTS),g' \
+                    -e 's,[@]LIBDIR[@],$(libdir),g' \
+                    -e 's,[@]ARCH[@],$(arch),g'
+test-runner: test-runner.in Makefile
+	$(AM_V_GEN)$(do_test_subst) <$(srcdir)/test-runner.in >$@
+	@chmod +x test-runner
+
+# Make the test binaries installable
+test_PROGRAMS = ${check_PROGRAMS} ${noinst_PROGRAMS}
+test_SCRIPTS  = ${check_SCRIPTS} test-runner
 
 Lia64_test_readonly_SOURCES = Lia64-test-readonly.c ia64-test-readonly-asm.S
 Gia64_test_readonly_SOURCES = Gia64-test-readonly.c ia64-test-readonly-asm.S

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,24 @@
+Testing libunwind
+=================
+
+Testing in the build tree
+-------------------------
+
+Testing in a self-hosted build environment is as simple as `make check`
+
+
+Testing staged builds
+---------------------
+
+```
+$ STAGINGDIR=/tmp/gh-705
+$ make install DESTDIR=$STAGINGDIR
+$ LIBUNWIND=$STAGINGDIR/usr/lib/libunwind.so LIBUNWIND_GENERIC=$STAGINGDIR/usr/lib/libunwind-x86_64.so LD_LIBRARY_PATH=$STAGINGDIR/usr/lib $STAGINGDIR/usr/libexec/libunwind/test-runner
+```
+
+Testing installed builds
+------------------------
+
+```
+$ /usr/libexec/libunwind/test-runner
+```

--- a/tests/check-namespace.sh.in
+++ b/tests/check-namespace.sh.in
@@ -1,4 +1,25 @@
 #!/bin/sh
+#
+# This file is part of libunwind.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
 verbose=false
 if [ "$1" = "-v" ]; then
     verbose=true
@@ -10,8 +31,8 @@ plat=@arch@
 os=@target_os@
 num_errors=0
 
-LIBUNWIND=../src/.libs/libunwind.so
-LIBUNWIND_GENERIC=../src/.libs/libunwind-${plat}.so
+: ${LIBUNWIND:=../src/.libs/libunwind.so}
+: ${LIBUNWIND_GENERIC:=../src/.libs/libunwind-${plat}.so}
 
 fetch_symtab () {
     filename=$1

--- a/tests/run-check-namespace
+++ b/tests/run-check-namespace
@@ -1,3 +1,0 @@
-#!/bin/sh
-chmod +x ./check-namespace.sh
-./check-namespace.sh $*

--- a/tests/run-ptrace-misc
+++ b/tests/run-ptrace-misc
@@ -1,2 +1,24 @@
 #!/bin/sh
-./test-ptrace -c -t ./test-ptrace-misc
+#
+# This file is part of libunwind.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+dir="$(dirname $0)"
+"${dir}/test-ptrace" -c -t "${dir}/test-ptrace-misc"

--- a/tests/test-runner.in
+++ b/tests/test-runner.in
@@ -20,5 +20,26 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-dir="$(dirname $0)"
-"${dir}/test-ptrace" -c -n -t "${dir}/mapper" $*
+
+test_dir="$(dirname $0)"
+
+: ${LIBUNWIND:=@LIBDIR@/libunwind.so}
+: ${LIBUNWIND_GENERIC:=@LIBDIR@/libunwind-@ARCH@.so}
+
+count=0
+printf "TAP version 14\n"
+for t in @TESTS@; do
+    "$test_dir/$t" >$t.out 2>$t.err
+    status=$?
+    if [ $status = 77 ]; then
+        printf "%d ok - %s # SKIP\n" $count "$t"
+    elif [ $status = 0 ]; then
+        printf "%d ok - %s\n" $count "$t"
+    elif (echo @XFAIL_TESTS@ | grep -Fqw "$t"); then
+        printf "%d not ok - %s # TODO\n" $count "$t"
+    else
+        printf "%d not ok - %s returned %d\n" $count "$t" $status
+    fi
+    count=$(expr $count + 1)
+done
+printf "1..%d\n" $count


### PR DESCRIPTION
Tests will now always be built (unless configured with `--disable-tests`) and installed by default in `${prefix}/libexec/libunwind`. A new script, test-runner, is supplied to run all of the tests and produce TAP output.

- configure.ac:
  - make `tests/check-namespace.sh` executable
  - add license boilerplate
- tests/Makefile.am:
  - remove `run-coredump-unwind`
  - add `test-runner`
  - add license boilerplate
  - remove XFAIL from riscv64 target (seems #519 test fails only when statically linking)
- tests/README.md:
  - new file
- tests/check-namespace.sh.in:
  - make **`LIBUNWIND`** and **`LIBUNWIND_GENERIC`** externally settable
  - add license boilerplate
- tests/run-check-namespace:
  - remove file
- test/run-ptrace-mapper:
  - look for `test-ptrace` relative to script
  - add license boilerplate
- test/run-ptrace-misc:
  - look for `test-ptrace` relative to script
  - add license boilerplate
- test/test-runner.in:
  - new file
- .github/workflows/CI-unix.yml:
  - change `run-check-namespace` to `check-namespace.sh`
  - use **libtool** to run in-tree binaries instead of forcing static linking


(cherry picked from commit 663d4dcd6c891dd81d79c66a15527d91b45cf385)