### PR TITLE
Revert "Do not fallback to slow_backtrace when tdep_trace stops"

### DIFF
--- a/src/mi/backtrace.c
+++ b/src/mi/backtrace.c
@@ -67,8 +67,7 @@ unw_backtrace (void **buffer, int size)
   if (unlikely (unw_init_local (&cursor, &uc) < 0))
     return 0;
 
-  int ret = tdep_trace (&cursor, buffer, &n);
-  if (unlikely (ret < 0 && ret != -UNW_ESTOPUNWIND))
+  if (unlikely (tdep_trace (&cursor, buffer, &n) < 0))
     {
       unw_getcontext (&uc);
       return slow_backtrace (buffer, size, &uc, 0);
@@ -109,8 +108,7 @@ unw_backtrace2 (void **buffer, int size, unw_context_t* uc2, int flag)
 
   // returns the number of frames collected by tdep_trace or slow_backtrace
   // and add 1 to it (the one we retrieved above)
-  int ret = tdep_trace (&cursor, buffer, &n);
-  if (unlikely (ret < 0 && ret != -UNW_ESTOPUNWIND))
+  if (unlikely (tdep_trace (&cursor, buffer, &n) < 0))
     {
       return slow_backtrace (buffer, remaining_size, &uc, flag) + 1;
     }


### PR DESCRIPTION
This reverts commit 5b195ffd5020de5dac19d550c44b58201c69e5b4 because it breaks both arm and armhf test suites.