### PR TITLE
Add Intel control-flow protection to setjmp

### DIFF
--- a/src/x86_64/longjmp.S
+++ b/src/x86_64/longjmp.S
@@ -23,12 +23,36 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
+#include "ucontext_i.h"
+
 	.globl _UI_longjmp_cont
 	.type _UI_longjmp_cont, @function
 _UI_longjmp_cont:
+#if defined(__CET__) && __CET__ & 0x01
+	endbr64
+#endif
 	push %rax		/* push target IP as return address */
 	mov %rdx, %rax		/* set up return-value */
 	retq
 	.size _UI_longjmp_cont, .-_UI_longjmp_cont
 	/* We do not need executable stack.  */
 	.section	.note.GNU-stack,"",@progbits
+#if defined(__CET__)
+	/* ELF note indicating control-flow protection in effect */
+	.section NOTE_GNU_PROPERTY_SECTION_NAME,"a"
+	.align 8
+	.long 1f - 0f
+	.long 4f - 1f
+	.long NT_GNU_PROPERTY_TYPE_0
+0:
+	.string "GNU"
+1:
+	.align 8
+	.long GNU_PROPERTY_X86_FEATURE_1_AND_LO
+	.long 3f - 2f
+2:
+	.long __CET__
+3:
+	.align 8
+4:
+#endif


### PR DESCRIPTION
Missed adding Intel control-flow protection to libunwind-setjmp.so in a previous change.

Configure with the following.
```
configure --prefix=/usr LDFLAGS='-Wl,-z,cet-report=warning' CFLAGS='-fcf-protection'
```
Ran `make` and the only issue was
```
/usr/bin/ld: x64-test-dwarf-expressions.o: warning: missing IBT and SHSTK properties
```
whici I'm not concerned about because it's a test case using hand-rolled assembly that's not relevant to Intel control-flow protection.

Fixes #644 