### PR TITLE
include/coredump: Align for all 64bit platforms

### DIFF
--- a/include/dwarf.h
+++ b/include/dwarf.h
@@ -314,13 +314,13 @@ typedef struct dwarf_cursor
     void *as_arg;               /* argument to address-space callbacks */
     unw_addr_space_t as;        /* reference to per-address-space info */
 
+    dwarf_loc_t loc[DWARF_NUM_PRESERVED_REGS];
+
     unw_word_t cfa;     /* canonical frame address; aka frame-pointer */
     unw_word_t ip;              /* instruction pointer */
     unw_word_t args_size;       /* size of arguments */
     unw_word_t eh_args[UNW_TDEP_NUM_EH_REGS];
     unsigned int eh_valid_mask;
-
-    dwarf_loc_t loc[DWARF_NUM_PRESERVED_REGS];
 
     unsigned int stash_frames :1; /* stash frames for fast lookup */
     unsigned int use_prev_instr :1; /* use previous (= call) or current (= signal) instruction? */

--- a/include/libunwind-common.h.in
+++ b/include/libunwind-common.h.in
@@ -251,13 +251,13 @@ unw_save_loc_type_t;
 typedef struct unw_save_loc
   {
     unw_save_loc_type_t type;
+    unw_tdep_save_loc_t extra;	/* target-dependent additional information */
     union
       {
 	unw_word_t addr;	/* valid if type==UNW_SLT_MEMORY */
 	unw_regnum_t regnum;	/* valid if type==UNW_SLT_REG */
       }
     u;
-    unw_tdep_save_loc_t extra;	/* target-dependent additional information */
   }
 unw_save_loc_t;
 

--- a/src/coredump/_UCD_internal.h
+++ b/src/coredump/_UCD_internal.h
@@ -104,13 +104,13 @@ struct UCD_info
     char                   *coredump_filename; /* for error meesages only */
     coredump_phdr_t        *phdrs;             /* array, allocated */
     unsigned                phdrs_count;
+    int                     n_threads;
     ucd_file_table_t        ucd_file_table;
     void                   *note_phdr;         /* allocated or NULL */
     UCD_proc_status_t      *prstatus;          /* points inside note_phdr */
 #ifdef HAVE_ELF_FPREGSET_T
     elf_fpregset_t         *fpregset;
 #endif
-    int                     n_threads;
     struct UCD_thread_info *threads;
     struct elf_dyn_info     edi;
   };


### PR DESCRIPTION
@bregma,
I decided to do this by looking at the organization of memory in the processor cache lines in libunwind, and I noticed that libunwind really uses large structures. It is desirable that the structures are no more than 64 bytes, so it will be easier for the C/C++/C# compiler to process them. Since it is very difficult to recycle structures, I solved the problem easier.

Out of habit, I aligned him.

This PR will decrease costs copying, moving, and creating object-structures only for common 64bit processors due to the 8-byte data alignment.
Smaller size structure or class, higher chance putting into CPU cache. Most processors are already 64 bit, so the change won't make it any worse.

If you know how to use pahole (https://linux.die.net/man/1/pahole), then you can view the object files in release, debug, non-optimized debug, and so on. By default, C/C++ compilers do not change the size of structures until the programmer himself specifies the packing or alignment attribute (keyword).

## Affected structs:

- UCD_info        272  ->  264     (saved 8 bytes)
- dwarf_cursor    424  ->  416    (saved 8 bytes)
- unw_save_loc    24   ->  16     (saved 8 bytes)

## Example pahole log for struct dwarf_cursor

- Comment `/* XXX {n} bytes hole, try to pack */` shows where optimization is possible by rearranging the order of fields structures and classes

```c
$ ~/GIT/dwarves/build/pahole -S --class_name=dwarf_cursor -j8 */*/*.o
struct dwarf_cursor {
        void *                     as_arg;               /*     0     8 */
        unw_addr_space_t           as;                   /*     8     8 */
        unw_word_t                 cfa;                  /*    16     8 */
        unw_word_t                 ip;                   /*    24     8 */
        unw_word_t                 args_size;            /*    32     8 */
        unw_word_t                 eh_args[2];           /*    40    16 */
        unsigned int               eh_valid_mask;        /*    56     4 */

        /* XXX 4 bytes hole, try to pack */

        /* --- cacheline 1 boundary (64 bytes) --- */
        dwarf_loc_t                loc[17];              /*    64   272 */
        /* --- cacheline 5 boundary (320 bytes) was 16 bytes ago --- */
        unsigned int               stash_frames:1;       /*   336: 0  4 */
        unsigned int               use_prev_instr:1;     /*   336: 1  4 */
        unsigned int               pi_valid:1;           /*   336: 2  4 */
        unsigned int               pi_is_dynamic:1;      /*   336: 3  4 */

        /* XXX 28 bits hole, try to pack */
        /* XXX 4 bytes hole, try to pack */

        unw_proc_info_t            pi;                   /*   344    72 */
        /* --- cacheline 6 boundary (384 bytes) was 32 bytes ago --- */
        short int                  hint;                 /*   416     2 */
        short int                  prev_rs;              /*   418     2 */

        /* size: 424, cachelines: 7, members: 15 */
        /* sum members: 408, holes: 2, sum holes: 8 */
        /* sum bitfield members: 4 bits, bit holes: 1, sum bit holes: 28 bits */
        /* padding: 4 */
        /* last cacheline: 40 bytes */
};
```

## References:

https://hpc.rz.rptu.de/Tutorials/AVX/alignment.shtml

https://wr.informatik.uni-hamburg.de/_media/teaching/wintersemester_2013_2014/epc-14-haase-svenhendrik-alignmentinc-presentation.pdf

https://en.wikipedia.org/wiki/Data_structure_alignment

https://stackoverflow.com/a/20882083

https://zijishi.xyz/post/optimization-technique/learning-to-use-data-alignment/