### PR TITLE
Use unw_word_t instead of unsigned long for registers

### DIFF
--- a/include/unwind.h
+++ b/include/unwind.h
@@ -88,9 +88,9 @@ extern _Unwind_Reason_Code _Unwind_ForcedUnwind (struct _Unwind_Exception *,
                                                  _Unwind_Stop_Fn, void *);
 extern void _Unwind_Resume (struct _Unwind_Exception *);
 extern void _Unwind_DeleteException (struct _Unwind_Exception *);
-extern unsigned long _Unwind_GetGR (struct _Unwind_Context *, int);
-extern void _Unwind_SetGR (struct _Unwind_Context *, int, unsigned long);
-extern unsigned long _Unwind_GetIP (struct _Unwind_Context *);
+extern unw_word_t _Unwind_GetGR (struct _Unwind_Context *, int);
+extern void _Unwind_SetGR (struct _Unwind_Context *, int, unw_word_t);
+extern unw_word_t _Unwind_GetIP (struct _Unwind_Context *);
 extern unsigned long _Unwind_GetIPInfo (struct _Unwind_Context *, int *);
 extern void _Unwind_SetIP (struct _Unwind_Context *, unsigned long);
 extern unsigned long _Unwind_GetLanguageSpecificData (struct _Unwind_Context*);

--- a/src/unwind/GetGR.c
+++ b/src/unwind/GetGR.c
@@ -25,7 +25,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "unwind-internal.h"
 
-unsigned long
+unw_word_t
 _Unwind_GetGR (struct _Unwind_Context *context, int index)
 {
   unw_word_t val;

--- a/src/unwind/GetIP.c
+++ b/src/unwind/GetIP.c
@@ -25,7 +25,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "unwind-internal.h"
 
-unsigned long
+unw_word_t
 _Unwind_GetIP (struct _Unwind_Context *context)
 {
   unw_word_t val;
@@ -34,5 +34,5 @@ _Unwind_GetIP (struct _Unwind_Context *context)
   return val;
 }
 
-unsigned long __libunwind_Unwind_GetIP (struct _Unwind_Context *)
+unw_word_t __libunwind_Unwind_GetIP (struct _Unwind_Context *)
      ALIAS (_Unwind_GetIP);

--- a/src/unwind/SetGR.c
+++ b/src/unwind/SetGR.c
@@ -30,7 +30,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 void
 _Unwind_SetGR (struct _Unwind_Context *context, int index,
-               unsigned long new_value)
+               unw_word_t new_value)
 {
 #ifdef UNW_TARGET_X86
   index = dwarf_to_unw_regnum(index);
@@ -43,5 +43,5 @@ _Unwind_SetGR (struct _Unwind_Context *context, int index,
 #endif
 }
 
-void __libunwind_Unwind_SetGR (struct _Unwind_Context *, int, unsigned long)
+void __libunwind_Unwind_SetGR (struct _Unwind_Context *, int, unw_word_t)
      ALIAS (_Unwind_SetGR);


### PR DESCRIPTION
Use unw_word_t instead of unsigned long in _Unwind_SetGR, _Unwind_GetGR and _Unwind_GetIP since the full integer register fits unw_word_t, not unsigned long.