### PR TITLE
Add unw_is_plt_entry() to public API (fixes FTBFS on QNX)

### DIFF
--- a/include/libunwind-common.h.in
+++ b/include/libunwind-common.h.in
@@ -288,6 +288,7 @@ typedef int (*unw_iterate_phdr_func_t) (unw_iterate_phdr_callback_t, void *);
 #define unw_set_fpreg			UNW_OBJ(set_fpreg)
 #define unw_get_save_loc		UNW_OBJ(get_save_loc)
 #define unw_is_signal_frame		UNW_OBJ(is_signal_frame)
+#define unw_is_plt_entry        UNW_OBJ(is_plt_entry)
 #define unw_get_proc_name		UNW_OBJ(get_proc_name)
 #define unw_get_proc_name_by_ip		UNW_OBJ(get_proc_name_by_ip)
 #define unw_get_elf_filename		UNW_OBJ(get_elf_filename)
@@ -331,6 +332,7 @@ extern int unw_get_fpreg (unw_cursor_t *, int, unw_fpreg_t *);
 extern int unw_set_fpreg (unw_cursor_t *, int, unw_fpreg_t);
 extern int unw_get_save_loc (unw_cursor_t *, int, unw_save_loc_t *);
 extern int unw_is_signal_frame (unw_cursor_t *);
+extern int unw_is_plt_entry (unw_cursor_t *);
 extern int unw_get_proc_name (unw_cursor_t *, char *, size_t, unw_word_t *);
 extern int unw_get_proc_name_by_ip (unw_addr_space_t, unw_word_t, char *,
 				    size_t, unw_word_t *, void *);

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,7 +21,7 @@
 #
 
 # Set the DSO versions
-SOVERSION=9:0:1		# See comments at end of file.
+SOVERSION=10:0:2		# See comments at end of file.
 SETJMP_SO_VERSION=0:0:0
 COREDUMP_SO_VERSION=0:0:0
 
@@ -239,6 +239,7 @@ libunwind_la_SOURCES_generic =                 \
 	mi/Gget_proc_info_by_ip.c              \
 	mi/Gget_proc_name.c                    \
 	mi/Gget_reg.c                          \
+	mi/Gis_plt_entry.c                     \
 	mi/Gput_dynamic_unwind_info.c          \
 	mi/Gset_cache_size.c                   \
 	mi/Gset_caching_policy.c               \
@@ -290,6 +291,7 @@ libunwind_la_SOURCES_local_nounwind =          \
 	mi/Lget_proc_info_by_ip.c              \
 	mi/Lget_proc_name.c                    \
 	mi/Lget_reg.c                          \
+	mi/Lis_plt_entry.c                     \
 	mi/Lput_dynamic_unwind_info.c          \
 	mi/Lset_cache_size.c                   \
 	mi/Lset_caching_policy.c               \

--- a/src/aarch64/Gstep.c
+++ b/src/aarch64/Gstep.c
@@ -40,7 +40,7 @@ static const int WSIZE = sizeof (unw_word_t);
   \note The current implementation only supports little endian modes.
 */
 static int
-is_plt_entry (struct dwarf_cursor *c)
+_is_plt_entry (struct dwarf_cursor *c)
 {
   unw_word_t w0 = 0, w1 = 0;
   unw_accessors_t *a;
@@ -150,6 +150,12 @@ is_plt_entry (struct dwarf_cursor *c)
     }
 }
 
+int
+unw_is_plt_entry (unw_cursor_t *uc)
+{
+	return _is_plt_entry (&((struct cursor *)uc)->dwarf);
+}
+
 typedef enum frame_record_location
   {
     NONE,           /* frame record creation has not been detected, use LR */
@@ -188,7 +194,7 @@ get_frame_state (unw_cursor_t *cursor)
   fs.offset = 0;
 
   /* PLT entries do not create frame records */
-  if (is_plt_entry (&c->dwarf))
+  if (_is_plt_entry (&c->dwarf))
     return fs;
 
   /* Use get_proc_name to find start_ip of procedure */
@@ -655,7 +661,7 @@ unw_step (unw_cursor_t *cursor)
           c->validate = 1;
         }
 
