### PR TITLE
Clean ci warnings & fix some musl `Build` step in various jobs

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -78,6 +78,7 @@ jobs:
           UNW_DEBUG_LEVEL: 4
 
       - name: Show Logs
+        if: ${{ failure() }}
         run: |
           cat build/tests/test-suite.log 2>/dev/null
 

--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -78,7 +78,6 @@ jobs:
           UNW_DEBUG_LEVEL: 4
 
       - name: Show Logs
-        if: ${{ failure() }}
         run: |
           cat build/tests/test-suite.log 2>/dev/null
 

--- a/configure.ac
+++ b/configure.ac
@@ -65,7 +65,7 @@ AC_CHECK_HEADERS(asm/ptrace_offsets.h asm/ptrace.h asm/vsyscall.h endian.h sys/e
 
 dnl Set target-specific compile flags
 AS_CASE([$target_os],
-        [*-gnu|*-gnueabi*], [UNW_TARGET_CPPFLAGS="-D_GNU_SOURCE"],
+        [*-gnu|*-gnueabi*|*-musl], [UNW_TARGET_CPPFLAGS="-D_GNU_SOURCE"],
         [solaris*],         [UNW_TARGET_CPPFLAGS="-D__EXTENSIONS__"]
 )
 AC_SUBST([UNW_TARGET_CPPFLAGS])

--- a/include/tdep-aarch64/libunwind_i.h
+++ b/include/tdep-aarch64/libunwind_i.h
@@ -131,7 +131,7 @@ dwarf_get_uc(const struct dwarf_cursor *cursor)
                                  tdep_uc_addr(dwarf_get_uc(c), (r)), 0))
 
 static inline int
-dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
+dwarf_getfp (struct dwarf_cursor *c UNUSED, dwarf_loc_t loc, unw_fpreg_t *val)
 {
   if (!DWARF_GET_LOC (loc))
     return -1;
@@ -140,7 +140,7 @@ dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
 }
 
 static inline int
-dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
+dwarf_putfp (struct dwarf_cursor *c UNUSED, dwarf_loc_t loc, unw_fpreg_t val)
 {
   if (!DWARF_GET_LOC (loc))
     return -1;
@@ -149,7 +149,7 @@ dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
 }
 
 static inline int
-dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
+dwarf_get (struct dwarf_cursor *c UNUSED, dwarf_loc_t loc, unw_word_t *val)
 {
   if (!DWARF_GET_LOC (loc))
     return -1;
@@ -158,7 +158,7 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
 }
 
 static inline int
-dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
+dwarf_put (struct dwarf_cursor *c UNUSED, dwarf_loc_t loc, unw_word_t val)
 {
   if (!DWARF_GET_LOC (loc))
     return -1;

--- a/include/tdep-riscv/libunwind_i.h
+++ b/include/tdep-riscv/libunwind_i.h
@@ -110,7 +110,7 @@ dwarf_get_uc(const struct dwarf_cursor *cursor)
                                  tdep_uc_addr(dwarf_get_uc(c), (r)), 0))
 
 static inline int
-dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
+dwarf_getfp (struct dwarf_cursor *c UNUSED, dwarf_loc_t loc, unw_fpreg_t *val)
 {
   if (!DWARF_GET_LOC (loc))
     return -1;
@@ -119,7 +119,7 @@ dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
 }
 
 static inline int
-dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
+dwarf_putfp (struct dwarf_cursor *c UNUSED, dwarf_loc_t loc, unw_fpreg_t val)
 {
   if (!DWARF_GET_LOC (loc))
     return -1;
@@ -128,7 +128,7 @@ dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
 }
 
 static inline int
-dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
+dwarf_get (struct dwarf_cursor *c UNUSED, dwarf_loc_t loc, unw_word_t *val)
 {
   if (!DWARF_GET_LOC (loc))
     return -1;
@@ -137,7 +137,7 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
 }
 
 static inline int
-dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
+dwarf_put (struct dwarf_cursor *c UNUSED, dwarf_loc_t loc, unw_word_t val)
 {
   if (!DWARF_GET_LOC (loc))
     return -1;

--- a/include/tdep-x86/libunwind_i.h
+++ b/include/tdep-x86/libunwind_i.h
@@ -111,7 +111,7 @@ dwarf_get_uc(const struct dwarf_cursor *cursor)
                                  tdep_uc_addr(dwarf_get_uc(c), (r)), 0))
 
 static inline int
-dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
+dwarf_getfp (struct dwarf_cursor *c UNUSED, dwarf_loc_t loc, unw_fpreg_t *val)
 {
   if (!DWARF_GET_LOC (loc))
     return -1;
@@ -120,7 +120,7 @@ dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
 }
 
 static inline int
-dwarf_putfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t val)
+dwarf_putfp (struct dwarf_cursor *c UNUSED, dwarf_loc_t loc, unw_fpreg_t val)
 {
   if (!DWARF_GET_LOC (loc))
     return -1;

--- a/src/aarch64/Gcreate_addr_space.c
+++ b/src/aarch64/Gcreate_addr_space.c
@@ -32,6 +32,9 @@ unw_addr_space_t
 unw_create_addr_space (unw_accessors_t *a, int byte_order)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)a;
+  (void)byte_order;
   return NULL;
 #else
   unw_addr_space_t as;

--- a/src/aarch64/Ginit.c
+++ b/src/aarch64/Ginit.c
@@ -105,14 +105,14 @@ tdep_uc_addr (unw_context_t *uc, int reg)
 # endif /* UNW_LOCAL_ONLY */
 
 static void
-put_unwind_info (unw_addr_space_t as, unw_proc_info_t *proc_info, void *arg)
+put_unwind_info (unw_addr_space_t as UNUSED, unw_proc_info_t *proc_info UNUSED, void *arg UNUSED)
 {
   /* it's a no-op */
 }
 
 static int
-get_dyn_info_list_addr (unw_addr_space_t as, unw_word_t *dyn_info_list_addr,
-                        void *arg)
+get_dyn_info_list_addr (unw_addr_space_t as UNUSED, unw_word_t *dyn_info_list_addr,
+                        void *arg UNUSED)
 {
 #ifndef UNW_LOCAL_ONLY
 # pragma weak _U_dyn_info_list_addr
@@ -126,7 +126,7 @@ get_dyn_info_list_addr (unw_addr_space_t as, unw_word_t *dyn_info_list_addr,
 
 
 static int
-access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
+access_mem (unw_addr_space_t as UNUSED, unw_word_t addr, unw_word_t *val, int write,
             void *arg)
 {
   if (unlikely (write))
@@ -150,7 +150,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
 }
 
 static int
-access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
+access_reg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_word_t *val, int write,
             void *arg)
 {
   unw_word_t *addr;
@@ -180,7 +180,7 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 }
 
 static int
-access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
+access_fpreg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_fpreg_t *val,
               int write, void *arg)
 {
   unw_context_t *uc = ((struct cursor *)arg)->uc;
@@ -215,18 +215,18 @@ access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
 static int
 get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
-                      void *arg)
+                      void *arg UNUSED)
 {
   return _Uelf64_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
 }
 
-static unw_word_t empty_ptrauth_mask(unw_addr_space_t addr_space_unused, void *as_arg_unused)
+static unw_word_t empty_ptrauth_mask(unw_addr_space_t addr_space_unused UNUSED, void *as_arg_unused UNUSED)
 {
   return 0;
 }
 
 static int
-get_static_elf_filename (unw_addr_space_t as, unw_word_t ip, char *buf, size_t buf_len, unw_word_t *offp, void *arg)
+get_static_elf_filename (unw_addr_space_t as, unw_word_t ip, char *buf, size_t buf_len, unw_word_t *offp, void *arg UNUSED)
 {
   return _Uelf64_get_elf_filename(as, getpid(), ip, buf, buf_len, offp);
 }

--- a/src/aarch64/Ginit_remote.c
+++ b/src/aarch64/Ginit_remote.c
@@ -29,6 +29,10 @@ int
 unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)cursor;
