### PR TITLE
Build libunwind using convenience libs

### DIFF
--- a/include/tdep-aarch64/libunwind_i.h
+++ b/include/tdep-aarch64/libunwind_i.h
@@ -335,4 +335,21 @@ extern void tdep_stash_frame (struct dwarf_cursor *c,
 extern int tdep_getcontext_trace (unw_context_t *);
 extern unw_word_t tdep_strip_ptrauth_insn_mask (unw_cursor_t *cursor, unw_word_t ip);
 
+typedef enum frame_record_location
+  {
+    NONE,           /* frame record creation has not been detected, use LR */
+    AT_SP_OFFSET,   /* frame record creation has been detected, but FP
+                       update not detected */
+    AT_FP,          /* frame record creation and FP update detected */
+  } frame_record_location_t;
+
+typedef struct frame_state
+  {
+    frame_record_location_t loc;
+    int32_t offset;
+  } frame_state_t;
+
+#define get_frame_state UNW_OBJ(get_frame_state)
+HIDDEN frame_state_t get_frame_state (unw_cursor_t *cursor);
+
 #endif /* AARCH64_LIBUNWIND_I_H */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,6 +37,13 @@ AM_CFLAGS = $(UNW_EXTRA_CFLAGS)
 COMMON_SO_LDFLAGS = $(LDFLAGS_NOSTARTFILES)
 
 #
+# Base for internal headers and libraries. These will get built up through
+# various build option processing below.
+#
+noinst_HEADERS =
+noinst_LTLIBRARIES =
+
+#
 # Which libraries to build and install
 #
 # Order is important here. The names of the libraries need to end up in reverse
@@ -48,6 +55,7 @@ if !REMOTE_ONLY
 endif
 if ARCH_AARCH64
  lib_LTLIBRARIES += libunwind-aarch64.la
+ noinst_LTLIBRARIES += libunwind-arch-aarch64.la
 endif
 if ARCH_ARM
  lib_LTLIBRARIES += libunwind-arm.la
@@ -99,8 +107,12 @@ if BUILD_SETJMP
  lib_LTLIBRARIES += libunwind-setjmp.la
 endif
 
-noinst_HEADERS =
-noinst_LTLIBRARIES =
+#
+# A convenience library for the local libunwind, shared with various unit
+# tests to expose internal seams for testing.
+#
+noinst_LTLIBRARIES += libunwind-local.la
+libunwind_local_la_LIBADD =
 
 if USE_ELF32
 libunwind_elf_libs = libunwind-elf32.la
@@ -222,7 +234,8 @@ libunwind_setjmp_la_LIBADD =                   \
 	$(libunwind_libadd)
 
 ### libunwind:
-libunwind_la_LIBADD =
+libunwind_la_SOURCES =
+libunwind_la_LIBADD  = libunwind-local.la
 
 # List of arch-independent files needed by both local-only and generic
 # libraries:
@@ -338,7 +351,7 @@ if USE_DWARF
 if !REMOTE_ONLY
  noinst_LTLIBRARIES += libunwind-dwarf-local.la
 endif
- libunwind_la_LIBADD += libunwind-dwarf-local.la
+ libunwind_local_la_LIBADD += libunwind-dwarf-local.la
 endif
 
 noinst_HEADERS += elf32.h elf64.h elfxx.h
@@ -351,7 +364,7 @@ libunwind_elf64_la_LIBADD  = $(LIBLZMA) $(LIBZ)
 libunwind_elfxx_la_LIBADD  = $(LIBLZMA) $(LIBZ)
 
 noinst_LTLIBRARIES += $(libunwind_elf_libs)
-libunwind_la_LIBADD += $(libunwind_elf_libs)
+libunwind_local_la_LIBADD += $(libunwind_elf_libs)
 
 if OS_LINUX
  libunwind_la_SOURCES_os               = os-linux.c dl-iterate-phdr.c
@@ -411,67 +424,70 @@ endif
 ### target AArch64:
 # The list of files that go into libunwind and libunwind-aarch64:
 noinst_HEADERS += aarch64/init.h aarch64/ucontext_i.h aarch64/unwind_i.h
-libunwind_la_SOURCES_aarch64_common =          \
-	$(libunwind_la_SOURCES_common)         \
-	aarch64/is_fpreg.c                     \
-	aarch64/regname.c
+libunwind_la_SOURCES_aarch64_common =         \
+    $(libunwind_la_SOURCES_common)            \
+    aarch64/is_fpreg.c                        \
+    aarch64/regname.c
 
 # The list of files that go into libunwind:
 if ARCH_AARCH64
-libunwind_la_SOURCES =                         \
-	$(libunwind_la_SOURCES_aarch64_common) \
-	$(libunwind_la_SOURCES_local)          \
-	$(libunwind_la_SOURCES_aarch64_os_local)   \
-	aarch64/getcontext.S                   \
-	aarch64/Lapply_reg_state.c             \
-	aarch64/Lcreate_addr_space.c           \
-	aarch64/Lget_proc_info.c               \
-	aarch64/Lget_save_loc.c                \
-	aarch64/Lglobal.c                      \
-	aarch64/Linit.c                        \
-	aarch64/Linit_local.c                  \
-	aarch64/Linit_remote.c                 \
-	aarch64/Lis_signal_frame.c             \
-	aarch64/Lregs.c                        \
-	aarch64/Lreg_states_iterate.c          \
-	aarch64/Lresume.c                      \
-	aarch64/Lstash_frame.c                 \
-	aarch64/Lstep.c                        \
-	aarch64/Ltrace.c                       \
-	aarch64/Lstrip_ptrauth_insn_mask.c
+libunwind_local_la_SOURCES =                  \
+    $(libunwind_la_SOURCES_aarch64_common)    \
+    $(libunwind_la_SOURCES_local)             \
+    $(libunwind_la_SOURCES_aarch64_os_local)  \
+    aarch64/getcontext.S                      \
+    aarch64/Lapply_reg_state.c                \
+    aarch64/Lcreate_addr_space.c              \
+    aarch64/Lget_proc_info.c                  \
+    aarch64/Lget_save_loc.c                   \
+    aarch64/Lglobal.c                         \
+    aarch64/Linit.c                           \
+    aarch64/Linit_local.c                     \
+    aarch64/Linit_remote.c                    \
+    aarch64/Lis_signal_frame.c                \
+    aarch64/Lregs.c                           \
+    aarch64/Lreg_states_iterate.c             \
+    aarch64/Lresume.c                         \
+    aarch64/Lstash_frame.c                    \
+    aarch64/Lstep.c                           \
+    aarch64/Ltrace.c                          \
+    aarch64/Lstrip_ptrauth_insn_mask.c
 
-libunwind_setjmp_la_SOURCES +=                 \
-	aarch64/longjmp.S                      \
-	aarch64/siglongjmp.S
+libunwind_setjmp_la_SOURCES +=                \
+    aarch64/longjmp.S                         \
+    aarch64/siglongjmp.S
 endif ARCH_AARCH64
 
-libunwind_aarch64_la_SOURCES =                 \
-	$(libunwind_la_SOURCES_aarch64_common) \
-	$(libunwind_la_SOURCES_generic)        \
-	$(libunwind_la_SOURCES_aarch64_os)     \
-	aarch64/Gapply_reg_state.c             \
-	aarch64/Gcreate_addr_space.c           \
-	aarch64/Gget_proc_info.c               \
-	aarch64/Gget_save_loc.c                \
-	aarch64/Gglobal.c                      \
-	aarch64/Ginit.c                        \
-	aarch64/Ginit_local.c                  \
-	aarch64/Ginit_remote.c                 \
-	aarch64/Gis_signal_frame.c             \
-	aarch64/Gregs.c                        \
-	aarch64/Greg_states_iterate.c          \
-	aarch64/Gresume.c                      \
-	aarch64/Gstash_frame.c                 \
-	aarch64/Gstep.c                        \
-	aarch64/Gtrace.c                       \
-	aarch64/Gstrip_ptrauth_insn_mask.c
-libunwind_aarch64_la_LDFLAGS =                 \
-	$(COMMON_SO_LDFLAGS)                   \
-	-version-info $(SOVERSION)
-libunwind_aarch64_la_LIBADD =                  \
-	libunwind-dwarf-generic.la             \
-	libunwind-elf64.la                     \
-	$(libunwind_libadd)
+libunwind_aarch64_la_SOURCES =
+libunwind_arch_aarch64_la_SOURCES =           \
+    $(libunwind_la_SOURCES_aarch64_common)    \
+    $(libunwind_la_SOURCES_generic)           \
+    $(libunwind_la_SOURCES_aarch64_os)        \
+    aarch64/Gapply_reg_state.c                \
+    aarch64/Gcreate_addr_space.c              \
+    aarch64/Gget_proc_info.c                  \
+    aarch64/Gget_save_loc.c                   \
+    aarch64/Gglobal.c                         \
+    aarch64/Ginit.c                           \
+    aarch64/Ginit_local.c                     \
+    aarch64/Ginit_remote.c                    \
+    aarch64/Gis_signal_frame.c                \
+    aarch64/Gregs.c                           \
+    aarch64/Greg_states_iterate.c             \
+    aarch64/Gresume.c                         \
+    aarch64/Gstash_frame.c                    \
+    aarch64/Gstep.c                           \
+    aarch64/Gtrace.c                          \
+    aarch64/Gstrip_ptrauth_insn_mask.c
+libunwind_aarch64_la_LDFLAGS =                \
+    $(COMMON_SO_LDFLAGS)                      \
+    -version-info $(SOVERSION)
+libunwind_arch_aarch64_la_LIBADD =            \
+    libunwind-dwarf-generic.la                \
+    libunwind-elf64.la                        \
+    $(libunwind_libadd)
+libunwind_aarch64_la_LIBADD =                 \
+    libunwind-arch-aarch64.la
 
 ### target ARMv7:
 # The list of files that go into libunwind and libunwind-arm:
@@ -485,7 +501,7 @@ libunwind_la_SOURCES_arm_common =              \
 
 # The list of files that go into libunwind:
 if ARCH_ARM
-libunwind_la_SOURCES = \
+libunwind_local_la_SOURCES =               \
 	$(libunwind_la_SOURCES_arm_common)     \
 	$(libunwind_la_SOURCES_arm_os_local)   \
 	$(libunwind_la_SOURCES_local)          \
@@ -548,7 +564,7 @@ libunwind_la_SOURCES_hppa_common =             \
 
 if ARCH_HPPA
 # The list of files that go into libunwind:
-libunwind_la_SOURCES =                         \
+libunwind_local_la_SOURCES =               \
 	$(libunwind_la_SOURCES_hppa_common)    \
 	$(libunwind_la_SOURCES_local)          \
 	hppa/getcontext.S                      \
@@ -624,7 +640,7 @@ Lcursor_i.h: mk_Lcursor_i.s
 	"$(srcdir)/ia64/mk_cursor_i" mk_Lcursor_i.s > Lcursor_i.h
 
 # The list of files that go into libunwind:
-libunwind_la_SOURCES =                         \
+libunwind_local_la_SOURCES =               \
 	$(libunwind_la_SOURCES_ia64_common)    \
 	$(libunwind_la_SOURCES_local)          \
 	ia64/dyn_info_list.S                   \
@@ -699,7 +715,7 @@ libunwind_la_SOURCES_loongarch64_common =      \
 
 if ARCH_LOONGARCH64
 # The list of files that go into libunwind:
-libunwind_la_SOURCES =                         \
+libunwind_local_la_SOURCES =               \
 	$(libunwind_la_SOURCES_loongarch64_common) \
 	$(libunwind_la_SOURCES_local)          \
 	loongarch64/getcontext.S               \
@@ -758,7 +774,7 @@ libunwind_la_SOURCES_mips_common =             \
 
 if ARCH_MIPS
 # The list of files that go into libunwind:
-libunwind_la_SOURCES =                         \
+libunwind_local_la_SOURCES =               \
 	$(libunwind_la_SOURCES_mips_common)    \
 	$(libunwind_la_SOURCES_local)          \
 	mips/getcontext.S                      \
@@ -834,7 +850,7 @@ libunwind_la_SOURCES_ppc32_common =            \
 
 if ARCH_PPC32
 # The list of files that go into libunwind:
-libunwind_la_SOURCES =                         \
+libunwind_local_la_SOURCES =               \
 	$(libunwind_la_SOURCES_ppc32_common)   \
 	$(libunwind_la_SOURCES_local)          \
 	$(libunwind_la_SOURCES_ppc)            \
@@ -886,7 +902,7 @@ libunwind_la_SOURCES_ppc64_common =            \
 
 if ARCH_PPC64
 # The list of files that go into libunwind:
-libunwind_la_SOURCES =                         \
+libunwind_local_la_SOURCES =               \
 	$(libunwind_la_SOURCES_ppc64_common)   \
 	$(libunwind_la_SOURCES_local)          \
 	$(libunwind_la_SOURCES_ppc)            \
@@ -938,7 +954,7 @@ libunwind_la_SOURCES_riscv_common =            \
 
 if ARCH_RISCV
 # The list of files that go into libunwind:
-libunwind_la_SOURCES =                         \
+libunwind_local_la_SOURCES =               \
 	$(libunwind_la_SOURCES_riscv_common)   \
 	$(libunwind_la_SOURCES_local)          \
 	riscv/getcontext.S                     \
@@ -998,7 +1014,7 @@ libunwind_la_SOURCES_s390x_common =            \
 
 if ARCH_S390X
 # The list of files that go into libunwind:
-libunwind_la_SOURCES =                         \
+libunwind_local_la_SOURCES =               \
 	$(libunwind_la_SOURCES_s390x_common)   \
 	$(libunwind_la_SOURCES_local)          \
 	s390x/getcontext.S                     \
@@ -1056,7 +1072,7 @@ libunwind_la_SOURCES_sh_common =               \
 
 if ARCH_SH
 # The list of files that go into libunwind:
-libunwind_la_SOURCES =                         \
+libunwind_local_la_SOURCES =               \
 	$(libunwind_la_SOURCES_sh_common)      \
 	$(libunwind_la_SOURCES_local)          \
 	sh/Lapply_reg_state.c                  \
@@ -1112,7 +1128,7 @@ libunwind_la_SOURCES_x86_common =              \
 
 if ARCH_X86
 # The list of files that go into libunwind:
-libunwind_la_SOURCES =                         \
+libunwind_local_la_SOURCES =               \
 	$(libunwind_la_SOURCES_x86_common)     \
 	$(libunwind_la_SOURCES_x86_os_local)   \
 	$(libunwind_la_SOURCES_local)          \
@@ -1172,7 +1188,7 @@ libunwind_la_SOURCES_x86_64_common =           \
 
 if ARCH_X86_64
 # The list of files that go into libunwind:
-libunwind_la_SOURCES =                         \
+libunwind_local_la_SOURCES =               \
 	$(libunwind_la_SOURCES_x86_64_common)  \
 	$(libunwind_la_SOURCES_x86_64_os_local)\
 	$(libunwind_la_SOURCES_local)          \

--- a/src/aarch64/Gstep.c
+++ b/src/aarch64/Gstep.c
@@ -156,20 +156,6 @@ unw_is_plt_entry (unw_cursor_t *uc)
 	return _is_plt_entry (&((struct cursor *)uc)->dwarf);
 }
 
