### PR TITLE
Ltest-mem-validate: Fix testcase for stack-grows-upwards architectures

### DIFF
--- a/tests/Ltest-mem-validate.c
+++ b/tests/Ltest-mem-validate.c
@@ -134,8 +134,8 @@ main (int argc UNUSED, char **argv UNUSED)
     }
   else
     {
-      stack_start = (void *)(((uintptr_t)&start & ~(page_size - 1)) + page_size);
-      count  = (uintptr_t)stack_start - (uintptr_t)&start;
+      stack_start = (void *)(((uintptr_t)&start & ~(page_size - 1)) - page_size);
+      count  = (uintptr_t)&start - (uintptr_t)stack_start;
     }
     count = count / STACK_SLICE + STEPS;
 


### PR DESCRIPTION
The calculation of the area to mprotect and the amount of loops was wrong for the stack-grows-upwards architectures. With this fix the testcase succeeds on the hppa architecture (which is probably the last active architecture left where the stack grows upwards).