+  (void)as;
+  (void)as_arg;
   return -UNW_EINVAL;
 #else /* !UNW_LOCAL_ONLY */
   struct cursor *c = (struct cursor *) cursor;

--- a/src/aarch64/Gos-linux.c
+++ b/src/aarch64/Gos-linux.c
@@ -52,7 +52,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #define SC_SP_OFF   "0x100"
 
 HIDDEN int
-aarch64_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
+aarch64_local_resume (unw_addr_space_t as UNUSED, unw_cursor_t *cursor, void *arg UNUSED)
 {
   struct cursor *c = (struct cursor *) cursor;
   unw_context_t *uc = c->uc;

--- a/src/arm/Gcreate_addr_space.c
+++ b/src/arm/Gcreate_addr_space.c
@@ -30,6 +30,9 @@ unw_addr_space_t
 unw_create_addr_space (unw_accessors_t *a, int byte_order)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)a;
+  (void)byte_order;
   return NULL;
 #else
   unw_addr_space_t as;

--- a/src/arm/Ginit_remote.c
+++ b/src/arm/Ginit_remote.c
@@ -29,6 +29,10 @@ int
 unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)cursor;
+  (void)as;
+  (void)as_arg;
   return -UNW_EINVAL;
 #else /* !UNW_LOCAL_ONLY */
   struct cursor *c = (struct cursor *) cursor;

--- a/src/coredump/_UCD_get_elf_filename.c
+++ b/src/coredump/_UCD_get_elf_filename.c
@@ -71,7 +71,7 @@ _get_text_offset (uint8_t *image)
 }
 
 static int
-elf_w (CD_get_elf_filename) (struct UCD_info *ui, unw_addr_space_t as, unw_word_t ip,
+elf_w (CD_get_elf_filename) (struct UCD_info *ui, unw_addr_space_t as UNUSED, unw_word_t ip,
                              char *buf, size_t buf_len, unw_word_t *offp)
 {
   int ret = UNW_ESUCCESS;

--- a/src/dwarf/Gfde.c
+++ b/src/dwarf/Gfde.c
@@ -32,7 +32,7 @@ is_cie_id (unw_word_t val, int is_debug_frame)
      0xffffffffffffffff (for 64-bit ELF).  However, .eh_frame
      uses 0.  */
   if (is_debug_frame)
-      return (val == (uint32_t)(-1) || val == (uint64_t)(-1));
+      return val == (unw_word_t)(-1);
   else
     return (val == 0);
 }

--- a/src/elfxx.c
+++ b/src/elfxx.c
@@ -712,7 +712,7 @@ elf_w (get_proc_ip_range) (unw_addr_space_t as, pid_t pid, unw_word_t ip,
 }
 
 HIDDEN int
-elf_w (get_elf_filename) (unw_addr_space_t as, pid_t pid, unw_word_t ip,
+elf_w (get_elf_filename) (unw_addr_space_t as UNUSED, pid_t pid, unw_word_t ip,
                           char *buf, size_t buf_len, unw_word_t *offp)
 {
   unsigned long segbase, mapoff;

--- a/src/hppa/Gcreate_addr_space.c
+++ b/src/hppa/Gcreate_addr_space.c
@@ -31,6 +31,9 @@ unw_addr_space_t
 unw_create_addr_space (unw_accessors_t *a, int byte_order)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)a;
+  (void)byte_order;
   return NULL;
 #else
   unw_addr_space_t as;

--- a/src/hppa/Ginit_remote.c
+++ b/src/hppa/Ginit_remote.c
@@ -30,6 +30,10 @@ int
 unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)cursor;
+  (void)as;
+  (void)as_arg;
   return -UNW_EINVAL;
 #else /* !UNW_LOCAL_ONLY */
   struct cursor *c = (struct cursor *) cursor;

--- a/src/ia64/Gcreate_addr_space.c
+++ b/src/ia64/Gcreate_addr_space.c
@@ -31,6 +31,9 @@ unw_addr_space_t
 unw_create_addr_space (unw_accessors_t *a, int byte_order)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)a;
+  (void)byte_order;
   return NULL;
 #else
   unw_addr_space_t as;

