### PR TITLE
Switch to using check-namespace.sh

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -147,7 +147,7 @@ jobs:
             *)
                 srcdir=$(pwd)
                 cd build/tests
-                ${srcdir}/tests/run-check-namespace
+                ./check-namespace.sh
                 ;;
             esac
 


### PR DESCRIPTION
Some cross-builty CI ABI checks were failing because the wrapper script was removed.

Closes #762 