### PR TITLE
Bump QEMU version used in CI to latest available.

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup
+      - name: Install ${{ matrix.target.triple }} Toolchain
         if: ${{ matrix.target.arch }} = 'i686'
         run: |
           sudo apt update
@@ -96,20 +96,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install QEMU
-        # this ensure install latest qemu on ubuntu, apt get version is old
-        env:
-          QEMU_SRC: "http://archive.ubuntu.com/ubuntu/pool/universe/q/qemu"
-          QEMU_VER: "qemu-user-static_7\\.2.*_amd64.deb$"
-        run: |
-          DEB=`curl -s $QEMU_SRC/ | grep -o -E 'href="([^"#]+)"' | cut -d'"' -f2 | grep $QEMU_VER | tail -1`
-          wget $QEMU_SRC/$DEB
-          sudo dpkg -i $DEB
 
       - name: Install ${{ matrix.config.host }} Toolchain
         run: |
           sudo apt update
-          sudo apt install g++-${{ matrix.config.gccver }}-${{ matrix.config.host }} -y
+          sudo apt install -y g++-${{ matrix.config.gccver }}-${{ matrix.config.host }} \
+                              qemu-user-static
 
       - name: Configure with ${{ matrix.config.cc }}
         run: |


### PR DESCRIPTION
GitHub CI is failing because the explicit version of QEMU is no longer available. Just use the latest version instead, it should be Good Enough.

Closes #837 