-typedef enum frame_record_location
-  {
-    NONE,           /* frame record creation has not been detected, use LR */
-    AT_SP_OFFSET,   /* frame record creation has been detected, but FP
-                       update not detected */
-    AT_FP,          /* frame record creation and FP update detected */
-  } frame_record_location_t;
-
-typedef struct frame_state
-  {
-    frame_record_location_t loc;
-    int32_t offset;
-  } frame_state_t;
-
 /* Recognise when a frame record storing FP+LR has been created and whether FP
    has been updated to point to the frame record. For example:
   4183d4:       a9bd7bfd        stp     x29, x30, [sp,#-48]!    <= FP+LR stored
@@ -183,7 +169,7 @@ typedef struct frame_state
   41844c:       a8c37bfd        ldp     x29, x30, [sp],#48      <= FP+LR retrieved
   418450:       d65f03c0        ret
 */
-static frame_state_t
+frame_state_t
 get_frame_state (unw_cursor_t *cursor)
 {
   struct cursor *c = (struct cursor *) cursor;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -65,6 +65,7 @@ perf:
 
 else
  LIBUNWIND_local = $(top_builddir)/src/libunwind.la
+ LIBUNWIND_internal = $(top_builddir)/src/libunwind-local.la
 if ARCH_IA64
  noinst_PROGRAMS_arch += ia64-test-dyn1
  check_SCRIPTS_arch +=	run-ia64-test-dyn1
@@ -92,7 +93,8 @@ endif
 
 if ARCH_AARCH64
   check_PROGRAMS_arch += Garm64-test-sve-signal Larm64-test-sve-signal   \
-                         aarch64-test-plt aarch64-test-frame-record
+                         aarch64-test-plt \
+                         Laarch64-test-frame-record Gaarch64-test-frame-record
 endif
 
  check_PROGRAMS_cdep +=	Gtest-bt Ltest-bt				 \
@@ -259,7 +261,8 @@ Larm_test_debug_frame_bt_SOURCES = Larm-test-debug-frame-bt.c ident.c
 Garm64_test_sve_signal_SOURCES = Garm64-test-sve-signal.c
 Larm64_test_sve_signal_SOURCES = Larm64-test-sve-signal.c
 aarch64_test_plt_SOURCES = aarch64-test-plt.c
-aarch64_test_frame_record_SOURCES = aarch64-test-frame-record.c
+Laarch64_test_frame_record_SOURCES = aarch64-test-frame-record.c
+Gaarch64_test_frame_record_SOURCES = aarch64-test-frame-record.c
 
 if COMPILER_SUPPORTS_MARCH_ARMV8_A_SVE
  Garm64_test_sve_signal_CFLAGS = $(AM_CFLAGS) -fno-inline -march=armv8-a+sve
@@ -290,6 +293,7 @@ Ltest_trace_SOURCES = Ltest-trace.c ident.c
 Ltest_mem_validate_SOURCES = Ltest-mem-validate.c
 
 LIBUNWIND = $(top_builddir)/src/libunwind-$(arch).la
+LIBUNWIND_arch = $(top_builddir)/src/libunwind-arch-$(arch).la
 LIBUNWIND_ptrace = $(top_builddir)/src/libunwind-ptrace.la
 LIBUNWIND_coredump = $(top_builddir)/src/libunwind-coredump.la
 
@@ -377,4 +381,6 @@ Larm_test_debug_frame_bt_LDADD = $(LIBUNWIND_local)
 Garm64_test_sve_signal_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 Larm64_test_sve_signal_LDADD = $(LIBUNWIND_local)
 aarch64_test_plt_LDADD = $(LIBUNWIND)
-aarch64_test_frame_record_LDADD = $(LIBUNWIND)
+Laarch64_test_frame_record_CFLAGS = $(AM_CFLAGS) -DUNW_LOCAL_ONLY
+Laarch64_test_frame_record_LDADD = $(LIBUNWIND_internal)
+Gaarch64_test_frame_record_LDADD = $(LIBUNWIND_arch)

--- a/tests/aarch64-test-frame-record.c
+++ b/tests/aarch64-test-frame-record.c
@@ -8,7 +8,6 @@
 
 int unw_is_signal_frame (unw_cursor_t *cursor) { return 0; }
 int dwarf_step (struct dwarf_cursor *c) { return 0; }
-#include "aarch64/Gstep.c"
 
 static int procedure_size;
 


### PR DESCRIPTION
A (new) unit test was failing at -O0 because it referenced functions private to the implementation and not exposed through the shared library ABI. To fix this, the shared library(ies) are now built using a convenience library, which can also be directly linked to unit tests so the private functions can be exposed.

This is the first step to greatly expanded unit testing (ie. testing at unit seams instead of integration testing only at the public API level).

Only one single unit test for the AARCH64 architecture is fully enabled at this point.

Fixes #841