### PR TITLE
Address warnings from MSVC

### DIFF
--- a/include/dwarf_i.h
+++ b/include/dwarf_i.h
@@ -280,7 +280,7 @@ dwarf_readw (unw_addr_space_t as, unw_accessors_t *a, unw_word_t *addr,
       ret = dwarf_readu64 (as, a, addr, &u64, arg);
       if (ret < 0)
         return ret;
-      *val = u64;
+      *val = (unw_word_t) u64;
       return ret;
 
     default:
@@ -398,7 +398,7 @@ dwarf_read_encoded_pointer_inlined (unw_addr_space_t as, unw_accessors_t *a,
     case DW_EH_PE_udata8:
       if ((ret = dwarf_readu64 (as, a, addr, &uval64, arg)) < 0)
         return ret;
-      val = uval64;
+      val = (unw_word_t) uval64;
       break;
 
     case DW_EH_PE_sleb128:
@@ -421,7 +421,7 @@ dwarf_read_encoded_pointer_inlined (unw_addr_space_t as, unw_accessors_t *a,
     case DW_EH_PE_sdata8:
       if ((ret = dwarf_reads64 (as, a, addr, &sval64, arg)) < 0)
         return ret;
-      val = sval64;
+      val = (unw_word_t) sval64;
       break;
 
     default:

--- a/include/libunwind_i.h
+++ b/include/libunwind_i.h
@@ -333,7 +333,7 @@ static inline void _unw_debug(int level, char const * const fname, char const * 
 
       if (level > 16) level = 16;
       int bcount = snprintf (buf, buf_size, "%*c>%s: ", level, ' ', fname);
-      int res = write(STDERR_FILENO, buf, bcount);
+      ssize_t res = write(STDERR_FILENO, buf, bcount);
 
       va_list ap;
       va_start(ap, fmt);
@@ -350,7 +350,7 @@ static inline void _unw_debug(int level, char const * const fname, char const * 
 # define Dprintf( /* format */ ...)
 #endif /* defined(UNW_DEBUG) */
 
-static ALWAYS_INLINE int
+static ALWAYS_INLINE ssize_t
 print_error (const char *string)
 {
   return write (2, string, strlen (string));
@@ -418,6 +418,9 @@ static inline void invalidate_edi (struct elf_dyn_info *edi)
 #ifndef PT_ARM_EXIDX
 # define PT_ARM_EXIDX           0x70000001      /* ARM unwind segment */
 #endif /* !PT_ARM_EXIDX */
+
+#define DWARF_GET_MEM_LOC(l)    DWARF_GET_LOC(l)
+#define DWARF_GET_REG_LOC(l)    ((unw_regnum_t) DWARF_GET_LOC(l))
 
 #include "tdep/libunwind_i.h"
 

--- a/include/tdep-aarch64/libunwind_i.h
+++ b/include/tdep-aarch64/libunwind_i.h
@@ -197,10 +197,10 @@ dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        val, 0, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
   if ((ret = (*c->as->acc.access_mem) (c->as, addr + 0, (unw_word_t *) valp,
                                        0, c->as_arg)) < 0)
     return ret;
@@ -220,10 +220,10 @@ dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        &val, 1, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
   if ((ret = (*c->as->acc.access_mem) (c->as, addr + 0, (unw_word_t *) valp,
                                        1, c->as_arg)) < 0)
     return ret;
@@ -245,10 +245,10 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), val,
                                      0, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), val,
                                      0, c->as_arg);
 }
 
@@ -265,10 +265,10 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), &val,
                                      1, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), &val,
                                      1, c->as_arg);
 }
 

--- a/include/tdep-arm/ex_tables.h
+++ b/include/tdep-arm/ex_tables.h
@@ -49,7 +49,7 @@ struct arm_exbuf_data
 #define arm_exidx_apply_cmd     UNW_OBJ(arm_exidx_apply_cmd)
 
 int arm_exidx_extract (struct dwarf_cursor *c, uint8_t *buf);
-int arm_exidx_decode (const uint8_t *buf, uint8_t len, struct dwarf_cursor *c);
+int arm_exidx_decode (const uint8_t *buf, int len, struct dwarf_cursor *c);
 int arm_exidx_apply_cmd (struct arm_exbuf_data *edata, struct dwarf_cursor *c);
 
 #endif // ARM_EX_TABLES_H

