### PR TITLE
configure.ac: stop adding -D__EXTENSIONS__

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -484,12 +484,12 @@ fi
 AC_MSG_RESULT([$intel_compiler])
 
 AC_MSG_CHECKING([if building on Solaris then define __EXTENSIONS__ macro])
-if $OS_SOLARIS; then
+AM_COND_IF([OS_SOLARIS],[
   CFLAGS="${CFLAGS} -D__EXTENSIONS__"
   AC_MSG_RESULT([yes])
-else
+],[
   AC_MSG_RESULT([no])
-fi
+])
 
 AC_MSG_CHECKING([for QCC compiler])
 AS_CASE([$CC], [qcc*|QCC*], [qcc_compiler=yes], [qcc_compiler=no])


### PR DESCRIPTION
An incorrect use of an automake conditional in a shell `if` construct forced -D__EXTENSIONS__ to be added to all compilation command lines. The AM_COND_IF automake macro was used instead.

Tested against x86_64-linux-gnu and the -D__EXTENSIONS__ no longer appeared on the compile command line.

Closes #743 