### PR TITLE
Fix all occurrences of returning -UNW_ESTOPUNWIND

### DIFF
--- a/src/aarch64/Gtrace.c
+++ b/src/aarch64/Gtrace.c
@@ -544,10 +544,9 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       /* We cannot trace through this frame, give up and tell the
           caller we had to stop.  Data collected so far may still be
           useful to the caller, so let it know how far we got.  */
-	  Debug (1, "returning -UNW_ESTOPUNWIND, depth %d\n", depth);
-	  *size = depth;
-      ret = -UNW_ESTOPUNWIND;
-      break;
+      Debug (1, "returning -UNW_ESTOPUNWIND, depth %d\n", depth);
+      *size = depth;
+      return -UNW_ESTOPUNWIND;
     }
 
     Debug (4, "new cfa 0x%lx pc 0x%lx sp 0x%lx fp 0x%lx\n",

--- a/src/arm/Gtrace.c
+++ b/src/arm/Gtrace.c
@@ -533,8 +533,9 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       /* We cannot trace through this frame, give up and tell the
           caller we had to stop.  Data collected so far may still be
           useful to the caller, so let it know how far we got.  */
-      ret = -UNW_ESTOPUNWIND;
-      break;
+      Debug (1, "returning UNW_ESTOPUNWIND, depth %d\n", depth);
+      *size = depth;
+      return -UNW_ESTOPUNWIND;
     }
 
     Debug (4, "new cfa 0x%x pc 0x%x sp 0x%x r7 0x%x\n",

--- a/src/x86_64/Gtrace.c
+++ b/src/x86_64/Gtrace.c
@@ -540,9 +540,7 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
          useful to the caller, so let it know how far we got.  */
       Debug (1, "returning UNW_ESTOPUNWIND, depth %d\n", depth);
       *size = depth;
-      ret = -UNW_ESTOPUNWIND;
-      return ret;
-      break;
+      return -UNW_ESTOPUNWIND;
     }
 
     Debug (4, "new cfa 0x%lx rip 0x%lx rsp 0x%lx rbp 0x%lx\n",


### PR DESCRIPTION
Sometimes `-UNW_ESTOPUNWIND` is returned with a wrong `*size`. Although https://github.com/libunwind/libunwind/pull/780 tried to fix it, the `ret = ...; break;` is not enough (`break` only jumps out of `switch`). Therefore this PR replaces them with necessary `return` statements.

Also fix it on the `arm` platform.