--- a/include/tdep-arm/libunwind_i.h
+++ b/include/tdep-arm/libunwind_i.h
@@ -178,7 +178,7 @@ dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        val, 0, c->as_arg);
 
   addr = DWARF_GET_LOC (loc);
@@ -201,7 +201,7 @@ dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        &val, 1, c->as_arg);
 
   addr = DWARF_GET_LOC (loc);
@@ -226,10 +226,10 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), val,
                                      0, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), val,
                                      0, c->as_arg);
 }
 
@@ -246,10 +246,10 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), &val,
                                      1, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), &val,
                                      1, c->as_arg);
 }
 

--- a/include/tdep-hppa/libunwind_i.h
+++ b/include/tdep-hppa/libunwind_i.h
@@ -146,10 +146,10 @@ dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        val, 0, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
   if ((ret = (*c->as->acc.access_mem) (c->as, addr + 0, (unw_word_t *) valp,
                                        0, c->as_arg)) < 0)
     return ret;
@@ -169,10 +169,10 @@ dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        &val, 1, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
   if ((ret = (*c->as->acc.access_mem) (c->as, addr + 0, (unw_word_t *) valp,
                                        1, c->as_arg)) < 0)
     return ret;
@@ -194,10 +194,10 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), val,
                                      0, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), val,
                                      0, c->as_arg);
 }
 
@@ -214,10 +214,10 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), &val,
                                      1, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), &val,
                                      1, c->as_arg);
 }
 

--- a/include/tdep-loongarch64/libunwind_i.h
+++ b/include/tdep-loongarch64/libunwind_i.h
@@ -167,10 +167,10 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), val,
                                      0, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), val,
                                      0, c->as_arg);
 }
 

--- a/include/tdep-mips/libunwind_i.h
+++ b/include/tdep-mips/libunwind_i.h
@@ -195,10 +195,10 @@ dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        val, 0, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
   if ((ret = (*c->as->acc.access_mem) (c->as, addr + 0, (unw_word_t *) valp,
                                        0, c->as_arg)) < 0)
     return ret;
@@ -218,10 +218,10 @@ dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        &val, 1, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
   if ((ret = (*c->as->acc.access_mem) (c->as, addr + 0, (unw_word_t *) valp,
                                        1, c->as_arg)) < 0)
     return ret;
@@ -243,20 +243,20 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), val,
                                      0, c->as_arg);
   else if (c->as->abi == UNW_MIPS_ABI_O32)
-    return read_s32 (c, DWARF_GET_LOC (loc), val);
+    return read_s32 (c, DWARF_GET_MEM_LOC (loc), val);
   else if (c->as->abi == UNW_MIPS_ABI_N32) {
     if (tdep_big_endian(c->as))
-      return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc) + 4, val,
+      return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc) + 4, val,
                                        0, c->as_arg);
     else
-      return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+      return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), val,
                                        0, c->as_arg);
   }
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), val,
                                      0, c->as_arg);
 }
 
@@ -273,12 +273,12 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), &val,
                                      1, c->as_arg);
   else if (c->as->abi == UNW_MIPS_ABI_O32)
-    return write_s32 (c, DWARF_GET_LOC (loc), &val);
+    return write_s32 (c, DWARF_GET_MEM_LOC (loc), &val);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), &val,
                                      1, c->as_arg);
 }
 

--- a/include/tdep-ppc32/libunwind_i.h
+++ b/include/tdep-ppc32/libunwind_i.h
@@ -130,10 +130,10 @@ dwarf_getvr (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t * val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                       val, 0, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
 
   if ((ret = (*c->as->acc.access_mem) (c->as, addr + 0, valp,
                                        0, c->as_arg)) < 0)
@@ -156,10 +156,10 @@ dwarf_putvr (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                       &val, 1, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
   if ((ret = (*c->as->acc.access_mem) (c->as, addr + 0, valp,
                                        1, c->as_arg)) < 0)
     return ret;
@@ -180,10 +180,10 @@ dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t * val)
   assert (!DWARF_IS_V_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        val, 0, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
   return (*c->as->acc.access_mem) (c->as, addr + 0, valp, 0, c->as_arg);
 
 }
@@ -201,10 +201,10 @@ dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
   assert (!DWARF_IS_V_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        &val, 1, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
 
   return (*c->as->acc.access_mem) (c->as, addr + 0, valp, 1, c->as_arg);
 }
@@ -223,10 +223,10 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t * val)
   assert (!DWARF_IS_V_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), val,
                                      0, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), val,
                                      0, c->as_arg);
 }
 
