### PR TITLE
Fix crash when decompressing MiniDebugInfo section

### DIFF
--- a/src/elfxx.c
+++ b/src/elfxx.c
@@ -534,6 +534,7 @@ elf_w (extract_minidebuginfo) (struct elf_image *ei, struct elf_image *mdi)
     .free   = xz_free,
     .opaque = &allocator_data
   };
+  memset (&allocator_data, 0, sizeof(allocator_data));
 
   shdr = elf_w (find_section) (ei, ".gnu_debugdata");
   if (!shdr)


### PR DESCRIPTION
Libunwind may crash when decompressing the MiniDebugInfo section (.gnu_debugdata). The reason is that `allocator_data` in `extract_minidebuginfo` (in `elfxx.c`) is uninitialized.

main.c:
-------

```
void show_backtrace (void) {
    unw_cursor_t cursor; unw_context_t uc;
    unw_word_t ip, sp;

    unw_getcontext(&uc);
    unw_init_local(&cursor, &uc);
    while (unw_step(&cursor) > 0) {
        char buf[1024] = {0};
        if (unw_get_proc_name(&cursor, buf, 1024, NULL) != 0) {
            printf("ERROR\n");
            return;
        }
        printf("%s\n", buf);
    }
}

int main() {
    show_backtrace();
}
```

build.sh:
---------

```
gcc main.c -lunwind -lunwind-x86_64 -fsanitize=address
dd if=/dev/urandom bs=1M count=1 | xz -z > minidebug.xz
rm minidebug
cp a.out minidebug
objcopy --add-section .gnu_debugdata=minidebug.xz minidebug
```

Instructions
------------

Build libunwind with options `CFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address`

Run the following

```
ASAN_OPTIONS=detect_odr_violation=0
LD_LIBRARY_PATH=/path/to/libunwind/.libs ./minidebug
```

You will hopefully see a segfault within `xz_alloc`.