### PR TITLE
Add VDSO support to libunwind , port the patch from https://sourcewar…

### DIFF
--- a/doc/unw_get_proc_name_by_ip.man
+++ b/doc/unw_get_proc_name_by_ip.man
@@ -1,7 +1,7 @@
 .\" *********************************** start of \input{common.tex}
 .\" *********************************** end of \input{common.tex}
 '\" t
-.\" Manual page created with latex2man on Tue Aug 29 12:09:48 2023
+.\" Manual page created with latex2man on Fri Feb 23 11:27:29 2024
 .\" NOTE: This file is generated, DO NOT EDIT.
 .de Vb
 .ft CW
@@ -12,7 +12,7 @@
 
 .fi
 ..
-.TH "UNW\\_GET\\_PROC\\_NAME\\_BY\\_IP" "3libunwind" "29 August 2023" "Programming Library " "Programming Library "
+.TH "UNW\\_GET\\_PROC\\_NAME\\_BY\\_IP" "3libunwind" "23 February 2024" "Programming Library " "Programming Library "
 .SH NAME
 unw_get_proc_name_by_ip
 \-\- get procedure name 

--- a/include/tdep-aarch64/libunwind_i.h
+++ b/include/tdep-aarch64/libunwind_i.h
@@ -320,9 +320,10 @@ extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
                                      unw_dyn_info_t *di, unw_proc_info_t *pi,
                                      int need_unwind_info, void *arg);
 extern void *tdep_uc_addr (unw_context_t *uc, int reg);
-extern int tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+extern int tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                                unsigned long *segbase, unsigned long *mapoff,
-                               char *path, size_t pathlen);
+                               char *path, size_t pathlen,
+-                  void *arg);
 extern void tdep_get_exe_image_path (char *path);
 extern int tdep_access_reg (struct cursor *c, unw_regnum_t reg,
                             unw_word_t *valp, int write);

--- a/include/tdep-arm/libunwind_i.h
+++ b/include/tdep-arm/libunwind_i.h
@@ -310,9 +310,10 @@ extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
                                      unw_dyn_info_t *di, unw_proc_info_t *pi,
                                      int need_unwind_info, void *arg);
 extern void *tdep_uc_addr (unw_tdep_context_t *uc, int reg);
-extern int tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+extern int tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                                unsigned long *segbase, unsigned long *mapoff,
-                               char *path, size_t pathlen);
+                               char *path, size_t pathlen,
+                  void *arg);
 extern void tdep_get_exe_image_path (char *path);
 extern int tdep_access_reg (struct cursor *c, unw_regnum_t reg,
                             unw_word_t *valp, int write);

--- a/include/tdep-hppa/libunwind_i.h
+++ b/include/tdep-hppa/libunwind_i.h
@@ -267,9 +267,10 @@ extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
                                      unw_dyn_info_t *di, unw_proc_info_t *pi,
                                      int need_unwind_info, void *arg);
 extern void *tdep_uc_addr (ucontext_t *uc, int reg);
-extern int tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+extern int tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                                unsigned long *segbase, unsigned long *mapoff,
-                               char *path, size_t pathlen);
+                               char *path, size_t pathlen,
+                  void *arg);
 extern void tdep_get_exe_image_path (char *path);
 extern int tdep_access_reg (struct cursor *c, unw_regnum_t reg,
                             unw_word_t *valp, int write);

--- a/include/tdep-ia64/libunwind_i.h
+++ b/include/tdep-ia64/libunwind_i.h
@@ -261,9 +261,10 @@ extern void tdep_put_unwind_info (unw_addr_space_t as,
                                   unw_proc_info_t *pi, void *arg);
 extern void *tdep_uc_addr (ucontext_t *uc, unw_regnum_t regnum,
                            uint8_t *nat_bitnr);
-extern int tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+extern int tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                                unsigned long *segbase, unsigned long *mapoff,
-                               char *path, size_t pathlen);
+                               char *path, size_t pathlen,
+                  void *arg);
 extern void tdep_get_exe_image_path (char *path);
 extern int tdep_access_reg (struct cursor *c, unw_regnum_t reg,
                             unw_word_t *valp, int write);