@@ -244,10 +244,10 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
   assert (!DWARF_IS_V_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), &val,
                                      1, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), &val,
                                      1, c->as_arg);
 }
 

--- a/include/tdep-ppc64/libunwind_i.h
+++ b/include/tdep-ppc64/libunwind_i.h
@@ -183,10 +183,10 @@ dwarf_getvr (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t * val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                       val, 0, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
 
   if ((ret = (*c->as->acc.access_mem) (c->as, addr + 0, valp,
                                        0, c->as_arg)) < 0)
@@ -209,10 +209,10 @@ dwarf_putvr (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                       &val, 1, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
   if ((ret = (*c->as->acc.access_mem) (c->as, addr + 0, valp,
                                        1, c->as_arg)) < 0)
     return ret;
@@ -233,12 +233,11 @@ dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t * val)
   assert (!DWARF_IS_V_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        val, 0, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
   return (*c->as->acc.access_mem) (c->as, addr + 0, valp, 0, c->as_arg);
-
 }
 
 static inline int
@@ -254,11 +253,10 @@ dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
   assert (!DWARF_IS_V_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        &val, 1, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
-
+  addr = DWARF_GET_MEM_LOC (loc);
   return (*c->as->acc.access_mem) (c->as, addr + 0, valp, 1, c->as_arg);
 }
 
@@ -276,10 +274,10 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t * val)
   assert (!DWARF_IS_V_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), val,
                                      0, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), val,
                                      0, c->as_arg);
 }
 
@@ -297,10 +295,10 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
   assert (!DWARF_IS_V_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), &val,
                                      1, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), &val,
                                      1, c->as_arg);
 }
 

--- a/include/tdep-riscv/libunwind_i.h
+++ b/include/tdep-riscv/libunwind_i.h
@@ -169,11 +169,11 @@ dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        val, 0, c->as_arg);
 
   /* FIXME: unw_word_t may not be equal to FLEN */
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
 #if __riscv_xlen == __riscv_flen
   return (*c->as->acc.access_mem) (c->as, addr, (unw_word_t *) valp,
                                        0, c->as_arg);
@@ -192,11 +192,11 @@ dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        &val, 1, c->as_arg);
 
   /* FIXME: unw_word_t may not be equal to FLEN */
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
 #if __riscv_xlen == __riscv_flen
   return (*c->as->acc.access_mem) (c->as, addr, (unw_word_t *) valp,
                                        1, c->as_arg);
@@ -218,10 +218,10 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), val,
                                      0, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), val,
                                      0, c->as_arg);
 }
 
@@ -238,10 +238,10 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), &val,
                                      1, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), &val,
                                      1, c->as_arg);
 }
 

--- a/include/tdep-s390x/libunwind_i.h
+++ b/include/tdep-s390x/libunwind_i.h
@@ -123,17 +123,17 @@ dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_FP_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc), val,
                                        0, c->as_arg);
   /* FPRs may be saved in GPRs */
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), (unw_word_t*)val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), (unw_word_t*)val,
                                      0, c->as_arg);
   if (DWARF_IS_MEM_LOC (loc))
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), (unw_word_t*)val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), (unw_word_t*)val,
                                      0, c->as_arg);
   assert(DWARF_IS_VAL_LOC (loc));
-  *val = *(unw_fpreg_t*) DWARF_GET_LOC (loc);
+  *val = *(unw_fpreg_t*) DWARF_GET_MEM_LOC (loc);
   return 0;
 }
 
@@ -147,15 +147,15 @@ dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_FP_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc), &val,
                                        1, c->as_arg);
   /* FPRs may be saved in GPRs */
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), (unw_word_t*) &val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), (unw_word_t*) &val,
                                      1, c->as_arg);
 
   assert(DWARF_IS_MEM_LOC (loc));
-  return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), (unw_word_t*) &val,
+  return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), (unw_word_t*) &val,
                                    1, c->as_arg);
 }
 
@@ -169,13 +169,13 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
 
   /* GPRs may be saved in FPRs */
   if (DWARF_IS_FP_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc), (unw_fpreg_t*)val,
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc), (unw_fpreg_t*)val,
                                        0, c->as_arg);
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), val,
                                      0, c->as_arg);
   if (DWARF_IS_MEM_LOC (loc))
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), val,
                                      0, c->as_arg);
   assert(DWARF_IS_VAL_LOC (loc));
   *val = DWARF_GET_LOC (loc);
