### PR TITLE
Fix a misusing of AS_IF in configure.ac while checking ABICHECK.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -542,7 +542,7 @@ fi
 AC_MSG_RESULT([$have__builtin_unreachable])
 
 AC_CHECK_TOOL([ABICHECK], [abidw])
-AS_IF([test "$ABICHECK" = ":"],, [
+AS_IF([test x"$ABICHECK" != "x"], [
     abicheck_version=$($ABICHECK --version | sed -n 's/[[^ ]]* \([[0-9]]\).*/\1/p')
     AC_MSG_WARN([$ABICHECK version $abicheck_version])
     AS_IF([test $abicheck_version -ge 2],


### PR DESCRIPTION
If abigail-tools are not installed, this misusing will casue a warning like this:

```
checking for abidw... no
./configure: line 14451: --version: command not found
configure: WARNING:  version
./configure: line 14454: test: -ge: unary operator expected
configure: WARNING:  is version , need at least 2.0
```