### PR TITLE
x86-64: Include <cet.h> for Intel CET

### DIFF
--- a/src/x86_64/getcontext.S
+++ b/src/x86_64/getcontext.S
@@ -38,9 +38,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 	.type _Ux86_64_getcontext, @function
 _Ux86_64_getcontext:
 	.cfi_startproc
-#if defined(__CET__) && __CET__ & 0x01
-	endbr64
-#endif
+	_CET_ENDBR
 
 	/* Callee saved: RBX, RBP, R12-R15  */
 	movq %r12, UC_MCONTEXT_GREGS_R12(%rdi)
@@ -141,23 +139,3 @@ _Ux86_64_getcontext_trace:
 
       /* We do not need executable stack.  */
       .section        .note.GNU-stack,"",@progbits
-
-#if defined(__CET__)
-      /* ELF note indicating control-flow protection in effect */
-	.section NOTE_GNU_PROPERTY_SECTION_NAME,"a"
-	.align 8
-	.long 1f - 0f
-	.long 4f - 1f
-	.long NT_GNU_PROPERTY_TYPE_0
-0:
-	.string "GNU"
-1:
-	.align 8
-	.long GNU_PROPERTY_X86_FEATURE_1_AND_LO
-	.long 3f - 2f
-2:
-	.long __CET__ 
-3:
-	.align 8
-4:
-#endif

--- a/src/x86_64/longjmp.S
+++ b/src/x86_64/longjmp.S
@@ -23,9 +23,12 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
+#include "ucontext_i.h"
+
 	.globl _UI_longjmp_cont
 	.type _UI_longjmp_cont, @function
 _UI_longjmp_cont:
+	_CET_ENDBR
 	push %rax		/* push target IP as return address */
 	mov %rdx, %rax		/* set up return-value */
 	retq

--- a/src/x86_64/setcontext.S
+++ b/src/x86_64/setcontext.S
@@ -36,9 +36,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 	.type _Ux86_64_setcontext, @function
 _Ux86_64_setcontext:
 	.cfi_startproc
-#if defined(__CET__) && __CET__ & 0x01
-	endbr64
-#endif
+	_CET_ENDBR
 
 #if defined __linux__ || defined __sun
         /* restore fp state */
@@ -90,24 +88,3 @@ _Ux86_64_setcontext:
 
       /* We do not need executable stack.  */
       .section        .note.GNU-stack,"",@progbits
-
-#if defined(__CET__)
-      /* ELF note indicating control-flow protection in effect */
-	.section NOTE_GNU_PROPERTY_SECTION_NAME,"a"
-	.align 8
-	.long 1f - 0f
-	.long 4f - 1f
-	.long NT_GNU_PROPERTY_TYPE_0
-0:
-	.string "GNU"
-1:
-	.align 8
-	.long GNU_PROPERTY_X86_FEATURE_1_AND_LO
-	.long 3f - 2f
-2:
-	.long __CET__ 
-3:
-	.align 8
-4:
-#endif
-

--- a/src/x86_64/siglongjmp.S
+++ b/src/x86_64/siglongjmp.S
@@ -32,9 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 	.globl _UI_siglongjmp_cont
 	.type _UI_siglongjmp_cont, @function
 _UI_siglongjmp_cont:
-#if defined(__CET__) && __CET__ & 0x01
-	endbr64
-#endif
+	_CET_ENDBR
 #if defined(__linux__) || defined(__QNX__)
 	retq
 #elif defined(__FreeBSD__)
@@ -53,23 +51,3 @@ _UI_siglongjmp_cont:
 	.size _UI_siglongjmp_cont, . - _UI_siglongjmp_cont
 	/* We do not need executable stack.  */
 	.section	.note.GNU-stack,"",@progbits
-#if defined(__CET__)
-	/* ELF note indicating control-flow protection in effect */
-	.section NOTE_GNU_PROPERTY_SECTION_NAME,"a"
-	.align 8
-	.long 1f - 0f
-	.long 4f - 1f
-	.long NT_GNU_PROPERTY_TYPE_0
-0:
-	.string "GNU"
-1:
-	.align 8
-	.long GNU_PROPERTY_X86_FEATURE_1_AND_LO
-	.long 3f - 2f
-2:
-	.long __CET__ 
-3:
-	.align 8
-4:
-#endif
-

--- a/src/x86_64/ucontext_i.h
+++ b/src/x86_64/ucontext_i.h
@@ -122,17 +122,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #endif
 
-/**
- * Details for the GNU note.gnu.property extension.
- *
- * These are required for indicating the presence of the Intel Indirect Branch
- * Tracking and Shadow Stack features (the Intel CET extension).
- *
- * https://software.intel.com/en-us/articles/intel-sdm
- *
- */
-#define NOTE_GNU_PROPERTY_SECTION_NAME ".note.gnu.property"
-#define NT_GNU_PROPERTY_TYPE_0                        5
-#define GNU_PROPERTY_X86_FEATURE_1_AND_LO    0xc0000002
+#if defined(__CET__)
+# include <cet.h>
+#else
+# define _CET_ENDBR
+#endif
 
 #endif /* unw_ucontext_i_h */

--- a/tests/x64-test-dwarf-expressions.S
+++ b/tests/x64-test-dwarf-expressions.S
@@ -33,6 +33,12 @@
 # these registers and cause this test to fail mysteriously.
 
 
+#if defined(__CET__)
+# include <cet.h>
+#else
+# define _CET_ENDBR
+#endif
+
 ########################################################
 # Test: Restoring a register using a DW_CFA_expression #
 # which uses implicit CFA pushed onto stack.           #
@@ -41,6 +47,7 @@
 .type DW_CFA_expression_testcase STT_FUNC
 DW_CFA_expression_testcase:
   .cfi_startproc
+  _CET_ENDBR
   push %r12
   .cfi_adjust_cfa_offset 8
   # Move our sentinel (known) value into non-volatile (Callee-saved) r12


### PR DESCRIPTION
Include <cet.h> when Intel Control-flow Enforcement Technology (CET) is enabled.  Both GCC and Clang provide <cet.h> which should be included in assembly codes with .S suffix when -fcf-protection is used.  It will define _CET_ENDBR (endbr64) and the .note.gnu.property note section.

Fixes #644.