@@ -193,14 +193,14 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
 
   /* GPRs may be saved in FPRs */
   if (DWARF_IS_FP_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc), (unw_fpreg_t*) &val,
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc), (unw_fpreg_t*) &val,
                                        1, c->as_arg);
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), &val,
                                      1, c->as_arg);
 
   assert(DWARF_IS_MEM_LOC (loc));
-  return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), &val,
+  return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), &val,
                                    1, c->as_arg);
 }
 

--- a/include/tdep-sh/libunwind_i.h
+++ b/include/tdep-sh/libunwind_i.h
@@ -147,10 +147,10 @@ dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        val, 0, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
   if ((ret = (*c->as->acc.access_mem) (c->as, addr + 0, (unw_word_t *) valp,
                                        0, c->as_arg)) < 0)
     return ret;
@@ -170,10 +170,10 @@ dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        &val, 1, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
   if ((ret = (*c->as->acc.access_mem) (c->as, addr + 0, (unw_word_t *) valp,
                                        1, c->as_arg)) < 0)
     return ret;
@@ -195,10 +195,10 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), val,
                                      0, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), val,
                                      0, c->as_arg);
 }
 
@@ -215,10 +215,10 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
   assert (!DWARF_IS_FP_LOC (loc));
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), &val,
                                      1, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), &val,
                                      1, c->as_arg);
 }
 

--- a/include/tdep-x86/libunwind_i.h
+++ b/include/tdep-x86/libunwind_i.h
@@ -144,10 +144,10 @@ dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        val, 0, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
   if ((ret = (*c->as->acc.access_mem) (c->as, addr + 0, (unw_word_t *) valp,
                                        0, c->as_arg)) < 0)
     return ret;
@@ -167,10 +167,10 @@ dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_LOC (loc),
+    return (*c->as->acc.access_fpreg) (c->as, DWARF_GET_REG_LOC (loc),
                                        &val, 1, c->as_arg);
 
-  addr = DWARF_GET_LOC (loc);
+  addr = DWARF_GET_MEM_LOC (loc);
   if ((ret = (*c->as->acc.access_mem) (c->as, addr + 0, (unw_word_t *) valp,
                                        1, c->as_arg)) < 0)
     return ret;
@@ -188,10 +188,10 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), val,
                                      0, c->as_arg);
   if (DWARF_IS_MEM_LOC (loc))
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), val,
                                      0, c->as_arg);
   assert(DWARF_IS_VAL_LOC (loc));
   *val = DWARF_GET_LOC (loc);
@@ -207,10 +207,10 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), &val,
                                      1, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), &val,
                                      1, c->as_arg);
 }
 

--- a/include/tdep-x86_64/libunwind_i.h
+++ b/include/tdep-x86_64/libunwind_i.h
@@ -199,10 +199,10 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), val,
                                      0, c->as_arg);
   if (DWARF_IS_MEM_LOC (loc))
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), val,
                                      0, c->as_arg);
   assert(DWARF_IS_VAL_LOC (loc));
   *val = DWARF_GET_LOC (loc);
@@ -218,10 +218,10 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
     return -UNW_EBADREG;
 
   if (DWARF_IS_REG_LOC (loc))
-    return (*c->as->acc.access_reg) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_reg) (c->as, DWARF_GET_REG_LOC (loc), &val,
                                      1, c->as_arg);
   else
-    return (*c->as->acc.access_mem) (c->as, DWARF_GET_LOC (loc), &val,
+    return (*c->as->acc.access_mem) (c->as, DWARF_GET_MEM_LOC (loc), &val,
                                      1, c->as_arg);
 }
 

--- a/src/aarch64/Gget_save_loc.c
+++ b/src/aarch64/Gget_save_loc.c
@@ -88,13 +88,13 @@ unw_get_save_loc (unw_cursor_t *cursor, int reg, unw_save_loc_t *sloc)
   if (DWARF_IS_REG_LOC (loc))
     {
       sloc->type = UNW_SLT_REG;
-      sloc->u.regnum = DWARF_GET_LOC (loc);
+      sloc->u.regnum = DWARF_GET_REG_LOC (loc);
     }
   else
 #endif
     {
       sloc->type = UNW_SLT_MEMORY;
-      sloc->u.addr = DWARF_GET_LOC (loc);
+      sloc->u.addr = DWARF_GET_MEM_LOC (loc);
     }
   return 0;
 }

