### PR TITLE
[Debugging] Do not fallback to slow_backtrace when tdep_trace stops unwinding

### DIFF
--- a/src/mi/backtrace.c
+++ b/src/mi/backtrace.c
@@ -67,7 +67,8 @@ unw_backtrace (void **buffer, int size)
   if (unlikely (unw_init_local (&cursor, &uc) < 0))
     return 0;
 
-  if (unlikely (tdep_trace (&cursor, buffer, &n) < 0))
+  int ret = tdep_trace (&cursor, buffer, &n);
+  if (unlikely (ret < 0 && ret != -UNW_ESTOPUNWIND))
     {
       unw_getcontext (&uc);
       return slow_backtrace (buffer, size, &uc, 0);
@@ -108,7 +109,8 @@ unw_backtrace2 (void **buffer, int size, unw_context_t* uc2, int flag)
 
   // returns the number of frames collected by tdep_trace or slow_backtrace
   // and add 1 to it (the one we retrieved above)
-  if (unlikely (tdep_trace (&cursor, buffer, &n) < 0))
+  int ret = tdep_trace (&cursor, buffer, &n);
+  if (unlikely (ret < 0 && ret != -UNW_ESTOPUNWIND))
     {
       return slow_backtrace (buffer, remaining_size, &uc, flag) + 1;
     }


### PR DESCRIPTION
On an aarch64 system tdep_trace was returning `-UNW_ESTOPUNWIND` a lot while profiling a Qt 6 / QML application with heaptrack. I have not understood why exactly, but note that QML injects JIT frames and more, which potentially lead to such failures?

Without the patch here, unwinding became excessively slow because the `slow_backtrace` fallback continuously called `tdep_get_elf_image` which is extremely slow for applications with many entries in their `/proc/<pid>/maps` file.

With the patch here applied, I could use heaptrack again with the expected bearable overhead. The backtraces still look fine, so for me this patch here looks like a good workaround.