### PR TITLE
Disable Ltest-mem-validate test when CONSERVATIVE_CHECKS on x86_64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -431,6 +431,7 @@ if test x$enable_conservative_checks = xyes; then
   AC_DEFINE(CONSERVATIVE_CHECKS, 1,
 	[Define to 1 if you want every memory access validated])
 fi
+AM_CONDITIONAL(CONSERVATIVE_CHECKS, test x$enable_conservative_checks = xyes)
 AC_MSG_RESULT([$enable_conservative_checks])
 
 AC_MSG_CHECKING([whether to enable msabi support])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -100,12 +100,22 @@ endif
 			Gtest-concurrent Ltest-concurrent		 \
 			Gtest-sig-context Ltest-sig-context		 \
 			Gtest-trace Ltest-trace				 \
-			Ltest-mem-validate				 \
 			test-async-sig test-flush-cache test-init-remote \
 			test-mem test-reg-state Ltest-varargs		 \
 			Ltest-nomalloc Ltest-nocalloc Lrs-race
  noinst_PROGRAMS_cdep += forker Gperf-simple Lperf-simple \
 			Gperf-trace Lperf-trace
+
+# only enable Ltest-mem-validate on archs without conservative checks
+if !CONSERVATIVE_CHECKS
+ check_PROGRAMS_cdep += Ltest-mem-validate
+else #CONSERVATIVE_CHECKS
+if !ARCH_X86_64
+if !ARCH_S390X
+ check_PROGRAMS_cdep += Ltest-mem-validate
+endif
+endif
+endif
 
 # unw_init_local2() is not implemented on ia64
 if !ARCH_IA64


### PR DESCRIPTION
This PR addresses #778 by implementing option 2 in the [first comment](https://github.com/libunwind/libunwind/issues/778#issuecomment-2230753184).

A new automake conditional is added in `configure.ac`, and used in `tests/Makefile.am` to disable `Ltest-mem-validate` only on the x86_64 architecture. The issue only applies to x86_64 so this is equally narrow.

Note: Also s390x has different behavior when the conservative checks option is given, but since there are no reports of failing checks on that architecture, it remains enabled.

Admittedly, this is not the optimal solution among the three outlined in the comment. But I'm not qualified to pursue any of the other two solutions.