--- a/src/aarch64/Gstash_frame.c
+++ b/src/aarch64/Gstash_frame.c
@@ -54,25 +54,25 @@ tdep_stash_frame (struct dwarf_cursor *d, struct dwarf_reg_state *rs)
       && (rs->reg.where[DWARF_CFA_REG_COLUMN] == DWARF_WHERE_REG)
       && (rs->reg.val[DWARF_CFA_REG_COLUMN] == FP
           || rs->reg.val[DWARF_CFA_REG_COLUMN] == SP)
-      && labs(rs->reg.val[DWARF_CFA_OFF_COLUMN]) < (1 << 29)
+      && labs((long)rs->reg.val[DWARF_CFA_OFF_COLUMN]) < (1 << 29)
       && rs->ret_addr_column == LR
       && (rs->reg.where[FP] == DWARF_WHERE_UNDEF
           || rs->reg.where[FP] == DWARF_WHERE_SAME
           || rs->reg.where[FP] == DWARF_WHERE_CFA
           || (rs->reg.where[FP] == DWARF_WHERE_CFAREL
-              && labs(rs->reg.val[FP]) < (1 << 29)
+              && labs((long)rs->reg.val[FP]) < (1 << 29)
               && rs->reg.val[FP]+1 != 0))
       && (rs->reg.where[LR] == DWARF_WHERE_UNDEF
           || rs->reg.where[LR] == DWARF_WHERE_SAME
           || rs->reg.where[LR] == DWARF_WHERE_CFA
           || (rs->reg.where[LR] == DWARF_WHERE_CFAREL
-              && labs(rs->reg.val[LR]) < (1 << 29)
+              && labs((long)rs->reg.val[LR]) < (1 << 29)
               && rs->reg.val[LR]+1 != 0))
       && (rs->reg.where[SP] == DWARF_WHERE_UNDEF
           || rs->reg.where[SP] == DWARF_WHERE_SAME
           || rs->reg.where[SP] == DWARF_WHERE_CFA
           || (rs->reg.where[SP] == DWARF_WHERE_CFAREL
-              && labs(rs->reg.val[SP]) < (1 << 29)
+              && labs((long)rs->reg.val[SP]) < (1 << 29)
               && rs->reg.val[SP]+1 != 0)))
   {
     /* Save information for a standard frame. */

--- a/src/arm/Gex_tables.c
+++ b/src/arm/Gex_tables.c
@@ -151,7 +151,7 @@ arm_exidx_apply_cmd (struct arm_exbuf_data *edata, struct dwarf_cursor *c)
  * arm_exidx_apply_cmd that applies the command onto the dwarf_cursor.
  */
 HIDDEN int
-arm_exidx_decode (const uint8_t *buf, uint8_t len, struct dwarf_cursor *c)
+arm_exidx_decode (const uint8_t *buf, int len, struct dwarf_cursor *c)
 {
 #define READ_OP() *buf++
   assert(buf != NULL);
@@ -317,9 +317,9 @@ arm_exidx_extract (struct dwarf_cursor *c, uint8_t *buf)
     {
       Debug (2, "%p compact model %d [%8.8x]\n", (void *)addr,
              (data >> 24) & 0x7f, data);
-      buf[nbuf++] = data >> 16;
-      buf[nbuf++] = data >> 8;
-      buf[nbuf++] = data;
+      buf[nbuf++] = (uint8_t) (data >> 16);
+      buf[nbuf++] = (uint8_t) (data >> 8);
+      buf[nbuf++] = (uint8_t) data;
     }
   else
     {
@@ -342,9 +342,11 @@ arm_exidx_extract (struct dwarf_cursor *c, uint8_t *buf)
               extbl_data += 4;
             }
           else
-            buf[nbuf++] = data >> 16;
-          buf[nbuf++] = data >> 8;
-          buf[nbuf++] = data;
+            {
+              buf[nbuf++] = (uint8_t) (data >> 16);
+            }
+          buf[nbuf++] = (uint8_t) (data >> 8);
+          buf[nbuf++] = (uint8_t) data;
         }
       else
         {
@@ -357,9 +359,9 @@ arm_exidx_extract (struct dwarf_cursor *c, uint8_t *buf)
                                        c->as_arg) < 0)
             return -UNW_EINVAL;
           n_table_words = data >> 24;
