### PR TITLE
Avoid clobbering user variables in autotools files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -543,8 +543,6 @@ if test x$have__builtin_unreachable = xyes; then
 fi
 AC_MSG_RESULT([$have__builtin_unreachable])
 
-CCASFLAGS="${CCASFLAGS} ${CPPFLAGS}"
-
 arch="$target_arch"
 ARCH=`echo $target_arch | tr [a-z] [A-Z]`
 

--- a/configure.ac
+++ b/configure.ac
@@ -476,14 +476,18 @@ AC_SUBST([LIBZ])
 AM_CONDITIONAL(HAVE_ZLIB, test x$enable_zlibdebuginfo = xyes)
 
 AC_MSG_CHECKING([for Intel compiler])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[#ifndef __INTEL_COMPILER
-#error choke me
-#endif]])],[intel_compiler=yes],[intel_compiler=no])
-
-if test x$GCC = xyes -a x$intel_compiler != xyes; then
-  CFLAGS="${CFLAGS} -fexceptions -Wall -Wsign-compare"
-fi
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+        [],
+        [#ifndef __INTEL_COMPILER
+         #error choke me
+         #endif
+        ])],
+    [intel_compiler=yes],
+    [intel_compiler=no])
 AC_MSG_RESULT([$intel_compiler])
+if test x$GCC = xyes -a x$intel_compiler != xyes; then
+    AC_SUBST([UNW_EXTRA_CFLAGS],["-fexceptions -Wall -Wsign-compare"])
+fi
 
 AC_MSG_CHECKING([for QCC compiler])
 AS_CASE([$CC], [qcc*|QCC*], [qcc_compiler=yes], [qcc_compiler=no])

--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,12 @@ AC_CHECK_HEADERS(asm/ptrace_offsets.h asm/ptrace.h asm/vsyscall.h endian.h sys/e
 		sys/types.h sys/procfs.h sys/ptrace.h sys/syscall.h byteswap.h elf.h \
 		sys/elf.h link.h sys/link.h)
 