-      if (is_plt_entry (&c->dwarf))
+      if (_is_plt_entry (&c->dwarf))
         {
           Debug (2, "found plt entry\n");
           c->frame_info.frame_type = UNW_AARCH64_FRAME_STANDARD;

--- a/src/mi/Gis_plt_entry.c
+++ b/src/mi/Gis_plt_entry.c
@@ -1,0 +1,39 @@
+/**
+ * Default implementation of unw_is_plt_entry() for those CPU-OS-ENV targets
+ * that don't need to specialize this function.
+ */
+/*
+ * Copyright 2024 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ *
+ * This file is part of libunwind.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "libunwind_i.h"
+
+/**
+ * This weakly-defined version of this public API function does nothing other
+ * than always return false.
+ */
+WEAK int
+unw_is_plt_entry (unw_cursor_t *c UNUSED)
+{
+	return 0;
+}

--- a/src/mi/Lis_plt_entry.c
+++ b/src/mi/Lis_plt_entry.c
@@ -1,0 +1,33 @@
+/**
+ * Default implementation of unw_is_plt_entry() for those CPU-OS-ENV targets
+ * that don't need to specialize this function.
+ */
+/*
+ * Copyright 2024 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ *
+ * This file is part of libunwind.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#define UNW_LOCAL_ONLY
+#include "libunwind_i.h"
+#if defined(UNW_LOCAL_ONLY) && !defined(UNW_REMOTE_ONLY)
+#include "Gis_plt_entry.c"
+#endif

--- a/src/ppc64/Gstep.c
+++ b/src/ppc64/Gstep.c
@@ -60,7 +60,7 @@ typedef struct
   \note The current implementation only supports little endian modes.
 */
 static int
-is_plt_entry (struct dwarf_cursor *c)
+_is_plt_entry (struct dwarf_cursor *c)
 {
   unw_word_t w0, w1;
   unw_accessors_t *a;
@@ -171,6 +171,14 @@ is_plt_entry (struct dwarf_cursor *c)
     }
 }
 
