### PR TITLE
add Fix of ELFW in find_build_id_path

### DIFF
--- a/src/elfxx.c
+++ b/src/elfxx.c
@@ -819,10 +819,10 @@ elf_w (find_build_id_path) (const struct elf_image *ei, char *path, unsigned pat
           const char prefix[] = "/usr/lib/debug/.build-id/";
 
           /* See "man 5 elf" for notes about alignment in Nhdr */
-          const Elf_W(Nhdr) *nhdr = (const ElfW(Nhdr) *) notes;
-          const ElfW(Word) namesz = nhdr->n_namesz;
-          const ElfW(Word) descsz = nhdr->n_descsz;
-          const ElfW(Word) nameasz = UNW_ALIGN(namesz, 4); /* Aligned size */
+          const Elf_W(Nhdr) *nhdr = (const Elf_W(Nhdr) *) notes;
+          const Elf_W(Word) namesz = nhdr->n_namesz;
+          const Elf_W(Word) descsz = nhdr->n_descsz;
+          const Elf_W(Word) nameasz = UNW_ALIGN(namesz, 4); /* Aligned size */
           const char *name = (const char *) (nhdr + 1);
           const uint8_t *desc = (const uint8_t *) name + nameasz;
           unsigned j;


### PR DESCRIPTION
There is ELFW in find_build_id_path but I did't find any definition of ElfW, thus I think it is a legacy naming convention.

I have test on Ubuntu 22.04, and
```c
#if defined(ELF_NOTE_GNU) && defined(NT_GNU_BILD_ID)
```
will return false, which cause the gcc emits no error. I think GCC disable generating build-id in default.