--- a/src/ia64/Ginit_remote.c
+++ b/src/ia64/Ginit_remote.c
@@ -30,6 +30,10 @@ int
 unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)cursor;
+  (void)as;
+  (void)as_arg;
   return -UNW_EINVAL;
 #else /* !UNW_LOCAL_ONLY */
   struct cursor *c = (struct cursor *) cursor;

--- a/src/loongarch64/Gcreate_addr_space.c
+++ b/src/loongarch64/Gcreate_addr_space.c
@@ -31,6 +31,8 @@ unw_addr_space_t
 unw_create_addr_space (unw_accessors_t *a, int byte_order)
 {
 #ifdef UNW_LOCAL_ONLY
+  (void)a;
+  (void)byte_order;
   return NULL;
 #else
   unw_addr_space_t as;

--- a/src/loongarch64/Ginit_remote.c
+++ b/src/loongarch64/Ginit_remote.c
@@ -30,6 +30,10 @@ int
 unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)cursor;
+  (void)as;
+  (void)as_arg;
   return -UNW_EINVAL;
 #else /* !UNW_LOCAL_ONLY */
   struct cursor *c = (struct cursor *) cursor;

--- a/src/mips/Gcreate_addr_space.c
+++ b/src/mips/Gcreate_addr_space.c
@@ -30,6 +30,9 @@ unw_addr_space_t
 unw_create_addr_space (unw_accessors_t *a, int byte_order)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)a;
+  (void)byte_order;
   return NULL;
 #else
   unw_addr_space_t as;

--- a/src/mips/Ginit_remote.c
+++ b/src/mips/Ginit_remote.c
@@ -29,6 +29,10 @@ int
 unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)cursor;
+  (void)as;
+  (void)as_arg;
   return -UNW_EINVAL;
 #else /* !UNW_LOCAL_ONLY */
   struct cursor *c = (struct cursor *) cursor;

--- a/src/ppc/Ginit_remote.c
+++ b/src/ppc/Ginit_remote.c
@@ -37,6 +37,10 @@ int
 unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)cursor;
+  (void)as;
+  (void)as_arg;
   return -UNW_EINVAL;
 #else /* !UNW_LOCAL_ONLY */
   struct cursor *c = (struct cursor *) cursor;

--- a/src/ppc32/Gcreate_addr_space.c
+++ b/src/ppc32/Gcreate_addr_space.c
@@ -33,6 +33,9 @@ unw_addr_space_t
 unw_create_addr_space (unw_accessors_t *a, int byte_order)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)a;
+  (void)byte_order;
   return NULL;
 #else
   unw_addr_space_t as;

--- a/src/ppc64/Gcreate_addr_space.c
+++ b/src/ppc64/Gcreate_addr_space.c
@@ -33,6 +33,9 @@ unw_addr_space_t
 unw_create_addr_space (unw_accessors_t *a, int byte_order)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)a;
+  (void)byte_order;
   return NULL;
 #else
   unw_addr_space_t as;

--- a/src/ptrace/_UPT_access_reg.c
+++ b/src/ptrace/_UPT_access_reg.c
@@ -325,7 +325,7 @@ _UPT_access_reg (UNUSED unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val,
 # include <sys/user.h>
 
 int
-_UPT_access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val,
+_UPT_access_reg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_word_t *val,
                  int write, void *arg)
 {
   struct UPT_info *ui = arg;

--- a/src/riscv/Gcreate_addr_space.c
+++ b/src/riscv/Gcreate_addr_space.c
@@ -31,6 +31,9 @@ unw_addr_space_t
 unw_create_addr_space (unw_accessors_t *a, int byte_order)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)a;
+  (void)byte_order;
   return NULL;
 #else
   unw_addr_space_t as;

--- a/src/riscv/Gcreate_addr_space.c
+++ b/src/riscv/Gcreate_addr_space.c
@@ -27,8 +27,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "unwind_i.h"
 
+#ifdef UNW_LOCAL_ONLY
+#define LOCAL_UNUSED UNUSED
+#else
+#define LOCAL_UNUSED
+#endif
+
 unw_addr_space_t
