### PR TITLE
fix src/dl_iterate_phdr.c, return correct data

### DIFF
--- a/src/dl-iterate-phdr.c
+++ b/src/dl-iterate-phdr.c
@@ -79,6 +79,8 @@ dl_iterate_phdr (unw_iterate_phdr_callback_t callback,
           info.dlpi_phnum = ehdr->e_phnum;
 
           rc = callback (&info, sizeof (info), data);
+          if (rc)
+            break;
         }
     }
 


### PR DESCRIPTION
Like dl_iterate_phdr in glibc, we should return data when found table in callback. Is it right ?

If it was not a bug, ignore this pull request please.