### PR TITLE
Avoid NT_ARM_PAC_MASK on older Linux kernels

### DIFF
--- a/src/ptrace/_UPT_ptrauth_insn_mask.c
+++ b/src/ptrace/_UPT_ptrauth_insn_mask.c
@@ -22,7 +22,7 @@
  */
 #include "_UPT_internal.h"
 
-#if defined(UNW_TARGET_AARCH64) && defined(__linux__) && defined(NT_ARM_PAC_MASK)
+#if defined(UNW_TARGET_AARCH64) && defined(NT_ARM_PAC_MASK)
 
 unw_word_t _UPT_ptrauth_insn_mask (UNUSED unw_addr_space_t as, void *arg)
 {

--- a/src/ptrace/_UPT_ptrauth_insn_mask.c
+++ b/src/ptrace/_UPT_ptrauth_insn_mask.c
@@ -22,7 +22,7 @@
  */
 #include "_UPT_internal.h"
 
-#ifdef UNW_TARGET_AARCH64
+#if defined(UNW_TARGET_AARCH64) && defined(__linux__) && defined(NT_ARM_PAC_MASK)
 
 unw_word_t _UPT_ptrauth_insn_mask (UNUSED unw_addr_space_t as, void *arg)
 {


### PR DESCRIPTION
Older kernels still in wide use (e.g. Enterprise Linux 8) do not have `NT_ARM_PAC_MASK` support or the associated structs. Compilation fails:

```
ptrace/_UPT_ptrauth_insn_mask.c: In function ‘_UPT_ptrauth_insn_mask’:
ptrace/_UPT_ptrauth_insn_mask.c:38:40: error: ‘NT_ARM_PAC_MASK’ undeclared (first use in this function); did you mean ‘EF_ARM_EABIMASK’?
   ret = ptrace (PTRACE_GETREGSET, pid, NT_ARM_PAC_MASK, &iovec);
                                        ^~~~~~~~~~~~~~~
                                        EF_ARM_EABIMASK
ptrace/_UPT_ptrauth_insn_mask.c:38:40: note: each undeclared identifier is reported only once for each function it appears in
```

This patch disables this codepath unless this is a Linux host and `NT_ARM_PAC_MASK` is defined in `elf.h`. 

See also #873 which proposes a fix for FreeBSD platforms. This patch is a superset of #870. 