### PR TITLE
mi: removed excess check before free() in label 'out'

### DIFF
--- a/src/mi/Gdyn-remote.c
+++ b/src/mi/Gdyn-remote.c
@@ -118,8 +118,7 @@ intern_array (unw_addr_space_t as, unw_accessors_t *a,
   return 0;
 
  out:
-  if (data)
-    free (data);
+  free (data);
   return ret;
 }
 


### PR DESCRIPTION
@bregma,

More info: https://stackoverflow.com/questions/13818803/check-for-null-before-delete-in-c-good-practice

In C this became possible after C89, code is cleaner.

```
 C89: 4.10.3.2 The free function.

The free function causes the space pointed to by ptr to be deallocated, that is, made available for further allocation. If ptr is a null pointer, no action occurs.
```