-unw_create_addr_space (unw_accessors_t *a, int byte_order)
+unw_create_addr_space (unw_accessors_t *a LOCAL_UNUSED, int byte_order LOCAL_UNUSED)
 {
 #ifdef UNW_LOCAL_ONLY
   return NULL;

--- a/src/riscv/Gcreate_addr_space.c
+++ b/src/riscv/Gcreate_addr_space.c
@@ -27,14 +27,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "unwind_i.h"
 
-#ifdef UNW_LOCAL_ONLY
-#define LOCAL_UNUSED UNUSED
-#else
-#define LOCAL_UNUSED
-#endif
-
 unw_addr_space_t
-unw_create_addr_space (unw_accessors_t *a LOCAL_UNUSED, int byte_order LOCAL_UNUSED)
+unw_create_addr_space (unw_accessors_t *a, int byte_order)
 {
 #ifdef UNW_LOCAL_ONLY
   return NULL;

--- a/src/riscv/Ginit.c
+++ b/src/riscv/Ginit.c
@@ -76,14 +76,14 @@ tdep_uc_addr (unw_context_t *uc, int reg)
 # endif /* UNW_LOCAL_ONLY */
 
 static void
-put_unwind_info (unw_addr_space_t as, unw_proc_info_t *proc_info, void *arg)
+put_unwind_info (unw_addr_space_t as UNUSED, unw_proc_info_t *proc_info UNUSED, void *arg UNUSED)
 {
   /* it's a no-op */
 }
 
 static int
-get_dyn_info_list_addr (unw_addr_space_t as, unw_word_t *dyn_info_list_addr,
-                        void *arg)
+get_dyn_info_list_addr (unw_addr_space_t as UNUSED, unw_word_t *dyn_info_list_addr,
+                        void *arg UNUSED)
 {
 #ifndef UNW_LOCAL_ONLY
 # pragma weak _U_dyn_info_list_addr
@@ -97,7 +97,7 @@ get_dyn_info_list_addr (unw_addr_space_t as, unw_word_t *dyn_info_list_addr,
 
 
 static int
-access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
+access_mem (unw_addr_space_t as UNUSED, unw_word_t addr, unw_word_t *val, int write,
             void *arg)
 {
   if (write)
@@ -122,7 +122,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
 }
 
 static int
-access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
+access_reg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_word_t *val, int write,
             void *arg)
 {
   unw_word_t *addr;
@@ -153,7 +153,7 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 }
 
 static int
-access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *fpval, int write,
+access_fpreg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_fpreg_t *fpval, int write,
             void *arg)
 {
   struct cursor *c = (struct cursor *)arg;
@@ -188,7 +188,7 @@ access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *fpval, int wri
 static int
 get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
-                      void *arg)
+                      void *arg UNUSED)
 {
   return elf_w (get_proc_name) (as, getpid (), ip, buf, buf_len, offp);
 }
@@ -196,7 +196,7 @@ get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
 static int
 get_static_elf_filename (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
-                      void *arg)
+                      void *arg UNUSED)
 {
   return elf_w (get_elf_filename) (as, getpid (), ip, buf, buf_len, offp);
 }

--- a/src/riscv/Ginit_remote.c
+++ b/src/riscv/Ginit_remote.c
@@ -29,6 +29,10 @@ int
 unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)cursor;
+  (void)as;
+  (void)as_arg;
   return -UNW_EINVAL;
 #else /* !UNW_LOCAL_ONLY */
   struct cursor *c = (struct cursor *) cursor;

--- a/src/riscv/Gresume.c
+++ b/src/riscv/Gresume.c
@@ -30,7 +30,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #ifndef UNW_REMOTE_ONLY
 
 HIDDEN inline int
-riscv_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
+riscv_local_resume (unw_addr_space_t as UNUSED, unw_cursor_t *cursor, void *arg UNUSED)
 {
 #ifdef __linux__
   struct cursor *c = (struct cursor *) cursor;

--- a/src/s390x/Gcreate_addr_space.c
+++ b/src/s390x/Gcreate_addr_space.c
@@ -35,6 +35,9 @@ unw_addr_space_t
 unw_create_addr_space (unw_accessors_t *a, int byte_order)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)a;
