### PR TITLE
Fix register range check for armv7 QNX coredump

### DIFF
--- a/src/coredump/_UCD_access_reg_qnx.c
+++ b/src/coredump/_UCD_access_reg_qnx.c
@@ -126,7 +126,7 @@ _UCD_access_reg (unw_addr_space_t  as,
       return -UNW_EINVAL;
   }
 #elif defined(UNW_TARGET_ARM)
-  if (regnum >= UNW_ARM_R0 && regnum <= UNW_ARM_R16) {
+  if (regnum >= UNW_ARM_R0 && regnum <= UNW_ARM_R15) {
      *valp = ui->prstatus->greg.arm.gpr[regnum];
   } else {
        Debug(0, "bad regnum:%d\n", regnum);


### PR DESCRIPTION
The range check was using a non-existent register. It should use an existent register.

Closes #876 