### PR TITLE
Set image to null when invalid

### DIFF
--- a/src/elfxx.h
+++ b/src/elfxx.h
@@ -104,6 +104,7 @@ elf_map_image (struct elf_image *ei, const char *path)
   if (!elf_w (valid_object) (ei))
   {
     mi_munmap(ei->image, ei->size);
+    ei->image = NULL;
     return -1;
   }
 


### PR DESCRIPTION
Set the image to null when the elf is invalid, otherwise the address will be unmapped again later in `invalidate_edi`.

Fixes https://github.com/libunwind/libunwind/issues/738.