### PR TITLE
Add support for x86_64 Control-Flow Enforcement

### DIFF
--- a/src/x86_64/getcontext.S
+++ b/src/x86_64/getcontext.S
@@ -38,6 +38,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 	.type _Ux86_64_getcontext, @function
 _Ux86_64_getcontext:
 	.cfi_startproc
+#if defined(__CET__) && __CET__ & 0x01
+	endbr64
+#endif
 
 	/* Callee saved: RBX, RBP, R12-R15  */
 	movq %r12, UC_MCONTEXT_GREGS_R12(%rdi)
@@ -117,6 +120,9 @@ _Ux86_64_getcontext:
 	.type _Ux86_64_getcontext_trace, @function
 _Ux86_64_getcontext_trace:
 	.cfi_startproc
+#if defined(__CET__) && __CET__ & 0x01
+	endbr64
+#endif
 
 	/* Save only RBP, RBX, RSP, RIP - exclude this call. */
 	movq %rbp, UC_MCONTEXT_GREGS_RBP(%rdi)
@@ -135,3 +141,23 @@ _Ux86_64_getcontext_trace:
 
       /* We do not need executable stack.  */
       .section        .note.GNU-stack,"",@progbits
+
+#if defined(__CET__)
+      /* ELF note indicating control-flow protection in effect */
+	.section NOTE_GNU_PROPERTY_SECTION_NAME,"a"
+	.align 8
+	.long 1f - 0f
+	.long 4f - 1f
+	.long NT_GNU_PROPERTY_TYPE_0
+0:
+	.string "GNU"
+1:
+	.align 8
+	.long GNU_PROPERTY_X86_FEATURE_1_AND_LO
+	.long 3f - 2f
+2:
+	.long __CET__ 
+3:
+	.align 8
+4:
+#endif

--- a/src/x86_64/setcontext.S
+++ b/src/x86_64/setcontext.S
@@ -34,8 +34,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 */
 	.global _Ux86_64_setcontext
 	.type _Ux86_64_setcontext, @function
-
 _Ux86_64_setcontext:
+	.cfi_startproc
+#if defined(__CET__) && __CET__ & 0x01
+	endbr64
+#endif
 
 #if defined __linux__ || defined __sun
         /* restore fp state */
@@ -81,8 +84,30 @@ _Ux86_64_setcontext:
 	mov    UC_MCONTEXT_GREGS_RCX(%rdi),%rcx
 	mov    UC_MCONTEXT_GREGS_RDI(%rdi),%rdi
 	retq
+	.cfi_endproc
 
 	.size _Ux86_64_setcontext, . - _Ux86_64_setcontext
 
       /* We do not need executable stack.  */
       .section        .note.GNU-stack,"",@progbits
+
+#if defined(__CET__)
+      /* ELF note indicating control-flow protection in effect */
+	.section NOTE_GNU_PROPERTY_SECTION_NAME,"a"
+	.align 8
+	.long 1f - 0f
+	.long 4f - 1f
+	.long NT_GNU_PROPERTY_TYPE_0
+0:
+	.string "GNU"
+1:
+	.align 8
+	.long GNU_PROPERTY_X86_FEATURE_1_AND_LO
+	.long 3f - 2f
+2:
+	.long __CET__ 
+3:
+	.align 8
+4:
+#endif
+

--- a/src/x86_64/siglongjmp.S
+++ b/src/x86_64/siglongjmp.S
@@ -23,6 +23,8 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
+#include "ucontext_i.h"
+
 #if defined(__FreeBSD__)
 #define SIG_SETMASK 3
 #endif
@@ -30,6 +32,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 	.globl _UI_siglongjmp_cont
 	.type _UI_siglongjmp_cont, @function
 _UI_siglongjmp_cont:
+#if defined(__CET__) && __CET__ & 0x01
+	endbr64
+#endif
 #if defined(__linux__) || defined(__QNX__)
 	retq
 #elif defined(__FreeBSD__)
@@ -48,3 +53,23 @@ _UI_siglongjmp_cont:
 	.size _UI_siglongjmp_cont, . - _UI_siglongjmp_cont
 	/* We do not need executable stack.  */
 	.section	.note.GNU-stack,"",@progbits
+#if defined(__CET__)
+	/* ELF note indicating control-flow protection in effect */
+	.section NOTE_GNU_PROPERTY_SECTION_NAME,"a"
+	.align 8
+	.long 1f - 0f
+	.long 4f - 1f
+	.long NT_GNU_PROPERTY_TYPE_0
+0:
+	.string "GNU"
+1:
+	.align 8
+	.long GNU_PROPERTY_X86_FEATURE_1_AND_LO
+	.long 3f - 2f
+2:
+	.long __CET__ 
+3:
+	.align 8
+4:
+#endif
+

--- a/src/x86_64/ucontext_i.h
+++ b/src/x86_64/ucontext_i.h
@@ -21,6 +21,8 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+#ifndef unw_ucontext_i_h
+#define unw_ucontext_i_h
 
 #if defined __linux__
 #define UC_MCONTEXT_GREGS_R8    0x28
@@ -119,3 +121,18 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #define FPREGS_OFFSET_MXCSR	0x18
 
 #endif
+
+/**
+ * Details for the GNU note.gnu.property extension.
+ *
+ * These are required for indicating the presence of the Intel Indirect Branch
+ * Tracking and Shadow Stack features (the Intel CET extension).
+ *
+ * https://software.intel.com/en-us/articles/intel-sdm
+ *
+ */
+#define NOTE_GNU_PROPERTY_SECTION_NAME ".note.gnu.property"
+#define NT_GNU_PROPERTY_TYPE_0                        5
+#define GNU_PROPERTY_X86_FEATURE_1_AND_LO    0xc0000002
+
+#endif /* unw_ucontext_i_h */


### PR DESCRIPTION
The x86_64 assembly files need to add `enbr64` instructions and a special ELF note for the GNU gnu.property extension.

Verified using `make LDFLAGS="-Wl,-z,cet-report=warning"` (only the special test case gives a wanring) and `make CFLAGS="-fcf-protection=none"` for the negative case. No regressions either way.

Fixes #829 and #644