-CPPFLAGS="${CPPFLAGS} -D_GNU_SOURCE"
+dnl Set target-specific compile flags
+AS_CASE([$target_os],
+        [*-gnu],    [UNW_TARGET_CPPFLAGS="-D_GNU_SOURCE"],
+        [solaris*], [UNW_TARGET_CPPFLAGS="-D__EXTENSIONS__"]
+)
+AC_SUBST([UNW_TARGET_CPPFLAGS])
 
 AC_MSG_NOTICE([--- Checking for available types ---])
 AC_CHECK_MEMBERS([struct dl_phdr_info.dlpi_subs],,,[#include <link.h>])
@@ -385,12 +390,12 @@ AM_CONDITIONAL(USE_DWARF, [test x$use_dwarf = xyes])
 AC_MSG_RESULT([$use_dwarf])
 
 AC_MSG_CHECKING([whether to restrict build to remote support])
-if test x$target_arch != x$host_arch; then
-  CPPFLAGS="${CPPFLAGS} -DUNW_REMOTE_ONLY"
+AM_COND_IF([REMOTE_ONLY],[
+  AC_SUBST([UNW_REMOTE_CPPFLAGS], [-DUNW_REMOTE_ONLY])
   remote_only=yes
-else
+],[
   remote_only=no
-fi
+])
 AC_MSG_RESULT([$remote_only])
 
 AC_MSG_CHECKING([whether to load .debug_frame sections])
@@ -479,14 +484,6 @@ if test x$GCC = xyes -a x$intel_compiler != xyes; then
   CFLAGS="${CFLAGS} -fexceptions -Wall -Wsign-compare"
 fi
 AC_MSG_RESULT([$intel_compiler])
-
-AC_MSG_CHECKING([if building on Solaris then define __EXTENSIONS__ macro])
-if $OS_SOLARIS; then
-  CFLAGS="${CFLAGS} -D__EXTENSIONS__"
-  AC_MSG_RESULT([yes])
-else
-  AC_MSG_RESULT([no])
-fi
 
 AC_MSG_CHECKING([for QCC compiler])
 AS_CASE([$CC], [qcc*|QCC*], [qcc_compiler=yes], [qcc_compiler=no])

--- a/configure.ac
+++ b/configure.ac
@@ -287,17 +287,14 @@ AC_MSG_CHECKING([if debug support should be built])
 AC_ARG_ENABLE([debug],
               [AS_HELP_STRING([--enable-debug],
                               [enable debug support (slows down execution)
+                              CAUTION: changes the ABI
                                @<:@default=no@:>@])],
-              [],
+              [AC_SUBST([UNW_DEBUG_CPPFLAGS], ["-DUNW_DEBUG=1"])],
               [enable_debug=no]
 )
 AC_MSG_RESULT([$enable_debug])
-AS_IF([test x$enable_debug = xyes],
-      [CPPFLAGS="${CPPFLAGS} -DDEBUG"],
-      [CPPFLAGS="${CPPFLAGS} -DNDEBUG"]
-)
 
-AC_MSG_CHECKING([if C++ exception support should be built])
+AC_MSG_CHECKING([if C++ exception support shouldm  be built])
 AC_ARG_ENABLE([cxx_exceptions],
               [AS_HELP_STRING([--enable-cxx-exceptions],
                               [use libunwind to handle C++ exceptions

--- a/include/libunwind_i.h
+++ b/include/libunwind_i.h
@@ -148,12 +148,6 @@ target_is_big_endian(void)
 # define unreachable() do { } while (1)
 #endif
 
-#ifdef DEBUG
-# define UNW_DEBUG      1
-#else
-# undef UNW_DEBUG
-#endif
-
 /* Make it easy to write thread-safe code which may or may not be
    linked against libpthread.  The macros below can be used
    unconditionally and if -lpthread is around, they'll call the

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1243,7 +1243,10 @@ libunwind_la_LDFLAGS =	$(COMMON_SO_LDFLAGS) -XCClinker -nostdlib \
 libunwind_la_LIBADD  += -lc $(LIBCRTS)
 libunwind_la_LIBADD += $(LIBLZMA) $(LIBZ)
 
-AM_CPPFLAGS = $(UNW_DEBUG_CPPFLAGS) -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I.
+AM_CPPFLAGS = $(UNW_DEBUG_CPPFLAGS) \
+              $(UNW_REMOTE_CPPFLAGS) \
+              $(UNW_TARGET_CPPFLAGS) \
+              -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I.
 noinst_HEADERS += unwind/unwind-internal.h
 
 EXTRA_DIST = $(libunwind_la_EXTRAS_ia64)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1244,7 +1244,6 @@ libunwind_la_LIBADD  += -lc $(LIBCRTS)
 libunwind_la_LIBADD += $(LIBLZMA) $(LIBZ)
 
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I.
-AM_CCASFLAGS = $(AM_CPPFLAGS)
 noinst_HEADERS += unwind/unwind-internal.h
 
 EXTRA_DIST = $(libunwind_la_EXTRAS_ia64)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,6 +25,12 @@ SOVERSION=9:0:1		# See comments at end of file.
 SETJMP_SO_VERSION=0:0:0
 COREDUMP_SO_VERSION=0:0:0
 
+AM_CPPFLAGS = $(UNW_DEBUG_CPPFLAGS) \
+              $(UNW_REMOTE_CPPFLAGS) \
+              $(UNW_TARGET_CPPFLAGS) \
+              -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I.
+AM_CFLAGS = $(UNW_EXTRA_CFLAGS)
+
 #
 # Don't link with start-files since we don't use any constructors/destructors:
 #
@@ -1243,10 +1249,6 @@ libunwind_la_LDFLAGS =	$(COMMON_SO_LDFLAGS) -XCClinker -nostdlib \
 libunwind_la_LIBADD  += -lc $(LIBCRTS)
 libunwind_la_LIBADD += $(LIBLZMA) $(LIBZ)
 
-AM_CPPFLAGS = $(UNW_DEBUG_CPPFLAGS) \
-              $(UNW_REMOTE_CPPFLAGS) \
-              $(UNW_TARGET_CPPFLAGS) \
-              -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I.
 noinst_HEADERS += unwind/unwind-internal.h
 
 EXTRA_DIST = $(libunwind_la_EXTRAS_ia64)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1243,7 +1243,7 @@ libunwind_la_LDFLAGS =	$(COMMON_SO_LDFLAGS) -XCClinker -nostdlib \
 libunwind_la_LIBADD  += -lc $(LIBCRTS)
 libunwind_la_LIBADD += $(LIBLZMA) $(LIBZ)
 
-AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I.
+AM_CPPFLAGS = $(UNW_DEBUG_CPPFLAGS) -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I.
 noinst_HEADERS += unwind/unwind-internal.h
 
 EXTRA_DIST = $(libunwind_la_EXTRAS_ia64)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,7 +29,7 @@
 # Test binaries and scripts get installed here
 testdir = ${pkglibexecdir}
 
-AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I$(top_srcdir)/src
+AM_CPPFLAGS = $(UNW_DEBUG_CPPFLAGS) -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I$(top_srcdir)/src
 AM_CFLAGS = -fno-optimize-sibling-calls
 
 LOG_DRIVER = $(SHELL) $(UNW_TESTDRIVER)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,7 +29,10 @@
 # Test binaries and scripts get installed here
 testdir = ${pkglibexecdir}
 
-AM_CPPFLAGS = $(UNW_DEBUG_CPPFLAGS) -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I$(top_srcdir)/src
+AM_CPPFLAGS = $(UNW_DEBUG_CPPFLAGS) \
+              $(UNW_REMOTE_CPPFLAGS) \
+              $(UNW_TARGET_CPPFLAGS) \
+              -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I$(top_srcdir)/src
 AM_CFLAGS = -fno-optimize-sibling-calls
 
 LOG_DRIVER = $(SHELL) $(UNW_TESTDRIVER)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -33,7 +33,7 @@ AM_CPPFLAGS = $(UNW_DEBUG_CPPFLAGS) \
               $(UNW_REMOTE_CPPFLAGS) \
               $(UNW_TARGET_CPPFLAGS) \
               -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I$(top_srcdir)/src
-AM_CFLAGS = -fno-optimize-sibling-calls
+AM_CFLAGS = $(UNW_EXTRA_CFLAGS) -fno-optimize-sibling-calls
 
 LOG_DRIVER = $(SHELL) $(UNW_TESTDRIVER)
 


### PR DESCRIPTION
`configure.ac` and the various `Makefile.am` files were clobbering user variables CFLAGS, CPPFLAGS, and CCASFLAGS. This causes trouble when a user want to set those variables from the command line during a build (eg. `make CFLAGS="-g -O0"`).

This change replaces that clobber with various UNW_ variables propagated through the system.
Closes #744 
Closes #743 