### PR TITLE
Fix solaris build

### DIFF
--- a/src/os-solaris.c
+++ b/src/os-solaris.c
@@ -63,7 +63,7 @@ tdep_get_elf_image (struct elf_image *ei, pid_t pid, unw_word_t ip,
   if (ei)
     rc = elf_map_image (ei, mi.path);
   else
-    rc = strlen(mi.path) >= pathlen ? -UNW_ENOMEM : UNW_ESUCCESS:;
+    rc = strlen(mi.path) >= pathlen ? -UNW_ENOMEM : UNW_ESUCCESS;
 
   maps_close (&mi);
   return rc;


### PR DESCRIPTION
Similar to https://github.com/libunwind/libunwind/pull/687, but for solaris.
ran into it in illumos build: https://github.com/am11/CrossRepoCITesting/actions/runs/9291922072/job/25571584699

```
   /runtime/src/native/external/libunwind/src/os-solaris.c:66:65: error: expected ';' before ':' token
       rc = strlen(mi.path) >= pathlen ? -UNW_ENOMEM : UNW_ESUCCESS:;
                                                                   ^
                                                                   ;
```