### PR TITLE
Fixed miscompilation of unw_getcontext() on ARM

### DIFF
--- a/include/libunwind-arm.h
+++ b/include/libunwind-arm.h
@@ -288,7 +288,7 @@ unw_tdep_context_t;
     "mov r0, #0\n\t"                                                                            \
     "stmia %[base]!, {r0-r15}\n\t"                                                              \
     VSTMIA                                                                                      \
-    : [r0] "=r" (r0) : [base] "r" (unw_base) : "memory");                                       \
+    : [r0] "=r" (r0), [base] "+r" (unw_base) : : "memory");                                     \
   (int)r0; })
 #else /* __thumb__ */
 #define unw_tdep_getcontext(uc) ({                                        \


### PR DESCRIPTION
`unw_getcontext()` followed by `unw_init_local()` produced invalid code due to r1 not being specified as output register in the inline assembly. Compiler assumed that this register already contained the right value of `unw_context_t*` to be passed to `unw_init_local()`.