### PR TITLE
Support `-mbranch-protection=pac-ret` on aarch64

### DIFF
--- a/include/libunwind-ptrace.h
+++ b/include/libunwind-ptrace.h
@@ -56,6 +56,7 @@ extern int _UPT_get_proc_name (unw_addr_space_t, unw_word_t, char *, size_t,
 extern int _UPT_get_elf_filename (unw_addr_space_t, unw_word_t, char *, size_t,
                                   unw_word_t *, void *);
 extern int _UPT_resume (unw_addr_space_t, unw_cursor_t *, void *);
+extern unw_word_t _UPT_ptrauth_insn_mask (unw_addr_space_t, void *);
 extern unw_accessors_t _UPT_accessors;
 
 

--- a/include/tdep-aarch64/libunwind_i.h
+++ b/include/tdep-aarch64/libunwind_i.h
@@ -293,6 +293,7 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
 #define tdep_reuse_frame(c,frame)       do {} while(0)
 #define tdep_stash_frame                UNW_OBJ(tdep_stash_frame)
 #define tdep_trace                      UNW_OBJ(tdep_trace)
+#define tdep_strip_ptrauth_insn_mask    UNW_OBJ(tdep_strip_ptrauth_insn_mask)
 
 #ifdef UNW_LOCAL_ONLY
 # define tdep_find_proc_info(c,ip,n)                            \
@@ -332,5 +333,6 @@ extern int tdep_trace (unw_cursor_t *cursor, void **addresses, int *n);
 extern void tdep_stash_frame (struct dwarf_cursor *c,
                               struct dwarf_reg_state *rs);
 extern int tdep_getcontext_trace (unw_context_t *);
+extern unw_word_t tdep_strip_ptrauth_insn_mask (unw_cursor_t *cursor, unw_word_t ip);
 
 #endif /* AARCH64_LIBUNWIND_I_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,7 @@ SET(libunwind_ptrace_la_SOURCES
     ptrace/_UPT_find_proc_info.c ptrace/_UPT_get_dyn_info_list_addr.c
     ptrace/_UPT_put_unwind_info.c ptrace/_UPT_get_proc_name.c
     ptrace/_UPT_reg_offset.c ptrace/_UPT_resume.c
-    ptrace/_UPT_get_elf_filename.c
+    ptrace/_UPT_get_elf_filename.c ptrace/_UPT_ptrauth_insn_mask.c
 )
 
 SET(libunwind_coredump_la_SOURCES
@@ -202,7 +202,7 @@ SET(libunwind_la_SOURCES_aarch64
     aarch64/Linit_local.c aarch64/Linit_remote.c
     aarch64/Lis_signal_frame.c aarch64/Lregs.c aarch64/Lresume.c
     aarch64/Lstash_frame.c aarch64/Lstep.c aarch64/Ltrace.c
-    aarch64/getcontext.S
+    aarch64/Lstrip_ptrauth_insn_mask.c aarch64/getcontext.S
 )
 
 SET(libunwind_aarch64_la_SOURCES_aarch64
@@ -214,6 +214,7 @@ SET(libunwind_aarch64_la_SOURCES_aarch64
     aarch64/Ginit_local.c aarch64/Ginit_remote.c
     aarch64/Gis_signal_frame.c aarch64/Gregs.c aarch64/Gresume.c
     aarch64/Gstash_frame.c aarch64/Gstep.c aarch64/Gtrace.c
+    aarch64/Gstrip_ptrauth_insn_mask.c
 )
 
 # The list of files that go into libunwind and libunwind-arm:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -201,7 +201,8 @@ libunwind_ptrace_la_SOURCES =                  \
 	ptrace/_UPT_get_elf_filename.c         \
 	ptrace/_UPT_put_unwind_info.c          \
 	ptrace/_UPT_reg_offset.c               \
-	ptrace/_UPT_resume.c
+	ptrace/_UPT_resume.c                   \
+	ptrace/_UPT_ptrauth_insn_mask.c
 libunwind_ptrace_la_LIBADD =                   \
 	libunwind-$(arch).la                   \
 	$(LIBLZMA) $(LIBZ)
@@ -436,7 +437,8 @@ libunwind_la_SOURCES =                         \
 	aarch64/Lresume.c                      \
 	aarch64/Lstash_frame.c                 \
 	aarch64/Lstep.c                        \
-	aarch64/Ltrace.c
+	aarch64/Ltrace.c                       \
+	aarch64/Lstrip_ptrauth_insn_mask.c
 
 libunwind_setjmp_la_SOURCES +=                 \
 	aarch64/longjmp.S                      \
@@ -461,7 +463,8 @@ libunwind_aarch64_la_SOURCES =                 \
 	aarch64/Gresume.c                      \
 	aarch64/Gstash_frame.c                 \
 	aarch64/Gstep.c                        \
-	aarch64/Gtrace.c
+	aarch64/Gtrace.c                       \
+	aarch64/Gstrip_ptrauth_insn_mask.c
 libunwind_aarch64_la_LDFLAGS =                 \
 	$(COMMON_SO_LDFLAGS)                   \
 	-version-info $(SOVERSION)

--- a/src/aarch64/Gregs.c
+++ b/src/aarch64/Gregs.c
@@ -142,7 +142,14 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
   if (write)
     return dwarf_put (&c->dwarf, loc, *valp);
   else
-    return dwarf_get (&c->dwarf, loc, valp);
+    {
+      int ret = dwarf_get (&c->dwarf, loc, valp);
+      if (reg == UNW_AARCH64_X30)
+        {
+          *valp = tdep_strip_ptrauth_insn_mask((unw_cursor_t*)c, *valp);
+        }
+      return ret;
+    }
 }
 
 HIDDEN int

--- a/src/aarch64/Gstrip_ptrauth_insn_mask.c
+++ b/src/aarch64/Gstrip_ptrauth_insn_mask.c
@@ -1,0 +1,81 @@
+/* libunwind - a platform-independent unwind library
+
+This file is part of libunwind.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#include "unwind_i.h"
+
+static unw_word_t aarch64_strip_pac_remote (unw_accessors_t *a, unw_addr_space_t as, void *arg, unw_word_t old_ip)
+{
+  if (a->ptrauth_insn_mask)
+    {
+      unw_word_t ip, insn_mask;
+
+      insn_mask = a->ptrauth_insn_mask (as, arg);
+      ip = old_ip & (~insn_mask);
+
+      Debug (15, "stripping pac from address, before: %lx, after: %lx\n", old_ip, ip);
+      return ip;
+    }
+  else
+    {
+      Debug (15, "return address %lx might be signed, but no means to obtain mask\n", old_ip);
+      return old_ip;
+    }
+}
+
+static unw_word_t aarch64_strip_pac_local (unw_word_t in_addr)
+{
+  unw_word_t out_addr = in_addr;
+
+#if defined(__aarch64__) && !defined(UNW_REMOTE_ONLY)
+  // Strip the PAC with XPACLRI instruction
+  register unsigned long long x30 __asm__("x30") = in_addr;
+  __asm__("hint 0x7" : "+r" (x30));
+  out_addr = x30;
+#endif
+
+  return out_addr;
+}
+
+HIDDEN unw_word_t tdep_strip_ptrauth_insn_mask (unw_cursor_t *cursor, unw_word_t ip)
+{
+  struct cursor *c = (struct cursor *) cursor;
+  struct dwarf_cursor *d = &c->dwarf;
+  unw_addr_space_t as = d->as;
+  void *as_arg = d->as_arg;
+  unw_accessors_t *a;
+  unw_word_t stripped;
+
+  if (as != unw_local_addr_space)
+    {
+      a = unw_get_accessors_int (as);
+      stripped = aarch64_strip_pac_remote (a, as, as_arg, ip);
+    }
+  else
+    {
+      stripped = aarch64_strip_pac_local (ip);
+    }
+
+  Debug (16, "stripped PAC; oldip=0x%lx ip=0x%lx\n", ip, stripped);
+
+  return stripped;
+}

--- a/src/aarch64/Gtrace.c
+++ b/src/aarch64/Gtrace.c
@@ -495,6 +495,8 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       if (likely(f->lr_cfa_offset != -1))
         {
           ACCESS_MEM_FAST(ret, c->validate, d, cfa + f->lr_cfa_offset, pc);
+          if (likely(ret >= 0))
+            pc = tdep_strip_ptrauth_insn_mask(cursor, pc);
         }
       else if (lr != 0)
         {
@@ -524,7 +526,10 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
 
       ACCESS_MEM_FAST(ret, c->validate, d, cfa + SC_PC_OFF, pc);
       if (likely(ret >= 0))
-        ACCESS_MEM_FAST(ret, c->validate, d, cfa + SC_X29_OFF, fp);
+        {
+          pc = tdep_strip_ptrauth_insn_mask(cursor, pc);
+          ACCESS_MEM_FAST(ret, c->validate, d, cfa + SC_X29_OFF, fp);
+        }
       if (likely(ret >= 0))
         ACCESS_MEM_FAST(ret, c->validate, d, cfa + SC_SP_OFF, sp);
       /* Save the link register here in case we end up in a function that

--- a/src/aarch64/Lstrip_ptrauth_insn_mask.c
+++ b/src/aarch64/Lstrip_ptrauth_insn_mask.c
@@ -1,0 +1,5 @@
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
+#if defined(UNW_LOCAL_ONLY) && !defined(UNW_REMOTE_ONLY)
+#include "Gstrip_ptrauth_insn_mask.c"
+#endif

--- a/src/ptrace/_UPT_accessors.c
+++ b/src/ptrace/_UPT_accessors.c
@@ -35,5 +35,6 @@ unw_accessors_t _UPT_accessors =
     .access_fpreg               = _UPT_access_fpreg,
     .resume                     = _UPT_resume,
     .get_proc_name              = _UPT_get_proc_name,
-    .get_elf_filename           = _UPT_get_elf_filename
+    .get_elf_filename           = _UPT_get_elf_filename,
+    .ptrauth_insn_mask          = _UPT_ptrauth_insn_mask
   };

--- a/src/ptrace/_UPT_ptrauth_insn_mask.c
+++ b/src/ptrace/_UPT_ptrauth_insn_mask.c
@@ -1,0 +1,57 @@
+/*
+* This file is part of libunwind.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "_UPT_internal.h"
+
+#ifdef UNW_TARGET_AARCH64
+
+unw_word_t _UPT_ptrauth_insn_mask (UNUSED unw_addr_space_t as, void *arg)
+{
+  struct UPT_info *ui = arg;
+  pid_t pid = ui->pid;
+  int ret;
+  struct iovec iovec;
+  uint64_t regset[2] = {0, 0};
+
+  iovec.iov_base = &regset;
+  iovec.iov_len = sizeof (regset);
+
+  ret = ptrace (PTRACE_GETREGSET, pid, NT_ARM_PAC_MASK, &iovec);
+  if (ret != 0)
+    {
+      Debug (12, "Failed to fetch ptrauth instruction mask");
+      return 0;
+    }
+
+  // regset[0] => data_mask
+  // regset[1] => insn_mask
+  return regset[1];
+}
+
+#else
+
+unw_word_t _UPT_ptrauth_insn_mask (unw_addr_space_t, void *)
+{
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
- Support for pac-ret on aarch64 existed partially before inside the DWARF parser but this needed applying elsewhere in the code
- Move PAC mask stripping functions to be accessible from more places and rename to `tdep_ptrauth_insn_mask` for consistency with the corresponding accessor function
- Apply PAC stripping in appropriate places
- Add ptrace accessor function implementation for `ptrauth_insn_mask`
- make check is now passing on aarch64 when compiled with `CFLAGS="-mbranch-protection=standard"`
- There is an extra function in the ptrace library ABI now (`_UPT_ptrauth_insn_mask`) but there are also some other ABI changes reported by libabigail / `make abi-check` that are unrelated to this change, so I am not sure whether to proceed with updating the .abi files or not

Closes #647