+  (void)byte_order;
   return NULL;
 #else
   unw_addr_space_t as;

--- a/src/s390x/Ginit_remote.c
+++ b/src/s390x/Ginit_remote.c
@@ -32,6 +32,10 @@ int
 unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)cursor;
+  (void)as;
+  (void)as_arg;
   return -UNW_EINVAL;
 #else /* !UNW_LOCAL_ONLY */
   struct cursor *c = (struct cursor *) cursor;

--- a/src/sh/Gcreate_addr_space.c
+++ b/src/sh/Gcreate_addr_space.c
@@ -31,6 +31,9 @@ unw_addr_space_t
 unw_create_addr_space (unw_accessors_t *a, int byte_order)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)a;
+  (void)byte_order;
   return NULL;
 #else
   unw_addr_space_t as;

--- a/src/sh/Ginit_remote.c
+++ b/src/sh/Ginit_remote.c
@@ -29,6 +29,10 @@ int
 unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)cursor;
+  (void)as;
+  (void)as_arg;
   return -UNW_EINVAL;
 #else /* !UNW_LOCAL_ONLY */
   struct cursor *c = (struct cursor *) cursor;

--- a/src/unwind/unwind-internal.h
+++ b/src/unwind/unwind-internal.h
@@ -54,7 +54,7 @@ struct _Unwind_Context {
    ((unw_getcontext (uc) < 0 || unw_init_local (&(context)->cursor, uc) < 0) \
     ? -1 : 0))
 