--- a/include/tdep-loongarch64/libunwind_i.h
+++ b/include/tdep-loongarch64/libunwind_i.h
@@ -239,9 +239,10 @@ extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
                                      unw_dyn_info_t *di, unw_proc_info_t *pi,
                                      int need_unwind_info, void *arg);
 extern void *tdep_uc_addr (ucontext_t *uc, int reg);
-extern int tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+extern int tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                                unsigned long *segbase, unsigned long *mapoff,
-                               char *path, size_t pathlen);
+                               char *path, size_t pathlen,
+                  void *arg);
 extern void tdep_get_exe_image_path (char *path);
 extern int tdep_access_reg (struct cursor *c, unw_regnum_t reg,
                             unw_word_t *valp, int write);

--- a/include/tdep-mips/libunwind_i.h
+++ b/include/tdep-mips/libunwind_i.h
@@ -327,9 +327,10 @@ extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
                                      unw_dyn_info_t *di, unw_proc_info_t *pi,
                                      int need_unwind_info, void *arg);
 extern void *tdep_uc_addr (ucontext_t *uc, int reg);
-extern int tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+extern int tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                                unsigned long *segbase, unsigned long *mapoff,
-                               char *path, size_t pathlen);
+                               char *path, size_t pathlen,
+                  void *arg);
 extern void tdep_get_exe_image_path (char *path);
 extern int tdep_access_reg (struct cursor *c, unw_regnum_t reg,
                             unw_word_t *valp, int write);

--- a/include/tdep-ppc32/libunwind_i.h
+++ b/include/tdep-ppc32/libunwind_i.h
@@ -300,9 +300,10 @@ extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
                                      unw_proc_info_t * pi,
                                      int need_unwind_info, void *arg);
 extern void *tdep_uc_addr (ucontext_t * uc, int reg);
-extern int tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+extern int tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                                unsigned long *segbase, unsigned long *mapoff,
-                               char *path, size_t pathlen);
+                               char *path, size_t pathlen,
+                  void *arg);
 extern void tdep_get_exe_image_path (char *path);
 extern int tdep_access_reg (struct cursor *c, unw_regnum_t reg,
                             unw_word_t * valp, int write);

--- a/include/tdep-ppc64/libunwind_i.h
+++ b/include/tdep-ppc64/libunwind_i.h
@@ -355,9 +355,10 @@ extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
                                      unw_proc_info_t * pi,
                                      int need_unwind_info, void *arg);
 extern void *tdep_uc_addr (ucontext_t * uc, int reg);
-extern int tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+extern int tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                                unsigned long *segbase, unsigned long *mapoff,
-                               char *path, size_t pathlen);
+                               char *path, size_t pathlen,
+                  void *arg);
 extern void tdep_get_exe_image_path (char *path);
 extern int tdep_access_reg (struct cursor *c, unw_regnum_t reg,
                             unw_word_t * valp, int write);

--- a/include/tdep-riscv/libunwind_i.h
+++ b/include/tdep-riscv/libunwind_i.h
@@ -290,9 +290,10 @@ extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
                                      unw_dyn_info_t *di, unw_proc_info_t *pi,
                                      int need_unwind_info, void *arg);
 extern void *tdep_uc_addr (ucontext_t *uc, int reg);
-extern int tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+extern int tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                                unsigned long *segbase, unsigned long *mapoff,
-                               char *path, size_t pathlen);
+                               char *path, size_t pathlen,
+                               void *arg);
 extern void tdep_get_exe_image_path (char *path);
 extern int tdep_access_reg (struct cursor *c, unw_regnum_t reg,
                             unw_word_t *valp, int write);

--- a/include/tdep-s390x/libunwind_i.h
+++ b/include/tdep-s390x/libunwind_i.h
@@ -248,9 +248,10 @@ extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
                                      unw_dyn_info_t *di, unw_proc_info_t *pi,
                                      int need_unwind_info, void *arg);
 extern void *tdep_uc_addr (unw_tdep_context_t *uc, int reg);
-extern int tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+extern int tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                                unsigned long *segbase, unsigned long *mapoff,
-                               char *path, size_t pathlen);
+                               char *path, size_t pathlen),
+                  void *arg;
 extern void tdep_get_exe_image_path (char *path);
 extern int tdep_access_reg (struct cursor *c, unw_regnum_t reg,
                             unw_word_t *valp, int write);

