### PR TITLE
mips/getcontext.S: use assembler-friendly byte order symbols

### DIFF
--- a/src/mips/getcontext.S
+++ b/src/mips/getcontext.S
@@ -24,12 +24,11 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "offsets.h"
-#include <endian.h>
 
 	.text
 
 #if _MIPS_SIM == _ABIO32
-# if __BYTE_ORDER == __BIG_ENDIAN
+# if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #  define OFFSET 4
 # else
 #  define OFFSET 0


### PR DESCRIPTION
endian.h on musl/mips can't be included in __ASSEMBLER__ mode, so use the __BYTE_ORDER__ symbol instead.

Resolves:

sysroot/usr/include/bits/alltypes.h: Assembler messages:
sysroot/usr/include/bits/alltypes.h:119: Error: unrecognized opcode `typedef unsigned short uint16_t'
sysroot/usr/include/bits/alltypes.h:124: Error: unrecognized opcode `typedef unsigned int uint32_t'
sysroot/usr/include/bits/alltypes.h:129: Error: unrecognized opcode `typedef unsigned long long uint64_t'
sysroot/usr/include/endian.h:19: Error: unrecognized opcode `static __inline uint16_t __bswap16(uint16_t __x)'
sysroot/usr/include/endian.h:20: Error: junk at end of line, first unrecognized character is `{'
sysroot/usr/include/endian.h:21: Error: unrecognized opcode `return __x<<8|__x>>8'
sysroot/usr/include/endian.h:22: Error: junk at end of line, first unrecognized character is `}'
sysroot/usr/include/endian.h:24: Error: unrecognized opcode `static __inline uint32_t __bswap32(uint32_t __x)'
sysroot/usr/include/endian.h:25: Error: junk at end of line, first unrecognized character is `{'
sysroot/usr/include/endian.h:26: Error: unrecognized opcode `return __x>>24|__x>>8&0xff00|__x<<8&0xff0000|__x<<24'
sysroot/usr/include/endian.h:27: Error: junk at end of line, first unrecognized character is `}'
sysroot/usr/include/endian.h:29: Error: unrecognized opcode `static __inline uint64_t __bswap64(uint64_t __x)'
sysroot/usr/include/endian.h:30: Error: junk at end of line, first unrecognized character is `{'
sysroot/usr/include/endian.h:31: Error: unrecognized opcode `return __bswap32(__x)+0ULL<<32|__bswap32(__x>>32)'
sysroot/usr/include/endian.h:32: Error: junk at end of line, first unrecognized character is `}'