### PR TITLE
Fix the backtrace test on ARM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,5 +87,6 @@ tests/x64-unwind-badjmp-signal-frame
 tests/[GL]arm64-test-sve-signal
 tests/aarch64-test-plt
 tests/aarch64-test-frame-record
+tests/[GL]arm-test-debug-frame-bt
 tests/*.log
 tests/*.trs

--- a/src/arm/Gglobal.c
+++ b/src/arm/Gglobal.c
@@ -31,9 +31,9 @@ HIDDEN atomic_bool tdep_init_done = 0;
 /* Unwinding methods to use. See UNW_METHOD_ enums */
 #if defined(__ANDROID__)
 /* Android only supports three types of unwinding methods. */
-HIDDEN int unwi_unwind_method = UNW_ARM_METHOD_DWARF | UNW_ARM_METHOD_EXIDX | UNW_ARM_METHOD_LR;
+int unwi_unwind_method = UNW_ARM_METHOD_DWARF | UNW_ARM_METHOD_EXIDX | UNW_ARM_METHOD_LR;
 #else
-HIDDEN int unwi_unwind_method = UNW_ARM_METHOD_ALL;
+int unwi_unwind_method = UNW_ARM_METHOD_ALL;
 #endif
 
 HIDDEN void

--- a/tests/Garm-test-debug-frame-bt.c
+++ b/tests/Garm-test-debug-frame-bt.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+/*
+ * Run the backtrace test using the ARM DWARF unwinder based on the
+ * .debug_frame section.
+ */
+__attribute__((constructor))
+void set_dwarf(void) {
+	setenv("UNW_ARM_UNWIND_METHOD", "1", 1);
+}
+
+#include "Gtest-bt.c"

--- a/tests/Gtest-bt.c
+++ b/tests/Gtest-bt.c
@@ -48,6 +48,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #define panic(...)				\
 	{ fprintf (stderr, __VA_ARGS__); exit (-1); }
 
+#define MIN_FRAMES 3
 #define SIG_STACK_SIZE 0x100000
 
 int verbose;
@@ -65,6 +66,7 @@ do_backtrace (void)
 {
   unw_word_t ip, sp, off;
   unw_proc_info_t pi;
+  unsigned int num_frames = 0;
   int ret;
 
   if (verbose)
@@ -120,8 +122,16 @@ do_backtrace (void)
 		  ret, (long) ip);
 	  ++num_errors;
 	}
+
+      ++num_frames;
     }
   while (ret > 0);
+
+  if (num_frames < MIN_FRAMES) {
+         printf ("FAILURE: only found %u frames in the backtrace\n",
+                 num_frames);
+         ++num_errors;
+  }
 
   {
     void *buffer[20];

--- a/tests/Larm-test-debug-frame-bt.c
+++ b/tests/Larm-test-debug-frame-bt.c
@@ -1,0 +1,5 @@
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
+#if !defined(UNW_REMOTE_ONLY)
+#include "Garm-test-debug-frame-bt.c"
+#endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -86,6 +86,10 @@ endif #ARCH X86_64
 endif #!ARCH_PPC64
 endif #!ARCH_IA64
 
+if ARCH_ARM
+  check_PROGRAMS_arch += Garm-test-debug-frame-bt Larm-test-debug-frame-bt
+endif
+
 if ARCH_AARCH64
   check_PROGRAMS_arch += Garm64-test-sve-signal Larm64-test-sve-signal   \
                          aarch64-test-plt aarch64-test-frame-record
@@ -249,6 +253,9 @@ Gx64_test_dwarf_expressions_SOURCES =  Gx64-test-dwarf-expressions.c \
 Lx64_test_dwarf_expressions_SOURCES =  Lx64-test-dwarf-expressions.c \
 																			 x64-test-dwarf-expressions.S
 
+Garm_test_debug_frame_bt_SOURCES = Garm-test-debug-frame-bt.c ident.c
+Larm_test_debug_frame_bt_SOURCES = Larm-test-debug-frame-bt.c ident.c
+
 Garm64_test_sve_signal_SOURCES = Garm64-test-sve-signal.c
 Larm64_test_sve_signal_SOURCES = Larm64-test-sve-signal.c
 aarch64_test_plt_SOURCES = aarch64-test-plt.c
@@ -363,6 +370,9 @@ ppc64_test_plt_LDADD = $(LIBUNWIND)
 
 Gx64_test_dwarf_expressions_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 Lx64_test_dwarf_expressions_LDADD = $(LIBUNWIND_local)
+
+Garm_test_debug_frame_bt_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
+Larm_test_debug_frame_bt_LDADD = $(LIBUNWIND_local)
 
 Garm64_test_sve_signal_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 Larm64_test_sve_signal_LDADD = $(LIBUNWIND_local)

--- a/tests/check-namespace.sh.in
+++ b/tests/check-namespace.sh.in
@@ -173,6 +173,7 @@ check_local_unw_abi () {
 	arm)
 	    match _U${plat}_getcontext
 	    match _U${plat}_is_fpreg
+	    match _UL${plat}_unwind_method
 	    match _UL${plat}_search_unwind_table
 	    match _UL${plat}_dwarf_search_unwind_table
 	    match _UL${plat}_dwarf_find_unwind_table
@@ -283,6 +284,7 @@ check_generic_unw_abi () {
 	    ;;
 	arm)
 	    match _U${plat}_is_fpreg
+	    match _U${plat}_unwind_method
 	    match _U${plat}_get_elf_image
 	    match _U${plat}_get_exe_image_path
 	    match _U${plat}_search_unwind_table


### PR DESCRIPTION
Hello,

The `Gtest-bt` test is currently failing on ARM. That's because the last `unw_step` returns cantunwind when using the default EXIDX unwinder. Ignore that specific error when using that unwinder on ARM.

That fixes the backtrace test on ARM, but then it is still a very weak test because it doesn't check for the number of frames in the backtrace. It can very be that there is only one single frame, when we are expecting at least three frames for the various backtraces that are created.

Improve the test so that it checks that the backtraces that are produced have at least three frames.

Finally, there is nothing testing the DWARF, .debug_frame based unwinder on ARM that can be used by setting the `UNW_ARM_UNWIND_METHOD=1` environment variable. Introduce a new test, `Garm-test-debug-frame-bt.c` that is running the `Gtest-bt` test with that environment variable set.

The test is currently failing, but is fixed by #826 

Thanks,

Mathieu