+
+int
+unw_is_plt_entry (unw_cursor_t *uc)
+{
+	return _is_plt_entry (&((struct cursor *)uc)->dwarf);
+}
+
+
 int
 unw_step (unw_cursor_t * cursor)
 {
@@ -200,7 +208,7 @@ unw_step (unw_cursor_t * cursor)
       if (likely (unw_is_signal_frame (cursor) <= 0))
         {
           /* DWARF failed. */
-          if (is_plt_entry (&c->dwarf))
+          if (_is_plt_entry (&c->dwarf))
             {
               Debug (2, "found plt entry\n");
 

--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -34,7 +34,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
      3bdf6: 68 ae 03 00 00    pushq  $0x3ae
      3bdfb: e9 00 c5 ff ff    jmpq   38300 <_init+0x18> */
 static int
-is_plt_entry (struct dwarf_cursor *c)
+_is_plt_entry (struct dwarf_cursor *c)
 {
   unw_word_t w0, w1;
   unw_accessors_t *a;
@@ -51,6 +51,12 @@ is_plt_entry (struct dwarf_cursor *c)
 
   Debug (14, "ip=0x%lx => 0x%016lx 0x%016lx, ret = %d\n", c->ip, w0, w1, ret);
   return ret;
+}
+
+int
+unw_is_plt_entry (unw_cursor_t *uc)
+{
+	return _is_plt_entry (&((struct cursor *)uc)->dwarf);
 }
 
 int
@@ -139,7 +145,7 @@ unw_step (unw_cursor_t *cursor)
               return 0;
             }
         }
-      else if (is_plt_entry (&c->dwarf))
+      else if (_is_plt_entry (&c->dwarf))
         {
           /* Like regular frame, CFA = RSP+8, RA = [CFA-8], no regs saved. */
           Debug (2, "found plt entry\n");

--- a/tests/check-namespace.sh.in
+++ b/tests/check-namespace.sh.in
@@ -143,6 +143,7 @@ check_local_unw_abi () {
     match _UL${plat}_init_local
     match _UL${plat}_init_local2
     match _UL${plat}_init_remote
+    match _UL${plat}_is_plt_entry
     match _UL${plat}_is_signal_frame
     match _UL${plat}_local_addr_space
     match _UL${plat}_resume
@@ -259,6 +260,7 @@ check_generic_unw_abi () {
     match _U${plat}_init_local
     match _U${plat}_init_local2
     match _U${plat}_init_remote
+    match _U${plat}_is_plt_entry
     match _U${plat}_is_signal_frame
     match _U${plat}_local_addr_space
     match _U${plat}_regname

--- a/tests/ppc64-test-plt.c
+++ b/tests/ppc64-test-plt.c
@@ -1,15 +1,30 @@
-/*
+/**
  * Unittest PPC64 is_plt_entry function by inspecting output at
  * different points in a mock PLT address space.
  */
-
+/*
+ * This file is part of libunwind.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 #include "dwarf.h"
 #include "libunwind_i.h"
-
-#undef unw_get_accessors_int
-unw_accessors_t *unw_get_accessors_int (unw_addr_space_t) { return NULL; }
-int dwarf_step (struct dwarf_cursor*) { return 0; }
-#include "ppc64/Gstep.c"
 
 enum
 {
@@ -67,98 +82,100 @@ main ()
   mock_address_space.big_endian = 0;
   mock_address_space.acc.access_mem = &access_mem;
 
-  struct dwarf_cursor c;
-  c.as = &mock_address_space;
-  c.as_arg = &test_instructions;
+  struct cursor cursor;
+  struct dwarf_cursor *dwarf = &cursor.dwarf;
+  struct unw_cursor *c = (struct unw_cursor *)(&cursor);
+  dwarf->as = &mock_address_space;
+  dwarf->as_arg = &test_instructions;
 
   /* ip at std r2,24(r1) */
-  c.ip = (unw_word_t) (test_instructions + ip_std);
-  if (!is_plt_entry(&c)) return -1;
+  dwarf->ip = (unw_word_t) (test_instructions + ip_std);
+  if (!unw_is_plt_entry(c)) return -1;
 
   /* ld uses a different offset */
   test_instructions[ip_ld] = 0xe9820000;
-  if (!is_plt_entry(&c)) return -1;
+  if (!unw_is_plt_entry(c)) return -1;
   memcpy(test_instructions, plt_instructions, sizeof(test_instructions));
 
   /* ip_ld is not a ld instruction */
   test_instructions[ip_ld] = 0xf154f00d;
-  if (is_plt_entry(&c)) return -1;
+  if (unw_is_plt_entry(c)) return -1;
   memcpy(test_instructions, plt_instructions, sizeof(test_instructions));
 
   /* ip_mtctr is not a mtctr instruction */
   test_instructions[ip_mtctr] = 0xf154f00d;
-  if (is_plt_entry(&c)) return -1;
+  if (unw_is_plt_entry(c)) return -1;
   memcpy(test_instructions, plt_instructions, sizeof(test_instructions));
 
   /* ip_bctr is not a bctr instruction */
   test_instructions[ip_bctr] = 0xf154f00d;
-  if (is_plt_entry(&c)) return -1;
+  if (unw_is_plt_entry(c)) return -1;
   memcpy(test_instructions, plt_instructions, sizeof(test_instructions));
 
   /* ip at ld r12,-30928(r2) */
-  c.ip = (unw_word_t) (test_instructions + ip_ld);
-  if (!is_plt_entry(&c)) return -1;
+  dwarf->ip = (unw_word_t) (test_instructions + ip_ld);
+  if (!unw_is_plt_entry(c)) return -1;
 
   /* ip_std is not a std instruction */
   test_instructions[ip_std] = 0xf154f00d;
-  if (is_plt_entry(&c)) return -1;
+  if (unw_is_plt_entry(c)) return -1;
   memcpy(test_instructions, plt_instructions, sizeof(test_instructions));
 
   /* ip_mtctr is not a mtctr instruction */
   test_instructions[ip_mtctr] = 0xf154f00d;
-  if (is_plt_entry(&c)) return -1;
+  if (unw_is_plt_entry(c)) return -1;
   memcpy(test_instructions, plt_instructions, sizeof(test_instructions));
 
   /* ip_bctr is not a bctr instruction */
   test_instructions[ip_bctr] = 0xf154f00d;
-  if (is_plt_entry(&c)) return -1;
+  if (unw_is_plt_entry(c)) return -1;
   memcpy(test_instructions, plt_instructions, sizeof(test_instructions));
 
   /* ip at mtctr r12 */
-  c.ip = (unw_word_t) (test_instructions + ip_mtctr);
-  if (!is_plt_entry(&c)) return -1;
+  dwarf->ip = (unw_word_t) (test_instructions + ip_mtctr);
+  if (!unw_is_plt_entry(c)) return -1;
 
   /* ip_std is not a std instruction */
   test_instructions[ip_std] = 0xf154f00d;
-  if (is_plt_entry(&c)) return -1;
+  if (unw_is_plt_entry(c)) return -1;
   memcpy(test_instructions, plt_instructions, sizeof(test_instructions));
 
   /* ip_ld is not a ld instruction */
   test_instructions[ip_ld] = 0xf154f00d;
-  if (is_plt_entry(&c)) return -1;
+  if (unw_is_plt_entry(c)) return -1;
   memcpy(test_instructions, plt_instructions, sizeof(test_instructions));
 
   /* ip_bctr is not a bctr instruction */
   test_instructions[ip_bctr] = 0xf154f00d;
-  if (is_plt_entry(&c)) return -1;
+  if (unw_is_plt_entry(c)) return -1;
   memcpy(test_instructions, plt_instructions, sizeof(test_instructions));
 
   /* ip at bctr */
-  c.ip = (unw_word_t) (test_instructions + ip_bctr);
-  if (!is_plt_entry(&c)) return -1;
+  dwarf->ip = (unw_word_t) (test_instructions + ip_bctr);
+  if (!unw_is_plt_entry(c)) return -1;
 
   /* ip_std is not a std instruction */
   test_instructions[ip_std] = 0xf154f00d;
-  if (is_plt_entry(&c)) return -1;
+  if (unw_is_plt_entry(c)) return -1;
   memcpy(test_instructions, plt_instructions, sizeof(test_instructions));
 
   /* ip_ld is not a ld instruction */
   test_instructions[ip_ld] = 0xf154f00d;
-  if (is_plt_entry(&c)) return -1;
+  if (unw_is_plt_entry(c)) return -1;
   memcpy(test_instructions, plt_instructions, sizeof(test_instructions));
 
   /* ip_mtctr is not a mtctr instruction */
   test_instructions[ip_mtctr] = 0xf154f00d;
-  if (is_plt_entry(&c)) return -1;
+  if (unw_is_plt_entry(c)) return -1;
   memcpy(test_instructions, plt_instructions, sizeof(test_instructions));
 
   /* ip at non-PLT instruction */
-  c.ip = (unw_word_t) (test_instructions + ip_guard0);
-  if (is_plt_entry(&c)) return -1;
+  dwarf->ip = (unw_word_t) (test_instructions + ip_guard0);
+  if (unw_is_plt_entry(c)) return -1;
 
   /* ip at another non-PLT instruction */
-  c.ip = (unw_word_t) (test_instructions + ip_guard1);
-  if (is_plt_entry(&c)) return -1;
+  dwarf->ip = (unw_word_t) (test_instructions + ip_guard1);
+  if (unw_is_plt_entry(c)) return -1;
 
   return 0;
 }


### PR DESCRIPTION
Moved this function into the public API. Adjusted unit tests accordingly.

Based on 9fd5fe66ff247461cf86557622e619a502e8d103 on master.

Closes #752 