-          buf[nbuf++] = data >> 16;
-          buf[nbuf++] = data >> 8;
-          buf[nbuf++] = data;
+          buf[nbuf++] = (uint8_t) (data >> 16);
+          buf[nbuf++] = (uint8_t) (data >> 8);
+          buf[nbuf++] = (uint8_t) data;
           extbl_data += 8;
         }
       assert (n_table_words <= 5);
@@ -370,10 +372,10 @@ arm_exidx_extract (struct dwarf_cursor *c, uint8_t *buf)
                                        c->as_arg) < 0)
             return -UNW_EINVAL;
           extbl_data += 4;
-          buf[nbuf++] = data >> 24;
-          buf[nbuf++] = data >> 16;
-          buf[nbuf++] = data >> 8;
-          buf[nbuf++] = data >> 0;
+          buf[nbuf++] = (uint8_t) (data >> 24);
+          buf[nbuf++] = (uint8_t) (data >> 16);
+          buf[nbuf++] = (uint8_t) (data >> 8);
+          buf[nbuf++] = (uint8_t) data;
         }
     }
 

--- a/src/arm/Gget_save_loc.c
+++ b/src/arm/Gget_save_loc.c
@@ -88,13 +88,13 @@ unw_get_save_loc (unw_cursor_t *cursor, int reg, unw_save_loc_t *sloc)
   if (DWARF_IS_REG_LOC (loc))
     {
       sloc->type = UNW_SLT_REG;
-      sloc->u.regnum = DWARF_GET_LOC (loc);
+      sloc->u.regnum = DWARF_GET_REG_LOC (loc);
     }
   else
 #endif
     {
       sloc->type = UNW_SLT_MEMORY;
-      sloc->u.addr = DWARF_GET_LOC (loc);
+      sloc->u.addr = DWARF_GET_MEM_LOC (loc);
     }
   return 0;
 }

--- a/src/dwarf/Gexpr.c
+++ b/src/dwarf/Gexpr.c
@@ -122,7 +122,7 @@ sword (unw_addr_space_t as UNUSED, unw_word_t val)
     }
 }
 
-static inline unw_word_t
+static inline int
 read_operand (unw_addr_space_t as, unw_accessors_t *a,
               unw_word_t *addr, int operand_type, unw_word_t *val, void *arg)
 {
@@ -169,7 +169,7 @@ read_operand (unw_addr_space_t as, unw_accessors_t *a,
       ret = dwarf_readu64 (as, a, addr, &u64, arg);
       if (ret < 0)
         return ret;
-      *val = u64;
+      *val = (unw_word_t) u64;
       break;
 
     case ULEB128:
@@ -366,7 +366,7 @@ if (stackerror)                                 \
           Debug (15, "OP_bregx(r%d,0x%lx)\n",
                  (int) operand1, (unsigned long) operand2);
           if ((ret = unw_get_reg (dwarf_to_cursor (c),
-                                  dwarf_to_unw_regnum (operand1), &tmp1)) < 0)
+                                  dwarf_to_unw_regnum ((int) operand1), &tmp1)) < 0)
             return ret;
           push (tmp1 + operand2);
           break;
@@ -475,7 +475,7 @@ if (stackerror)                                 \
             case 8:
               if ((ret = dwarf_readu64 (as, a, &tmp1, &u64, arg)) < 0)
                 return ret;
