### PR TITLE
Read link register from context when unwinding on arm and aarch64

### DIFF
--- a/src/aarch64/Gis_signal_frame.c
+++ b/src/aarch64/Gis_signal_frame.c
@@ -73,6 +73,8 @@ unw_is_signal_frame (unw_cursor_t *cursor)
   arg = c->dwarf.as_arg;
 
   ip = c->dwarf.ip;
+  if (unlikely(!ip))
+    return 0;
 
   ret = (*a->access_mem) (as, ip, &w0, 0, arg);
   if (ret < 0)

--- a/src/aarch64/Gtrace.c
+++ b/src/aarch64/Gtrace.c
@@ -412,7 +412,7 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
   struct cursor *c = (struct cursor *) cursor;
   struct dwarf_cursor *d = &c->dwarf;
   unw_trace_cache_t *cache;
-  unw_word_t fp, sp, pc, cfa, lr;
+  unw_word_t fp, sp, pc, cfa, lr = 0;
   int maxdepth = 0;
   int depth = 0;
   int ret;
@@ -431,11 +431,6 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
   pc = d->ip;
   sp = cfa = d->cfa;
   ACCESS_MEM_FAST(ret, 0, d, DWARF_GET_LOC(d->loc[UNW_AARCH64_X29]), fp);
-  assert(ret == 0);
-
-  /* In case of unwinding from ucontext_t, we can look at the link
-     register value. */
-  ACCESS_MEM_FAST(ret, 0, d, DWARF_GET_LOC(d->loc[UNW_AARCH64_X30]), lr);
   assert(ret == 0);
 
   /* Get frame cache. */

--- a/src/aarch64/Gtrace.c
+++ b/src/aarch64/Gtrace.c
@@ -250,6 +250,12 @@ trace_init_addr (unw_tdep_frame_t *f,
       && likely(dwarf_put (d, d->loc[UNW_AARCH64_PC], pc) >= 0)
       && likely((ret = unw_step (cursor)) >= 0))
     *f = c->frame_info;
+  #if defined (__QNX__)
+    if (unw_is_signal_frame (cursor))
+      {
+        return NULL;
+      }
+  #endif
 
   /* If unw_step() stopped voluntarily, remember that, even if it
      otherwise could not determine anything useful.  This avoids

--- a/src/arm/Gtrace.c
+++ b/src/arm/Gtrace.c
@@ -423,7 +423,11 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
   sp = cfa = d->cfa;
   ACCESS_MEM_FAST(ret, 0, d, DWARF_GET_LOC(d->loc[UNW_ARM_R7]), r7);
   assert(ret == 0);
-  lr = 0;
+
+  /* In case of unwinding from ucontext_t, we can look at the link
+     register value. On ARM, the register R14 acts as the link register */
+  ACCESS_MEM_FAST(ret, 0, d, DWARF_GET_LOC(d->loc[UNW_ARM_R14]), lr);
+  assert(ret == 0);
 
   /* Get frame cache. */
   if (unlikely(! (cache = trace_cache_get())))
@@ -441,7 +445,7 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
   while (depth < maxdepth)
   {
     pc -= d->use_prev_instr;
-    Debug (2, "depth %d cfa 0x%x pc 0x%x sp 0x%x r7 0x%x\n",
+    Debug (2, "depth %d cfa 0x%x pc 0x%x sp 0x%x r7 0x%x lr 0x%lx\n",
            depth, cfa, pc, sp, r7);
 
     /* See if we have this address cached.  If not, evaluate enough of
@@ -488,6 +492,7 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       else if (lr != 0)
       {
         /* Use the saved link register as the new pc. */
+        Debug(4, "use link register value 0x%lx as the new pc\n", lr);
         pc = lr;
         lr = 0;
       }
@@ -513,6 +518,10 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
          doesn't save the link register in the prologue, e.g. kill. */
       if (likely(ret >= 0))
         ACCESS_MEM_FAST(ret, c->validate, d, cfa + LINUX_SC_LR_OFF, lr);
+
+      Debug(4, "signal frame cfa 0x%lx pc 0x%lx r7 0x%lx sp 0x%lx lr 0x%lx\n",
+            cfa, pc, r7, sp, lr);
+
 #elif defined(__FreeBSD__)
       Dprintf ("%s: implement me\n", __FUNCTION__);
       ret = -UNW_ESTOPUNWIND;
@@ -540,8 +549,8 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       return -UNW_ESTOPUNWIND;
     }
 