-static _Unwind_Reason_Code ALWAYS_INLINE
+ALWAYS_INLINE static _Unwind_Reason_Code
 _Unwind_Phase2 (struct _Unwind_Exception *exception_object,
                 struct _Unwind_Context *context)
 {

--- a/src/x86/Gcreate_addr_space.c
+++ b/src/x86/Gcreate_addr_space.c
@@ -32,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #endif
 
 unw_addr_space_t
-unw_create_addr_space (unw_accessors_t *a, int byte_order)
+unw_create_addr_space (unw_accessors_t *a UNUSED, int byte_order UNUSED)
 {
 #ifdef UNW_LOCAL_ONLY
   return NULL;

--- a/src/x86/Gcreate_addr_space.c
+++ b/src/x86/Gcreate_addr_space.c
@@ -35,6 +35,9 @@ unw_addr_space_t
 unw_create_addr_space (unw_accessors_t *a UNUSED, int byte_order UNUSED)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)a;
+  (void)byte_order;
   return NULL;
 #else
   unw_addr_space_t as;

--- a/src/x86/Ginit.c
+++ b/src/x86/Ginit.c
@@ -33,6 +33,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "unwind_i.h"
 
+#ifdef __GNUC__
+#  define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
+#else
+#  define UNUSED(x) UNUSED_ ## x
+#endif
+
 #ifdef UNW_REMOTE_ONLY
 
 /* unw_local_addr_space is a NULL pointer in this case.  */
@@ -55,14 +61,14 @@ tdep_uc_addr (ucontext_t *uc, int reg)
 # endif /* UNW_LOCAL_ONLY */
 
 static void
-put_unwind_info (unw_addr_space_t as, unw_proc_info_t *proc_info, void *arg)
+put_unwind_info (unw_addr_space_t UNUSED(as), unw_proc_info_t *UNUSED(proc_info), void *UNUSED(arg))
 {
   /* it's a no-op */
 }
 
 static int
-get_dyn_info_list_addr (unw_addr_space_t as, unw_word_t *dyn_info_list_addr,
-                        void *arg)
+get_dyn_info_list_addr (unw_addr_space_t UNUSED(as), unw_word_t *dyn_info_list_addr,
+                        void *UNUSED(arg))
 {
 #ifndef UNW_LOCAL_ONLY
 # pragma weak _U_dyn_info_list_addr
@@ -76,7 +82,7 @@ get_dyn_info_list_addr (unw_addr_space_t as, unw_word_t *dyn_info_list_addr,
 
 
 static int
-access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
+access_mem (unw_addr_space_t UNUSED(as), unw_word_t addr, unw_word_t *val, int write,
             void *arg)
 {
   if (write)
@@ -100,7 +106,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
 }
 
 static int
-access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
+access_reg (unw_addr_space_t UNUSED(as), unw_regnum_t reg, unw_word_t *val, int write,
             void *arg)
 {
   unw_word_t *addr;
@@ -130,7 +136,7 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 }
 
 static int
-access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
+access_fpreg (unw_addr_space_t UNUSED(as), unw_regnum_t reg, unw_fpreg_t *val,
               int write, void *arg)
 {
   ucontext_t *uc = ((struct cursor *)arg)->uc;
@@ -165,7 +171,7 @@ access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
 static int
 get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
-                      void *arg)
+                      void *UNUSED(arg))
 {
   return _Uelf32_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
 }
@@ -173,7 +179,7 @@ get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
 static int
 get_static_elf_filename (unw_addr_space_t as, unw_word_t ip,
                          char *buf, size_t buf_len, unw_word_t *offp,
-                         void *arg)
+                         void *UNUSED(arg))
 {
   return _Uelf32_get_elf_filename (as, getpid (), ip, buf, buf_len, offp);
 }

--- a/src/x86/Ginit.c
+++ b/src/x86/Ginit.c
@@ -33,12 +33,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "unwind_i.h"
 
-#ifdef __GNUC__
-#  define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
-#else
-#  define UNUSED(x) UNUSED_ ## x
-#endif
-
 #ifdef UNW_REMOTE_ONLY
 
 /* unw_local_addr_space is a NULL pointer in this case.  */
@@ -61,14 +55,14 @@ tdep_uc_addr (ucontext_t *uc, int reg)
 # endif /* UNW_LOCAL_ONLY */
 
 static void
-put_unwind_info (unw_addr_space_t UNUSED(as), unw_proc_info_t *UNUSED(proc_info), void *UNUSED(arg))
+put_unwind_info (unw_addr_space_t as UNUSED, unw_proc_info_t *proc_info UNUSED, void *arg UNUSED)
 {
   /* it's a no-op */
 }
 
 static int
-get_dyn_info_list_addr (unw_addr_space_t UNUSED(as), unw_word_t *dyn_info_list_addr,
-                        void *UNUSED(arg))
+get_dyn_info_list_addr (unw_addr_space_t as UNUSED, unw_word_t *dyn_info_list_addr,
+                        void *arg UNUSED)
 {
 #ifndef UNW_LOCAL_ONLY
 # pragma weak _U_dyn_info_list_addr
@@ -82,7 +76,7 @@ get_dyn_info_list_addr (unw_addr_space_t UNUSED(as), unw_word_t *dyn_info_list_a
 
 
 static int
-access_mem (unw_addr_space_t UNUSED(as), unw_word_t addr, unw_word_t *val, int write,
+access_mem (unw_addr_space_t as UNUSED, unw_word_t addr, unw_word_t *val, int write,
             void *arg)
 {
   if (write)
@@ -106,7 +100,7 @@ access_mem (unw_addr_space_t UNUSED(as), unw_word_t addr, unw_word_t *val, int w
 }
 
 static int
-access_reg (unw_addr_space_t UNUSED(as), unw_regnum_t reg, unw_word_t *val, int write,
+access_reg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_word_t *val, int write,
             void *arg)
 {
   unw_word_t *addr;
@@ -136,7 +130,7 @@ access_reg (unw_addr_space_t UNUSED(as), unw_regnum_t reg, unw_word_t *val, int 
 }
 
 static int
-access_fpreg (unw_addr_space_t UNUSED(as), unw_regnum_t reg, unw_fpreg_t *val,
+access_fpreg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_fpreg_t *val,
               int write, void *arg)
 {
   ucontext_t *uc = ((struct cursor *)arg)->uc;
@@ -171,7 +165,7 @@ access_fpreg (unw_addr_space_t UNUSED(as), unw_regnum_t reg, unw_fpreg_t *val,
 static int
 get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
                       char *buf, size_t buf_len, unw_word_t *offp,
-                      void *UNUSED(arg))
+                      void *arg UNUSED)
 {
   return _Uelf32_get_proc_name (as, getpid (), ip, buf, buf_len, offp);
 }
@@ -179,7 +173,7 @@ get_static_proc_name (unw_addr_space_t as, unw_word_t ip,
 static int
 get_static_elf_filename (unw_addr_space_t as, unw_word_t ip,
                          char *buf, size_t buf_len, unw_word_t *offp,
-                         void *UNUSED(arg))
+                         void * arg UNUSED)
 {
   return _Uelf32_get_elf_filename (as, getpid (), ip, buf, buf_len, offp);
 }

--- a/src/x86/Ginit_remote.c
+++ b/src/x86/Ginit_remote.c
@@ -27,9 +27,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "unwind_i.h"
 
 int
-unw_init_remote (unw_cursor_t *cursor UNUSED, unw_addr_space_t as UNUSED, void *as_arg UNUSED)
+unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)cursor;
+  (void)as;
+  (void)as_arg;
   return -UNW_EINVAL;
 #else /* !UNW_LOCAL_ONLY */
   struct cursor *c = (struct cursor *) cursor;

--- a/src/x86/Ginit_remote.c
+++ b/src/x86/Ginit_remote.c
@@ -27,7 +27,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "unwind_i.h"
 
 int
-unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
+unw_init_remote (unw_cursor_t *cursor UNUSED, unw_addr_space_t as UNUSED, void *as_arg UNUSED)
 {
 #ifdef UNW_LOCAL_ONLY
   return -UNW_EINVAL;

--- a/src/x86/Gos-linux.c
+++ b/src/x86/Gos-linux.c
@@ -286,7 +286,7 @@ x86_r_uc_addr (ucontext_t *uc, int reg)
 }
 
 HIDDEN int
-x86_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
+x86_local_resume (unw_addr_space_t as UNUSED, unw_cursor_t *cursor, void *arg UNUSED)
 {
   struct cursor *c = (struct cursor *) cursor;
   ucontext_t *uc = c->uc;

--- a/src/x86_64/Gcreate_addr_space.c
+++ b/src/x86_64/Gcreate_addr_space.c
@@ -34,6 +34,9 @@ unw_addr_space_t
 unw_create_addr_space (unw_accessors_t *a UNUSED, int byte_order UNUSED)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)a;
+  (void)byte_order;
   return NULL;
 #else
   unw_addr_space_t as;

--- a/src/x86_64/Ginit_remote.c
+++ b/src/x86_64/Ginit_remote.c
@@ -33,6 +33,10 @@ int
 unw_init_remote (unw_cursor_t *cursor UNUSED, unw_addr_space_t as UNUSED, void *as_arg UNUSED)
 {
 #ifdef UNW_LOCAL_ONLY
+  // to suppress warning (unused)
+  (void)cursor;
+  (void)as;
+  (void)as_arg;
   return -UNW_EINVAL;
 #else /* !UNW_LOCAL_ONLY */
   struct cursor *c = (struct cursor *) cursor;

--- a/tests/Gtest-trace.c
+++ b/tests/Gtest-trace.c
@@ -74,10 +74,10 @@ struct {
 	char const *name;
 	void       *addresses[MAX_BACKTRACE_SIZE];
 } trace[] = {
-	{ "unw_step" },
-	{ "backtrace" },
-	{ "unw_backtrace" },
-	{ "unw_backtrace2" }
+	{ "unw_step", {0} },
+	{ "backtrace", {0} },
+	{ "unw_backtrace", {0} },
+	{ "unw_backtrace2", {0} }
 };
 
 unw_cursor_t cursor;


### PR DESCRIPTION
This PR addresses https://github.com/libunwind/libunwind/issues/773

Most of the warning are gone (unused ones).

I also tried to fix some musl build where the errors were around unresolve symbol `REG_RIP` (and so).
In previous version, we defined `_GNU_SOURCE` but it got lost in some refactoring. 