-              tmp2 = u64;
+              tmp2 = (unw_word_t) u64;
               if (operand1 != 8)
                 {
                   if (dwarf_is_big_endian (as))

--- a/src/dwarf/Gfde.c
+++ b/src/dwarf/Gfde.c
@@ -102,7 +102,7 @@ parse_cie (unw_addr_space_t as, unw_accessors_t *a, unw_word_t addr,
 
       if ((ret = dwarf_readu64 (as, a, &addr, &u64val, arg)) < 0)
         return ret;
-      len = u64val;
+      len = (unw_word_t) u64val;
       cie_end_addr = addr + len;
       if ((ret = dwarf_readu64 (as, a, &addr, &cie_id, arg)) < 0)
         return ret;
@@ -237,7 +237,8 @@ dwarf_extract_proc_info_from_fde (unw_addr_space_t as, unw_accessors_t *a,
 {
   unw_word_t fde_end_addr, cie_addr, cie_offset_addr, aug_end_addr = 0;
   unw_word_t start_ip, ip_range, aug_size, addr = *addrp;
-  int ret, ip_range_encoding;
+  int ret;
+  uint8_t ip_range_encoding;
   struct dwarf_cie_info dci;
   uint64_t u64val;
   uint32_t u32val;
@@ -288,18 +289,18 @@ dwarf_extract_proc_info_from_fde (unw_addr_space_t as, unw_accessors_t *a,
       if ((ret = dwarf_readu64 (as, a, &addr, &u64val, arg)) < 0)
         return ret;
 
-      *addrp = fde_end_addr = addr + u64val;
+      *addrp = fde_end_addr = (unw_word_t) (addr + u64val);
       cie_offset_addr = addr;
 
       if ((ret = dwarf_reads64 (as, a, &addr, &cie_offset, arg)) < 0)
         return ret;
 
-      if (is_cie_id (cie_offset, is_debug_frame))
+      if (is_cie_id ((unw_word_t) cie_offset, is_debug_frame))
         /* ignore CIEs (happens during linear searches) */
         return 0;
 
       if (is_debug_frame)
-        cie_addr = base + cie_offset;
+        cie_addr = (unw_word_t) (base + cie_offset);
       else
         /* DWARF says that the CIE_pointer in the FDE is a
            .debug_frame-relative offset, but the GCC-generated .eh_frame

--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -975,10 +975,10 @@ dwarf_search_unwind_table (unw_addr_space_t as, unw_word_t ip,
 #endif
     {
 #ifndef UNW_LOCAL_ONLY
-      int32_t last_ip_offset = di->end_ip - ip_base - di->load_offset;
+      int32_t last_ip_offset = (int32_t) (di->end_ip - ip_base - di->load_offset);
       segbase = di->u.rti.segbase;
       if ((ret = remote_lookup (as, (uintptr_t) table, table_len,
-                                ip - ip_base, &ent, &last_ip_offset, arg)) < 0)
+                                (int32_t) (ip - ip_base), &ent, &last_ip_offset, arg)) < 0)
         return ret;
       if (ret)
 	{

--- a/src/hppa/Gget_save_loc.c
+++ b/src/hppa/Gget_save_loc.c
@@ -47,13 +47,13 @@ unw_get_save_loc (unw_cursor_t *cursor, int reg, unw_save_loc_t *sloc)
   if (DWARF_IS_REG_LOC (loc))
     {
       sloc->type = UNW_SLT_REG;
-      sloc->u.regnum = DWARF_GET_LOC (loc);
+      sloc->u.regnum = DWARF_GET_REG_LOC (loc);
     }
   else
 #endif
     {
       sloc->type = UNW_SLT_MEMORY;
-      sloc->u.addr = DWARF_GET_LOC (loc);
+      sloc->u.addr = DWARF_GET_MEM_LOC (loc);
     }
   return 0;
 }

--- a/src/loongarch64/Gget_save_loc.c
+++ b/src/loongarch64/Gget_save_loc.c
@@ -89,13 +89,13 @@ unw_get_save_loc (unw_cursor_t *cursor, int reg, unw_save_loc_t *sloc)
   if (DWARF_IS_REG_LOC (loc))
     {
       sloc->type = UNW_SLT_REG;
-      sloc->u.regnum = DWARF_GET_LOC (loc);
+      sloc->u.regnum = DWARF_GET_REG_LOC (loc);
     }
   else
 #endif
     {
       sloc->type = UNW_SLT_MEMORY;
-      sloc->u.addr = DWARF_GET_LOC (loc);
+      sloc->u.addr = DWARF_GET_MEM_LOC (loc);
     }
   return 0;
 }

--- a/src/mi/Gdyn-remote.c
+++ b/src/mi/Gdyn-remote.c
@@ -101,7 +101,7 @@ intern_array (unw_addr_space_t as, unw_accessors_t *a,
               unw_word_t *addr, unw_word_t table_len, unw_word_t **table_data,
               void *arg)
 {
-  unw_word_t i, *data = calloc (table_len, WSIZE);
+  unw_word_t i, *data = calloc ((size_t) table_len, WSIZE);
   int ret = 0;
 
   if (!data)

--- a/src/mips/Gget_save_loc.c
+++ b/src/mips/Gget_save_loc.c
@@ -88,13 +88,13 @@ unw_get_save_loc (unw_cursor_t *cursor, int reg, unw_save_loc_t *sloc)
   if (DWARF_IS_REG_LOC (loc))
     {
       sloc->type = UNW_SLT_REG;
-      sloc->u.regnum = DWARF_GET_LOC (loc);
+      sloc->u.regnum = DWARF_GET_REG_LOC (loc);
     }
   else
 #endif
     {
       sloc->type = UNW_SLT_MEMORY;
-      sloc->u.addr = DWARF_GET_LOC (loc);
+      sloc->u.addr = DWARF_GET_MEM_LOC (loc);
     }
   return 0;
 }

--- a/src/riscv/Gget_save_loc.c
+++ b/src/riscv/Gget_save_loc.c
@@ -85,13 +85,13 @@ unw_get_save_loc (unw_cursor_t *cursor, int reg, unw_save_loc_t *sloc)
   if (DWARF_IS_REG_LOC (loc))
     {
       sloc->type = UNW_SLT_REG;
-      sloc->u.regnum = DWARF_GET_LOC (loc);
+      sloc->u.regnum = DWARF_GET_REG_LOC (loc);
     }
   else
 #endif
     {
       sloc->type = UNW_SLT_MEMORY;
-      sloc->u.addr = DWARF_GET_LOC (loc);
+      sloc->u.addr = DWARF_GET_MEM_LOC (loc);
     }
   return 0;
 }

--- a/src/s390x/Gget_save_loc.c
+++ b/src/s390x/Gget_save_loc.c
@@ -74,13 +74,13 @@ unw_get_save_loc (unw_cursor_t *cursor, int reg, unw_save_loc_t *sloc)
   if (DWARF_IS_REG_LOC (loc))
     {
       sloc->type = UNW_SLT_REG;
-      sloc->u.regnum = DWARF_GET_LOC (loc);
+      sloc->u.regnum = DWARF_GET_REG_LOC (loc);
     }
   else
 #endif
     {
       sloc->type = UNW_SLT_MEMORY;
-      sloc->u.addr = DWARF_GET_LOC (loc);
+      sloc->u.addr = DWARF_GET_MEM_LOC (loc);
     }
   return 0;
 }

--- a/src/sh/Gget_save_loc.c
+++ b/src/sh/Gget_save_loc.c
@@ -71,13 +71,13 @@ unw_get_save_loc (unw_cursor_t *cursor, int reg, unw_save_loc_t *sloc)
   if (DWARF_IS_REG_LOC (loc))
     {
       sloc->type = UNW_SLT_REG;
-      sloc->u.regnum = DWARF_GET_LOC (loc);
+      sloc->u.regnum = DWARF_GET_REG_LOC (loc);
     }
   else
 #endif
     {
       sloc->type = UNW_SLT_MEMORY;
-      sloc->u.addr = DWARF_GET_LOC (loc);
+      sloc->u.addr = DWARF_GET_MEM_LOC (loc);
     }
   return 0;
 }

--- a/src/x86/Gget_save_loc.c
+++ b/src/x86/Gget_save_loc.c
@@ -121,13 +121,13 @@ unw_get_save_loc (unw_cursor_t *cursor, int reg, unw_save_loc_t *sloc)
   if (DWARF_IS_REG_LOC (loc))
     {
       sloc->type = UNW_SLT_REG;
-      sloc->u.regnum = DWARF_GET_LOC (loc);
+      sloc->u.regnum = DWARF_GET_REG_LOC (loc);
     }
   else
 #endif
     {
       sloc->type = UNW_SLT_MEMORY;
-      sloc->u.addr = DWARF_GET_LOC (loc);
+      sloc->u.addr = DWARF_GET_MEM_LOC (loc);
     }
   return 0;
 }

--- a/src/x86_64/Gget_save_loc.c
+++ b/src/x86_64/Gget_save_loc.c
@@ -62,13 +62,13 @@ unw_get_save_loc (unw_cursor_t *cursor, int reg, unw_save_loc_t *sloc)
   if (DWARF_IS_REG_LOC (loc))
     {
       sloc->type = UNW_SLT_REG;
-      sloc->u.regnum = DWARF_GET_LOC (loc);
+      sloc->u.regnum = DWARF_GET_REG_LOC (loc);
     }
   else
 #endif
     {
       sloc->type = UNW_SLT_MEMORY;
-      sloc->u.addr = DWARF_GET_LOC (loc);
+      sloc->u.addr = DWARF_GET_MEM_LOC (loc);
     }
   return 0;
 }


### PR DESCRIPTION
These issues were found when enabling C4242 and C4244 warnings.

See https://github.com/dotnet/runtime/pull/100241