-    Debug (4, "new cfa 0x%x pc 0x%x sp 0x%x r7 0x%x\n",
-           cfa, pc, sp, r7);
+    Debug (4, "new cfa 0x%x pc 0x%x sp 0x%x r7 0x%x lr 0x%lx\n",
+           cfa, pc, sp, r7, lr);
 
     /* If we failed or ended up somewhere bogus, stop. */
     if (unlikely(ret < 0 || pc < 0x4000))

--- a/src/arm/Gtrace.c
+++ b/src/arm/Gtrace.c
@@ -251,12 +251,6 @@ trace_init_addr (unw_tdep_frame_t *f,
       && likely(dwarf_put (d, d->loc[UNW_ARM_R15], pc) >= 0)
       && likely((ret = unw_step (cursor)) >= 0))
     *f = c->frame_info;
-  #if defined (__QNX__)
-    if (unw_is_signal_frame (cursor))
-      {
-        return NULL;
-      }
-  #endif
 
   /* If unw_step() stopped voluntarily, remember that, even if it
      otherwise could not determine anything useful.  This avoids

--- a/src/arm/Gtrace.c
+++ b/src/arm/Gtrace.c
@@ -251,6 +251,12 @@ trace_init_addr (unw_tdep_frame_t *f,
       && likely(dwarf_put (d, d->loc[UNW_ARM_R15], pc) >= 0)
       && likely((ret = unw_step (cursor)) >= 0))
     *f = c->frame_info;
+  #if defined (__QNX__)
+    if (unw_is_signal_frame (cursor))
+      {
+        return NULL;
+      }
+  #endif
 
   /* If unw_step() stopped voluntarily, remember that, even if it
      otherwise could not determine anything useful.  This avoids


### PR DESCRIPTION
This [PR](https://github.com/libunwind/libunwind/pull/775) prevents `unw_bactrace` family functions to unwind using the slow path if the fast path had to stop (return `-UNW_ESTOPUNWIND`)

One of the bugs exposed by this PR is that unwinding from the context fails on aarch64. The tests in question are in `Gtest-trace.c`.

In an implicit case, the unwinding goes from the current frame, pass through the signal frame until we reached the end. When handling the signal frame, we read from the `link register` for the return value. The next frame is a standard one, and we use the `link register` value (in the `lr` variable) to set the `pc` and continue unwinding.
As shown  below, you can see that when handling the signal frame (`type -1`) we extract the `link register` value (`0x5500000f30`) and it's used in the next frame handling as the new `cp`.

``` showLineNumbers 
 >unw_init_local_common: (cursor=0x5503011a78)
 >uc_addr: Accessing VG register from context is not supported
 >_ULaarch64_tdep_trace: begin ip 0x55000013e0 cfa 0x5503012a20
  >_ULaarch64_tdep_trace: depth 0 cfa 0x5503012a20 pc 0x55000013df sp 0x5503012a20 fp 0x5503012a20, lr 0
    >trace_lookup: found address after 0 steps
   >_ULaarch64_tdep_trace: frame va 55000013df type -2 last 0 cfa sp+112 fp @ cfa-112 lr @ cfa-104 sp @ cfa+0
    >_ULaarch64_tdep_trace: new cfa 0x5503012a90 pc 0x5500001a54 sp 0x5503012a90 fp 0x5503012a90 lr 0x0
  >_ULaarch64_tdep_trace: depth 1 cfa 0x5503012a90 pc 0x5500001a53 sp 0x5503012a90 fp 0x5503012a90, lr 0
    >trace_lookup: found address after 0 steps
   >_ULaarch64_tdep_trace: frame va 5500001a53 type -2 last 0 cfa sp+48 fp @ cfa-48 lr @ cfa-40 sp @ cfa+0
    >_ULaarch64_tdep_trace: new cfa 0x5503012ac0 pc 0x5503053000 sp 0x5503012ac0 fp 0x5503013d10 lr 0x0
  >_ULaarch64_tdep_trace: depth 2 cfa 0x5503012ac0 pc 0x5503052fff sp 0x5503012ac0 fp 0x5503013d10, lr 0
    >trace_lookup: found address after 0 steps
   >_ULaarch64_tdep_trace: frame va 5503052fff type -1 last 0 cfa sp+304 fp @ cfa-1 lr @ cfa-1 sp @ cfa-1
    >_ULaarch64_tdep_trace: signal frame cfa 5503012bf0 pc 550315a8cc fp 5503013d20 sp 5503013d20 lr 5500000f30 
    >_ULaarch64_tdep_trace: new cfa 0x5503013d20 pc 0x550315a8cc sp 0x5503013d20 fp 0x5503013d20 lr 0x5500000f30
  >_ULaarch64_tdep_trace: depth 3 cfa 0x5503013d20 pc 0x550315a8cc sp 0x5503013d20 fp 0x5503013d20, lr 0x5500000f30
    >trace_lookup: found address after 0 steps
   >_ULaarch64_tdep_trace: frame va 550315a8cc type -2 last 0 cfa sp+0 fp @ cfa-1 lr @ cfa-1 sp @ cfa+0
    >_ULaarch64_tdep_trace: using link register (0x5500000f30) as new pc
    >_ULaarch64_tdep_trace: new cfa 0x5503013d20 pc 0x5500000f30 sp 0x5503013d20 fp 0x5503013d20 lr 0x0
  >_ULaarch64_tdep_trace: depth 4 cfa 0x5503013d20 pc 0x5500000f2f sp 0x5503013d20 fp 0x5503013d20, lr 0
    >trace_lookup: found address after 0 steps
   >_ULaarch64_tdep_trace: frame va 5500000f2f type -2 last 0 cfa sp+288 fp @ cfa-288 lr @ cfa-280 sp @ cfa+0
    >_ULaarch64_tdep_trace: new cfa 0x5503013e40 pc 0x55031473fc sp 0x5503013e40 fp 0x5503013e40 lr 0x0
  >_ULaarch64_tdep_trace: depth 5 cfa 0x5503013e40 pc 0x55031473fb sp 0x5503013e40 fp 0x5503013e40, lr 0
    >trace_lookup: found address after 0 steps
   >_ULaarch64_tdep_trace: frame va 55031473fb type -2 last 0 cfa sp+272 fp @ cfa-272 lr @ cfa-264 sp @ cfa+0
    >_ULaarch64_tdep_trace: new cfa 0x5503013f50 pc 0x55031474cc sp 0x5503013f50 fp 0x5503013f50 lr 0x0
  >_ULaarch64_tdep_trace: depth 6 cfa 0x5503013f50 pc 0x55031474cb sp 0x5503013f50 fp 0x5503013f50, lr 0
    >trace_lookup: found address after 0 steps
   >_ULaarch64_tdep_trace: frame va 55031474cb type -2 last -1 cfa sp+96 fp @ cfa-96 lr @ cfa-88 sp @ cfa+0
 >_ULaarch64_tdep_trace: returning 0, depth 6
```

In the explicit case, the unwinding starts directly from the frame before the signal frame. And the `lr` variable is set to `0`. The unwinding just stops here by returning `-UNW_ESTOPUNWIND`.
```
>unw_init_local_common: (cursor=0x5503011a88)
 >uc_addr: Accessing VG register from context is not supported
 >_ULaarch64_tdep_trace: begin ip 0x550315a8cc cfa 0x5503013d20
  >_ULaarch64_tdep_trace: depth 0 cfa 0x5503013d20 pc 0x550315a8cc sp 0x5503013d20 fp 0x5503013d20, lr 0
    >trace_lookup: found address after 0 steps
   >_ULaarch64_tdep_trace: frame va 550315a8cc type -2 last 0 cfa sp+0 fp @ cfa-1 lr @ cfa-1 sp @ cfa+0
 >_ULaarch64_tdep_trace: returning -UNW_ESTOPUNWIND_Y, depth 0
FAILURE: unw_step() loop and unw_backtrace2() depths differ: 4 vs. 1
```

The fix is to read the `link register` just before starting the unwinding (set `lr` to the value).

## Test

I used the [PR](https://github.com/libunwind/libunwind/pull/775) to validate that it actually works. You can see that `Gtest-trace.c` in [aarch64 cross job is green](https://github.com/DataDog/libunwind/actions/runs/10581800730/job/29319990100?pr=2).
