### PR TITLE
Fix .debug_frame DWARF unwinding on arm

### DIFF
--- a/src/arm/Gos-linux.c
+++ b/src/arm/Gos-linux.c
@@ -121,6 +121,7 @@ arm_handle_signal_frame (unw_cursor_t *cursor)
   dwarf_get (&c->dwarf, c->dwarf.loc[UNW_ARM_R15], &c->dwarf.ip);
 
   c->dwarf.pi_valid = 0;
+  c->dwarf.use_prev_instr = 0;
 
   return 1;
 }

--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -107,8 +107,7 @@ linear_search (unw_addr_space_t as, unw_word_t ip,
 /* XXX: Could use mmap; but elf_map_image keeps tons mapped in.  */
 
 static int
-load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local,
-                  unw_word_t segbase, unw_word_t *load_offset)
+load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local, unw_word_t *load_offset)
 {
   struct elf_image ei;
   Elf_W (Ehdr) *ehdr;
@@ -200,7 +199,7 @@ load_debug_frame (const char *file, char **buf, size_t *bufsize, int is_local,
   for (i = 0; i < ehdr->e_phnum; ++i)
     if (phdr[i].p_type == PT_LOAD)
       {
-        *load_offset = segbase - phdr[i].p_vaddr;
+        *load_offset = phdr[i].p_vaddr;
 
         Debug (4, "%s load offset is 0x%zx\n", file, *load_offset);
 
@@ -250,8 +249,8 @@ find_binary_for_address (unw_word_t ip, char *name, size_t name_size)
    pointer to debug frame descriptor, or zero if not found.  */
 
 static struct unw_debug_frame_list *
-locate_debug_info (unw_addr_space_t as, unw_word_t addr, unw_word_t segbase,
-                   const char *dlname, unw_word_t start, unw_word_t end)
+locate_debug_info (unw_addr_space_t as, unw_word_t addr, const char *dlname,
+                   unw_word_t start, unw_word_t end)
 {
   struct unw_debug_frame_list *w, *fdesc = 0;
   char path[PATH_MAX];
@@ -286,8 +285,7 @@ locate_debug_info (unw_addr_space_t as, unw_word_t addr, unw_word_t segbase,
   else
     name = (char*) dlname;
 
-  err = load_debug_frame (name, &buf, &bufsize, as == unw_local_addr_space,
-                          segbase, &load_offset);
+  err = load_debug_frame (name, &buf, &bufsize, as == unw_local_addr_space, &load_offset);
 
   if (!err)
     {
@@ -438,8 +436,7 @@ dwarf_find_debug_frame (int found, unw_dyn_info_t *di_debug, unw_word_t ip,
 
   Debug (15, "Trying to find .debug_frame for %s\n", obj_name);
 
-  fdesc = locate_debug_info (unw_local_addr_space, ip, segbase, obj_name, start,
-                             end);
+  fdesc = locate_debug_info (unw_local_addr_space, ip, obj_name, start, end);
 
   if (!fdesc)
     {


### PR DESCRIPTION
Hello,

This fixes two issues that I encountered while trying to have .debug_frame based unwinding working on arm:

- The .debug_frame DWARF based unwinding is currently completely broken on x86_64, arm (and most likely all other architectures). That [commit](https://github.com/libunwind/libunwind/commit/cee5505a99d42a423059a1add8b87b75aeb45daa) is causing the segbase to be substracted twice. Reverting it fixes .debug_frame based unwinding on x86_64 and arm architectures.

- The PC value extracted from signal frames, was decremented by one on ARM, which is wrong. That's because the `use_prev_instr` boolean was not set as for other architectures. I did put that into evidence by missing an FDE that was right on PC.

Thanks,

Mathieu