### PR TITLE
tests/ppc64-test-plt: add parameter names

### DIFF
--- a/tests/ppc64-test-plt.c
+++ b/tests/ppc64-test-plt.c
@@ -7,8 +7,8 @@
 #include "libunwind_i.h"
 
 #undef unw_get_accessors_int
-unw_accessors_t *unw_get_accessors_int (unw_addr_space_t) { return NULL; }
-int dwarf_step (struct dwarf_cursor*) { return 0; }
+unw_accessors_t *unw_get_accessors_int (unw_addr_space_t unused) { return NULL; }
+int dwarf_step (struct dwarf_cursor* unused) { return 0; }
 #include "ppc64/Gstep.c"
 
 enum


### PR DESCRIPTION
ISO C does not support omitting parameter names in function definitions before C2X, so better add them.

fixes:
ppc64-test-plt.c: In function ‘unw_get_accessors_int’: ppc64-test-plt.c:10:41: error: parameter name omitted
   10 | unw_accessors_t *unw_get_accessors_int (unw_addr_space_t) { return NULL; }
      |                                         ^~~~~~~~~~~~~~~~
ppc64-test-plt.c: In function ‘_Uppc64_dwarf_step’:
ppc64-test-plt.c:11:17: error: parameter name omitted
   11 | int dwarf_step (struct dwarf_cursor*) { return 0; }
      |                 ^~~~~~~~~~~~~~~~~~~~
make[1]: *** [Makefile:1662: ppc64-test-plt.o] Error 1

seen on ppc64 with gcc 10.3.1