### PR TITLE
fix reading coredump mapinfo skipping paths smaller than 10 chars and…

### DIFF
--- a/src/coredump/_UCD_get_mapinfo_linux.c
+++ b/src/coredump/_UCD_get_mapinfo_linux.c
@@ -107,7 +107,7 @@ _handle_nt_file_note (uint8_t *desc, void *arg)
                   ui->phdrs[p].p_backing_file_index = ucd_file_table_insert (&ui->ucd_file_table, strings);
                   Debug (3, "adding '%s' at index %d\n", strings, ui->phdrs[p].p_backing_file_index);
                 }
-                else
+              else
                 {
                   Debug (3, "ignoring path: '%s', due to (deleted) or len == 0\n", strings);
                 }

--- a/src/coredump/_UCD_get_threadinfo_prstatus.c
+++ b/src/coredump/_UCD_get_threadinfo_prstatus.c
@@ -135,7 +135,7 @@ _UCD_get_threadinfo(struct UCD_info *ui, coredump_phdr_t *phdrs, unsigned phdr_s
 
   for (unsigned i = 0; i < phdr_size; ++i)
     {
-      Debug(8, "phdr[%03d]: type:%d", i, phdrs[i].p_type);
+      Debug(8, "phdr[%03d]: type:%d\n", i, phdrs[i].p_type);
       if (phdrs[i].p_type == PT_NOTE)
         {
           size_t thread_count = 0;


### PR DESCRIPTION
Small fixes to the coredump extension:
- ignoring paths with (deleted) suffix were not working properly.
- paths smaller than the deleted string len were also ignored.

Not working example:
```
// skipping paths like /a.so
>_handle_nt_file_note: adding '/SYSV00000000 (deleted)' at index 0
>_handle_nt_file_note: adding '/usr/share/fonts/ttf/arial.ttf' at index 1
>_handle_nt_file_note: adding '/usr/share/fonts/ttf/arialbd.ttf' at index 2
```

Working example:
```
>_handle_nt_file_note: adding '/a.so' at index 0
>_handle_nt_file_note: ignoring path: '/SYSV00000000 (deleted)', due to (deleted) or len == 0
>_handle_nt_file_note: adding '/usr/share/fonts/ttf/arial.ttf' at index 1
>_handle_nt_file_note: adding '/usr/share/fonts/ttf/arialbd.ttf' at index 2
```
