### PR TITLE
Fix crash when reading ELF files with invalid program segment pointers

### DIFF
--- a/src/elfxx.c
+++ b/src/elfxx.c
@@ -142,7 +142,7 @@ elf_w (lookup_symbol_from_dynamic) (unw_addr_space_t as UNUSED,
       }
     else if (phdr[i].p_type == PT_DYNAMIC)
       {
-        dyn = (Elf_W (Dyn) *) ((char *)ei->image + phdr[i].p_offset);
+        dyn = (Elf_W (Dyn) *) elf_w (get_program_segment) (ei, &phdr[i], NULL);
         break;
       }
 
@@ -811,8 +811,7 @@ elf_w (find_build_id_path) (const struct elf_image *ei, char *path, unsigned pat
       if (phdr->p_type != PT_NOTE)
         continue;
 
-      notes = ((const uint8_t *) ehdr) + phdr->p_offset;
-      notes_end = notes + phdr->p_memsz;
+      notes = elf_w (get_program_segment) (ei, phdr, &notes_end);
 
       while(notes < notes_end)
         {

--- a/src/elfxx.h
+++ b/src/elfxx.h
@@ -110,3 +110,21 @@ elf_map_image (struct elf_image *ei, const char *path)
 
   return 0;
 }
+
+static inline const uint8_t* elf_w (get_program_segment) (const struct elf_image *ei,
+  const Elf_W (Phdr) *phdr, const uint8_t** end)
+{
+  const uint8_t* result = NULL;
+
+  if (end)
+    *end = NULL;
+
+  if (!ei || !ei->image || !phdr || phdr->p_filesz == 0 || phdr->p_offset > ei->size)
+    return NULL;
+
+  result = ((const uint8_t*)ei->image) + phdr->p_offset;
+  if (end)
+    *end = result + phdr->p_filesz;
+
+  return result;
+}


### PR DESCRIPTION
In some cases, an ELF file could contain program headers with empty segments but non-null offsets (they have p_filesz = 0 but p_offset != 0).

The case that triggered this change is libcap.so.2.48 on Amazon Linux 2023,

```
Name         : libcap
Version      : 2.48
Release      : 2.amzn2023.0.3
Architecture : aarch64
Size         : 1.4 M
Source       : libcap-2.48-2.amzn2023.0.3.src.rpm
```

In this binary, there is a `.gnu_debugdata` section. We can extract that with objcopy and then run `readelf -l` on it to see the program headers:

```
cp /usr/lib64/libcap.so.2.48 .
objcopy --dump-section .gnu_debugdata=minidebuginfo_objcopy.xz
libcap.so.2.48
xz -d minidebuginfo_objcopy.xz
readelf -l minidebuginfo_objcopy
```

Note that the size of the file `minidebuginfo_objcopy` is 5608 bytes.

```
Elf file type is DYN (Shared object file)
Entry point 0x0
There are 11 program headers, starting at offset 64

Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
LOAD           0x0000000000000000 0x0000000000000000 0x0000000000000000
               0x0000000000000380 0x0000000000001fc8  R      0x10000
LOAD           0x0000000000000000 0x0000000000010000 0x0000000000010000
               0x0000000000000000 0x0000000000003d8c  R E    0x10000
LOAD           0x0000000000000000 0x0000000000020000 0x0000000000020000
               0x0000000000000000 0x0000000000001414  R      0x10000
LOAD           0x000000000000fa58 0x000000000003fa58 0x000000000003fa58
               0x0000000000000000 0x00000000000005e0  RW     0x10000
DYNAMIC        0x000000000000fa58 0x000000000003fbc8 0x000000000003fbc8
               0x0000000000000000 0x0000000000000210  RW     0x8
NOTE           0x00000000000002a8 0x00000000000002a8 0x00000000000002a8
               0x0000000000000020 0x0000000000000020  R      0x8
NOTE           0x00000000000002c8 0x00000000000002c8 0x00000000000002c8
               0x00000000000000b8 0x00000000000000b8  R      0x4
GNU_PROPERTY   0x00000000000002a8 0x00000000000002a8 0x00000000000002a8
               0x0000000000000020 0x0000000000000020  R      0x8
GNU_EH_FRAME   0x0000000000010000 0x0000000000020380 0x0000000000020380
               0x0000000000000000 0x000000000000027c  R      0x4
GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
               0x0000000000000000 0x0000000000000000  RW     0x10
GNU_RELRO      0x000000000000fa58 0x000000000003fa58 0x000000000003fa58
               0x0000000000000000 0x00000000000005a8  R      0x1
```

Here we see that some segments are listed as starting at an offset greater than the file size, e.g. the `DYNAMIC` segment, whose offset is `0x000000000000fa58 == 64088`. Note, however, that these segments have a size of 0.

Note further that this is not the same offset as the `DYNAMIC` segment in the outer library `libcap`:

```
DYNAMIC        0x000000000002fbc8 0x000000000003fbc8 0x000000000003fbc8
               0x0000000000000210 0x0000000000000210  RW     0x8
```

so where this number comes from is unknown. Either way, the segment size in the file is 0, so we should never try to read from it.

---

This change introduces a new function `get_program_segment` that can be used to obtain a pointer to the segment within the image for a given program header. If the program header specifies a zero size segment, NULL is returned. Using this function to dereference program segments instead of doing so directly avoids crashes in such cases.

There is also a slight change in behaviour in the `find_build_id_path` function - it was using `p_memsz` field of the program header to find the end of the notes section, but I also believe this to be incorrect and it should be using the `p_filesz` field. Probably benign in most cases but in general the memory size could be larger than the file size, so this error could lead to reading past the end of the image buffer.