--- a/include/tdep-sh/libunwind_i.h
+++ b/include/tdep-sh/libunwind_i.h
@@ -268,9 +268,10 @@ extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
                                      unw_dyn_info_t *di, unw_proc_info_t *pi,
                                      int need_unwind_info, void *arg);
 extern void *tdep_uc_addr (unw_tdep_context_t *uc, int reg);
-extern int tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+extern int tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                                unsigned long *segbase, unsigned long *mapoff,
-                               char *path, size_t pathlen);
+                               char *path, size_t pathlen,
+                  void *arg);
 extern void tdep_get_exe_image_path (char *path);
 extern int tdep_access_reg (struct cursor *c, unw_regnum_t reg,
                             unw_word_t *valp, int write);

--- a/include/tdep-x86/libunwind_i.h
+++ b/include/tdep-x86/libunwind_i.h
@@ -262,9 +262,10 @@ extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
                                      unw_dyn_info_t *di, unw_proc_info_t *pi,
                                      int need_unwind_info, void *arg);
 extern void *tdep_uc_addr (ucontext_t *uc, int reg);
-extern int tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+extern int tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                                unsigned long *segbase, unsigned long *mapoff,
-                               char *path, size_t pathlen);
+                               char *path, size_t pathlen,
+                  void *arg);
 extern void tdep_get_exe_image_path (char *path);
 extern int tdep_access_reg (struct cursor *c, unw_regnum_t reg,
                             unw_word_t *valp, int write);

--- a/include/tdep-x86_64/libunwind_i.h
+++ b/include/tdep-x86_64/libunwind_i.h
@@ -275,9 +275,10 @@ extern int tdep_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
                                      unw_dyn_info_t *di, unw_proc_info_t *pi,
                                      int need_unwind_info, void *arg);
 extern void *x86_64_r_uc_addr (ucontext_t *uc, int reg);
-extern int tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+extern int tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                                unsigned long *segbase, unsigned long *mapoff,
-                               char *path, size_t pathlen);
+                               char *path, size_t pathlen,
+                  void *arg);
 extern void tdep_get_exe_image_path (char *path);
 extern int tdep_access_reg (struct cursor *c, unw_regnum_t reg,
                             unw_word_t *valp, int write);

--- a/src/aarch64/Ginit.c
+++ b/src/aarch64/Ginit.c
@@ -217,7 +217,7 @@ get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
                       void *arg)
 {
-  return _Uelf64_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
+  return _Uelf64_get_proc_name (as, getpid (), ip, buf, buf_len, offp,arg);
 }
 
 static unw_word_t empty_ptrauth_mask(unw_addr_space_t addr_space_unused, void *as_arg_unused)
@@ -228,7 +228,7 @@ static unw_word_t empty_ptrauth_mask(unw_addr_space_t addr_space_unused, void *a
 static int
 get_static_elf_filename (unw_addr_space_t as, unw_word_t ip, char *buf, size_t buf_len, unw_word_t *offp, void *arg)
 {
-  return _Uelf64_get_elf_filename(as, getpid(), ip, buf, buf_len, offp);
+  return _Uelf64_get_elf_filename(as, getpid(), ip, buf, buf_len, offp,arg);
 }
 
 HIDDEN void

--- a/src/arm/Ginit.c
+++ b/src/arm/Ginit.c
@@ -167,7 +167,7 @@ get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
                       void *arg)
 {
-  return _Uelf32_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
+  return _Uelf32_get_proc_name (as, getpid (), ip, buf, buf_len, offp,arg);
 }
 
 static int

