### PR TITLE
Remove undefined functions from public coredump header. Definitions were removed in #363

### DIFF
--- a/include/libunwind-coredump.h
+++ b/include/libunwind-coredump.h
@@ -44,10 +44,6 @@ extern int _UCD_get_num_threads(struct UCD_info *);
 extern void _UCD_select_thread(struct UCD_info *, int);
 extern pid_t _UCD_get_pid(struct UCD_info *);
 extern int _UCD_get_cursig(struct UCD_info *);
-extern int _UCD_add_backing_file_at_segment(struct UCD_info *, int phdr_no, const char *filename);
-extern int _UCD_add_backing_file_at_vaddr(struct UCD_info *,
-                                          unsigned long vaddr,
-                                          const char *filename);
 
 extern int _UCD_find_proc_info (unw_addr_space_t, unw_word_t,
                                 unw_proc_info_t *, int, void *);


### PR DESCRIPTION
Removed undefined functions, which were removed in #363. I tried to use them using an old android-libunwind fork test.