### PR TITLE
Fix unw_backtrace2() missing frames sometimes.

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -50,7 +50,7 @@ jobs:
           autoreconf -i
           mkdir build
           cd build
-          ../configure --build=x86_64-pc-linux-gnu --host=${{ matrix.target.triple }}
+          ../configure --build=x86_64-pc-linux-gnu --host=${{ matrix.target.triple }} --enable-debug
         env:
           CC: ${{ matrix.toolchain.CC }}
           CXX: ${{ matrix.toolchain.CXX }}
@@ -74,6 +74,8 @@ jobs:
           sudo bash -c 'echo core.%p.%p > /proc/sys/kernel/core_pattern'
           ulimit -c unlimited
           make -C build check -j8
+        env:
+          UNW_DEBUG_LEVEL: 4
 
       - name: Show Logs
         if: ${{ failure() }}

--- a/src/aarch64/Gtrace.c
+++ b/src/aarch64/Gtrace.c
@@ -505,6 +505,8 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       else
         {
           /* Cached frame has no LR and neither do we. */
+          Debug (1, "returning -UNW_ESTOPUNWIND, depth %d\n", depth);
+          *size = depth;
           return -UNW_ESTOPUNWIND;
         }
       if (likely(ret >= 0) && likely(f->fp_cfa_offset != -1))
@@ -542,6 +544,8 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       /* We cannot trace through this frame, give up and tell the
           caller we had to stop.  Data collected so far may still be
           useful to the caller, so let it know how far we got.  */
+	  Debug (1, "returning -UNW_ESTOPUNWIND, depth %d\n", depth);
+	  *size = depth;
       ret = -UNW_ESTOPUNWIND;
       break;
     }
@@ -557,9 +561,7 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
     buffer[depth++] = (void *) (pc - d->use_prev_instr);
   }
 
-#if UNW_DEBUG
   Debug (1, "returning %d, depth %d\n", ret, depth);
-#endif
   *size = depth;
   return ret;
 }

--- a/src/x86_64/Gtrace.c
+++ b/src/x86_64/Gtrace.c
@@ -538,7 +538,10 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       /* We cannot trace through this frame, give up and tell the
          caller we had to stop.  Data collected so far may still be
          useful to the caller, so let it know how far we got.  */
+      Debug (1, "returning UNW_ESTOPUNWIND, depth %d\n", depth);
+      *size = depth;
       ret = -UNW_ESTOPUNWIND;
+      return ret;
       break;
     }
 
@@ -553,9 +556,7 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
     buffer[depth++] = (void *) rip;
   }
 
-#if UNW_DEBUG
   Debug (1, "returning %d, depth %d\n", ret, depth);
-#endif
   *size = depth;
   return ret;
 }


### PR DESCRIPTION
The function `unw_backtrace2()` would sometimes miss frames. This was exacerbated by `tdep_trace()` not retuning the count of frames already handled when it encounters a failure.

Also rewrote tests/Gtest-trace to (a) add more tests of `unw_backtrace2()`, (2) give more meaningful verbose output for the poor humans trying to figure out why it's failing, and (iii) iterate the signal callback several times to detect cache-related edge cases.

Closes #779 