--- a/src/elfxx.c
+++ b/src/elfxx.c
@@ -627,14 +627,14 @@ elf_w (get_proc_name_in_image) (unw_addr_space_t as, struct elf_image *ei,
 
 HIDDEN int
 elf_w (get_proc_name) (unw_addr_space_t as, pid_t pid, unw_word_t ip,
-                       char *buf, size_t buf_len, unw_word_t *offp)
+                       char *buf, size_t buf_len, unw_word_t *offp, void *arg)
 {
   unsigned long segbase, mapoff;
   struct elf_image ei;
   int ret;
   char file[PATH_MAX];
 
-  ret = tdep_get_elf_image (&ei, pid, ip, &segbase, &mapoff, file, PATH_MAX);
+  ret = tdep_get_elf_image (as, &ei, pid, ip, &segbase, &mapoff, file, PATH_MAX,arg);
   if (ret < 0)
     return ret;
 
@@ -687,14 +687,14 @@ elf_w (get_proc_ip_range_in_image) (unw_addr_space_t as, struct elf_image *ei,
 
 HIDDEN int
 elf_w (get_proc_ip_range) (unw_addr_space_t as, pid_t pid, unw_word_t ip,
-                           unw_word_t *start, unw_word_t *end)
+                           unw_word_t *start, unw_word_t *end, void *arg)
 {
   unsigned long segbase, mapoff;
   struct elf_image ei;
   int ret;
   char file[PATH_MAX];
 
-  ret = tdep_get_elf_image (&ei, pid, ip, &segbase, &mapoff, file, PATH_MAX);
+  ret = tdep_get_elf_image (as, &ei, pid, ip, &segbase, &mapoff, file, PATH_MAX, arg);
   if (ret < 0)
     return ret;
 
@@ -712,13 +712,13 @@ elf_w (get_proc_ip_range) (unw_addr_space_t as, pid_t pid, unw_word_t ip,
 
 HIDDEN int
 elf_w (get_elf_filename) (unw_addr_space_t as, pid_t pid, unw_word_t ip,
-                          char *buf, size_t buf_len, unw_word_t *offp)
+                          char *buf, size_t buf_len, unw_word_t *offp, void *arg)
 {
   unsigned long segbase, mapoff;
   int ret = UNW_ESUCCESS;
 
   // use NULL to no map elf image
-  ret = tdep_get_elf_image (NULL, pid, ip, &segbase, &mapoff, buf, buf_len);
+  ret = tdep_get_elf_image (as, NULL, pid, ip, &segbase, &mapoff, buf, buf_len, arg);
   if (ret < 0)
     return ret;
 

--- a/src/elfxx.h
+++ b/src/elfxx.h
@@ -45,7 +45,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 extern int elf_w (get_proc_name) (unw_addr_space_t as,
                                   pid_t pid, unw_word_t ip,
                                   char *buf, size_t len,
-                                  unw_word_t *offp);
+                                  unw_word_t *offp, void *arg);
 
 extern int elf_w (get_proc_name_in_image) (unw_addr_space_t as,
                                            struct elf_image *ei,
@@ -55,14 +55,14 @@ extern int elf_w (get_proc_name_in_image) (unw_addr_space_t as,
 
 extern int elf_w (get_proc_ip_range) (unw_addr_space_t as,
                                       pid_t pid, unw_word_t ip,
-                                      unw_word_t *start, unw_word_t *end);
+                                      unw_word_t *start, unw_word_t *end, void *arg);
 
 extern int elf_w (get_proc_ip_range_in_image) (unw_addr_space_t as, struct elf_image *ei,
                                                unsigned long segbase, unw_word_t ip,
                                                unw_word_t *start, unw_word_t *end);
 
 extern int elf_w (get_elf_filename) (unw_addr_space_t as, pid_t pid, unw_word_t ip,
-                                     char *buf, size_t buf_len, unw_word_t *offp);
+                                     char *buf, size_t buf_len, unw_word_t *offp, void *arg);
 
 extern Elf_W (Shdr)* elf_w (find_section) (const struct elf_image *ei, const char* secname);
 extern int elf_w (load_debuginfo) (const char* file, struct elf_image *ei, int is_local);

--- a/src/hppa/Ginit.c
+++ b/src/hppa/Ginit.c
@@ -171,7 +171,7 @@ get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
                       void *arg)
 {
-  return _Uelf32_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
+  return _Uelf32_get_proc_name (as, getpid (), ip, buf, buf_len, offp, arg);
 }
 
 static int

--- a/src/ia64/Ginit.c
+++ b/src/ia64/Ginit.c
@@ -349,7 +349,7 @@ get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
                       void *arg)
 {
-  return _Uelf64_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
+  return _Uelf64_get_proc_name (as, getpid (), ip, buf, buf_len, offp, arg);
 }
 
 static int

--- a/src/nto/unw_nto_find_proc_info.c
+++ b/src/nto/unw_nto_find_proc_info.c
@@ -75,7 +75,7 @@ int unw_nto_find_proc_info (unw_addr_space_t as,
                             &segbase,
                             &mapoff,
                             path,
-                            sizeof (path));
+                            sizeof (path),arg);
 
   if (ret >= 0)
     {

--- a/src/os-freebsd.c
+++ b/src/os-freebsd.c
@@ -89,8 +89,8 @@ get_pid_by_tid(int tid)
 }
 
 int
-tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
-                    unsigned long *segbase, unsigned long *mapoff, char *path, size_t pathlen)
+tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
+                    unsigned long *segbase, unsigned long *mapoff, char *path, size_t pathlen, void *arg)
 {
   int mib[4], error, ret;
   size_t len, len1;

--- a/src/os-hpux.c
+++ b/src/os-hpux.c
@@ -32,9 +32,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "elf64.h"
 
 HIDDEN int
-tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                     unsigned long *segbase, unsigned long *mapoff,
-                    char *path, size_t pathlen)
+                    char *path, size_t pathlen, void *arg)
 {
   struct load_module_desc lmd;
   const char *path2;

--- a/src/os-linux.c
+++ b/src/os-linux.c
@@ -33,10 +33,21 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "libunwind_i.h"
 #include "os-linux.h"
 
+#ifndef MAX_VDSO_SIZE
+/*Dont know what is the Max Size in my system it was 8192 or twice the page size*/
+# define MAX_VDSO_SIZE ((size_t) 2 * sysconf (_SC_PAGESIZE))
+#endif
+
+#ifndef MAP_32BIT
+# define MAP_32BIT 0
+#endif
+
+
 int
-tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                     unsigned long *segbase, unsigned long *mapoff,
-                    char *path, size_t pathlen)
+                    char *path, size_t pathlen,
+                    void *arg)
 {
   struct map_iterator mi;
   int found = 0, rc = UNW_ESUCCESS;
@@ -44,6 +55,9 @@ tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
   char root[sizeof ("/proc/0123456789/root")], *cp;
   char *full_path;
   struct stat st;
+  unw_accessors_t *a;
+  unw_word_t magic;
+
 
   if (maps_init (&mi, pid) < 0)
     return -1;
@@ -103,6 +117,93 @@ tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
     strcpy(full_path, mi.path);
 
   rc = elf_map_image (ei, full_path);
+
+  /*Follwing code is adapted from 
+    https://sourceware.org/pipermail/frysk-cvs/2008q1/007245.html,
+    For VDSO there is no file in the file system, so read the ELF , 
+    and create mmaped file for the content of the VDSO 
+  */
+  if (rc != -1)
+  {
+    maps_close (&mi);
+    goto err_exit;
+  }
+
+  /* If the above failed, try to bring in page-sized segments directly
+     from process memory.  This enables us to locate VDSO unwind
+     tables.  */
+  ei->size = hi - *segbase;
+  if (ei->size > MAX_VDSO_SIZE) 
+  {
+    maps_close (&mi);
+    goto err_exit;
+  }
+
+  a = unw_get_accessors (as);
+  if (! a->access_mem) 
+  {
+    maps_close (&mi);
+    goto err_exit;
+  }
+
+  /* Try to decide whether it's an ELF image before bringing it all
+     in.  */
+  if (ei->size <= EI_CLASS || ei->size <= sizeof (magic))
+  {
+    maps_close (&mi);
+    goto err_exit;
+  }
+
+  if (sizeof (magic) >= SELFMAG)
+    {
+      int ret = (*a->access_mem) (as, *segbase, &magic, 0, arg);
+      if (ret < 0)
+      {
+        rc = ret;
+        maps_close (&mi);
+        goto err_exit;
+      }
+
+      if (memcmp (&magic, ELFMAG, SELFMAG) != 0)
+      {
+        maps_close (&mi);
+        goto err_exit;
+      }
+    }
+
+  ei->image = mmap (0, ei->size, PROT_READ | PROT_WRITE,
+           MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0);
+  if (ei->image == MAP_FAILED)
+    {
+      maps_close (&mi);
+      goto err_exit;
+    }
+
+  if (sizeof (magic) >= SELFMAG)
+    {
+      *(unw_word_t *)ei->image = magic;
+      hi = sizeof (magic);
+    }
+  else
+    hi = 0;
+
+  for (; hi < ei->size; hi += sizeof (unw_word_t))
+    {
+      rc = (*a->access_mem) (as, *segbase + hi, ei->image + hi,
+               0, arg);
+      if (rc < 0)
+   {
+     munmap (ei->image, ei->size);
+     maps_close (&mi);
+     goto err_exit;
+   }
+    }
+
+  if (*segbase == *mapoff
+      && (*path == 0 || strcmp (path, "[vdso]") == 0))
+    *mapoff = 0;
+
+err_exit:
 
   if (!path)
     free (full_path);

--- a/src/os-qnx.c
+++ b/src/os-qnx.c
@@ -291,9 +291,9 @@ _get_remote_elf_image(struct elf_image *ei,
 
 
 int
-tdep_get_elf_image(struct elf_image *ei, pid_t pid, unw_word_t ip,
+tdep_get_elf_image(unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                    unsigned long *segbase, unsigned long *mapoff,
-                   char *path, size_t pathlen)
+                   char *path, size_t pathlen, void *arg)
 {
   int ret = -UNW_ENOINFO;
   if (pid != getpid())

--- a/src/os-solaris.c
+++ b/src/os-solaris.c
@@ -30,9 +30,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "os-linux.h" // using linux header for map_iterator implementation
 
 int
-tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
+tdep_get_elf_image (unw_addr_space_t as, struct elf_image *ei, pid_t pid, unw_word_t ip,
                     unsigned long *segbase, unsigned long *mapoff,
-                    char *path, size_t pathlen)
+                    char *path, size_t pathlen, void *arg)
 {
   struct map_iterator mi;
   int found = 0, rc = UNW_ESUCCESS;

--- a/src/ppc32/Ginit.c
+++ b/src/ppc32/Ginit.c
@@ -215,7 +215,7 @@ get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
                       void *arg)
 {
-  return _Uelf32_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
+  return _Uelf32_get_proc_name (as, getpid (), ip, buf, buf_len, offp, arg);
 }
 
 static int

--- a/src/ppc64/Ginit.c
+++ b/src/ppc64/Ginit.c
@@ -226,7 +226,7 @@ get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
                       void *arg)
 {
-  return _Uelf64_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
+  return _Uelf64_get_proc_name (as, getpid (), ip, buf, buf_len, offp, arg);
 }
 
 static int

--- a/src/ptrace/_UPT_find_proc_info.c
+++ b/src/ptrace/_UPT_find_proc_info.c
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "_UPT_internal.h"
 
 static int
-get_unwind_info (struct elf_dyn_info *edi, pid_t pid, unw_addr_space_t as, unw_word_t ip)
+get_unwind_info ( struct elf_dyn_info *edi, pid_t pid, unw_addr_space_t as, unw_word_t ip, void *arg)
 {
   unsigned long segbase, mapoff;
   char path[PATH_MAX];
@@ -58,8 +58,8 @@ get_unwind_info (struct elf_dyn_info *edi, pid_t pid, unw_addr_space_t as, unw_w
 
   invalidate_edi(edi);
 
-  if (tdep_get_elf_image (&edi->ei, pid, ip, &segbase, &mapoff, path,
-                          sizeof(path)) < 0)
+  if (tdep_get_elf_image (as, &edi->ei, pid, ip, &segbase, &mapoff, path,
+                          sizeof(path), arg) < 0)
     return -UNW_ENOINFO;
 
   /* Here, SEGBASE is the starting-address of the (mmap'ped) segment
@@ -96,7 +96,7 @@ _UPT_find_proc_info (unw_addr_space_t as, unw_word_t ip, unw_proc_info_t *pi,
   struct UPT_info *ui = arg;
   int ret = -UNW_ENOINFO;
 
-  if (get_unwind_info (&ui->edi, ui->pid, as, ip) < 0)
+  if (get_unwind_info (&ui->edi, ui->pid, as, ip,arg) < 0)
     return -UNW_ENOINFO;
 
 #if UNW_TARGET_IA64

--- a/src/ptrace/_UPT_get_elf_filename.c
+++ b/src/ptrace/_UPT_get_elf_filename.c
@@ -29,9 +29,9 @@ _UPT_get_elf_filename (unw_addr_space_t as, unw_word_t ip,
   struct UPT_info *ui = arg;
 
 #if UNW_ELF_CLASS == UNW_ELFCLASS64
-  return _Uelf64_get_elf_filename (as, ui->pid, ip, buf, buf_len, offp);
+  return _Uelf64_get_elf_filename (as, ui->pid, ip, buf, buf_len, offp,arg);
 #elif UNW_ELF_CLASS == UNW_ELFCLASS32
-  return _Uelf32_get_elf_filename (as, ui->pid, ip, buf, buf_len, offp);
+  return _Uelf32_get_elf_filename (as, ui->pid, ip, buf, buf_len, offp,arg);
 #else
   return -UNW_ENOINFO;
 #endif

--- a/src/ptrace/_UPT_get_proc_name.c
+++ b/src/ptrace/_UPT_get_proc_name.c
@@ -33,9 +33,9 @@ _UPT_get_proc_name (unw_addr_space_t as, unw_word_t ip,
   struct UPT_info *ui = arg;
 
 #if UNW_ELF_CLASS == UNW_ELFCLASS64
-  return _Uelf64_get_proc_name (as, ui->pid, ip, buf, buf_len, offp);
+  return _Uelf64_get_proc_name (as, ui->pid, ip, buf, buf_len, offp,arg);
 #elif UNW_ELF_CLASS == UNW_ELFCLASS32
-  return _Uelf32_get_proc_name (as, ui->pid, ip, buf, buf_len, offp);
+  return _Uelf32_get_proc_name (as, ui->pid, ip, buf, buf_len, offp,arg);
 #else
   return -UNW_ENOINFO;
 #endif

--- a/src/s390x/Ginit.c
+++ b/src/s390x/Ginit.c
@@ -186,7 +186,7 @@ get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
                       void *arg)
 {
-  return _Uelf64_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
+  return _Uelf64_get_proc_name (as, getpid (), ip, buf, buf_len, offp,arg);
 }
 
 static int

--- a/src/sh/Ginit.c
+++ b/src/sh/Ginit.c
@@ -163,7 +163,7 @@ get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
                       void *arg)
 {
-  return _Uelf32_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
+  return _Uelf32_get_proc_name (as, getpid (), ip, buf, buf_len, offp,arg);
 }
 
 static int

--- a/src/x86/Ginit.c
+++ b/src/x86/Ginit.c
@@ -167,7 +167,7 @@ get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
                       void *arg)
 {
-  return _Uelf32_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
+  return _Uelf32_get_proc_name (as, getpid (), ip, buf, buf_len, offp, arg);
 }
 
 static int
@@ -175,7 +175,7 @@ get_static_elf_filename (unw_addr_space_t as, unw_word_t ip,
                          char *buf, size_t buf_len, unw_word_t *offp,
                          void *arg)
 {
-  return _Uelf32_get_elf_filename (as, getpid (), ip, buf, buf_len, offp);
+  return _Uelf32_get_elf_filename (as, getpid (), ip, buf, buf_len, offp, arg);
 }
 
 HIDDEN void

--- a/src/x86_64/Ginit.c
+++ b/src/x86_64/Ginit.c
@@ -165,7 +165,7 @@ get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
                       void *arg UNUSED)
 {
-  return _Uelf64_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
+  return _Uelf64_get_proc_name (as, getpid (), ip, buf, buf_len, offp, arg);
 }
 
 static int
@@ -173,7 +173,7 @@ get_static_elf_filename (unw_addr_space_t as, unw_word_t ip,
                          char *buf, size_t buf_len, unw_word_t *offp,
                          void *arg UNUSED)
 {
-  return _Uelf64_get_elf_filename (as, getpid (), ip, buf, buf_len, offp);
+  return _Uelf64_get_elf_filename (as, getpid (), ip, buf, buf_len, offp, arg);
 }
 
 HIDDEN void


### PR DESCRIPTION
…e.org/pipermail/frysk-cvs/2008q1/007245.html

This commit attempts to add support of VDSO in libunwind . VDSO is mapped in the process address space by the kernel. It is not a physical file ,hence libunwind fails to open it and mmap it.
Instead this patch copies the VDSO in the calling process address space and then mmaps it for finding symbols or stack walking.
NOTE: it is ported from original work as documented in https://sourceware.org/pipermail/frysk-cvs/2008q1/007245.html 

This is further to the discussion I had in https://github.com/libunwind/libunwind/discussions/696. I am submitting a PR for running CI/CD.
I have verified it in 64bit x86_64 kernel and x86 32 bit apps.