### PR TITLE
x86-64: Add a configure option to enable Intel CET

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -480,6 +480,43 @@ fi
 AC_SUBST([LIBZ])
 AM_CONDITIONAL(HAVE_ZLIB, test x$enable_zlibdebuginfo = xyes)
 
+AC_MSG_CHECKING([if -fcf-protection is on by default])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+#if defined(__x86_64__) && defined(__CET__)
+# error CET is on by default
+#endif
+]])], [cet_on=no],[cet_on=yes])
+AC_MSG_RESULT([$cet_on])
+
+AC_MSG_CHECKING([whether to enable Intel CET support])
+AC_ARG_ENABLE(cet,
+AS_HELP_STRING([--enable-cet], [Enables support for Intel CET]),,
+	[enable_cet=auto])
+case x$enable_cet in
+  xyes)
+    AC_MSG_RESULT([$enable_cet])
+    AC_SUBST([UNW_CET_CFLAGS],["-mshstk -fcf-protection"])
+    AC_SUBST([LD_FLAGS_UNW_CET],["-Wl,-z,cet-report=error"])
+    ;;
+  xno)
+    if test $cet_on = yes; then
+	AC_MSG_RESULT([yes, ignoring --disable-cet since Intel CET is always enabled])
+	AC_SUBST([UNW_CET_CFLAGS],["-mshstk -fcf-protection"])
+	AC_SUBST([LD_FLAGS_UNW_CET],["-Wl,-z,cet-report=error"])
+	enable_cet=yes
+    else
+	AC_MSG_RESULT([$enable_cet])
+    fi
+    ;;
+  xauto)
+    AC_MSG_RESULT([$enable_cet])
+    if test $cet_on = yes; then
+	AC_SUBST([UNW_CET_CFLAGS],["-mshstk -fcf-protection"])
+	AC_SUBST([LD_FLAGS_UNW_CET],["-Wl,-z,cet-report=error"])
+    fi
+    ;;
+esac
+
 AC_MSG_CHECKING([for Intel compiler])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
         [],

--- a/include/tdep-x86_64/libunwind_i.h
+++ b/include/tdep-x86_64/libunwind_i.h
@@ -80,6 +80,8 @@ struct cursor
   {
     struct dwarf_cursor dwarf;          /* must be first */
 
+    uintptr_t frames;                   /* Stack frames to pop.  */
+
     unw_tdep_frame_t frame_info;        /* quick tracing assist info */
 
     /* Format of sigcontext structure and address at which it is

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,8 +28,11 @@ COREDUMP_SO_VERSION=0:0:0
 AM_CPPFLAGS = $(UNW_DEBUG_CPPFLAGS) \
               $(UNW_REMOTE_CPPFLAGS) \
               $(UNW_TARGET_CPPFLAGS) \
+              $(UNW_CET_CFLAGS) \
               -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I.
 AM_CFLAGS = $(UNW_EXTRA_CFLAGS)
+
+AM_LDFLAGS = $(LD_FLAGS_UNW_CET)
 
 #
 # Don't link with start-files since we don't use any constructors/destructors:

--- a/src/x86_64/Ginit_local.c
+++ b/src/x86_64/Ginit_local.c
@@ -51,6 +51,7 @@ unw_init_local_common (unw_cursor_t *cursor, ucontext_t *uc, unsigned use_prev_i
 
   c->dwarf.as = unw_local_addr_space;
   c->dwarf.as_arg = dwarf_build_as_arg(uc, /*validate*/ 0);
+  c->frames = 0;
   return common_init (c, use_prev_instr);
 }
 

--- a/src/x86_64/Gos-linux.c
+++ b/src/x86_64/Gos-linux.c
@@ -150,6 +150,22 @@ x86_64_sigreturn (unw_cursor_t *cursor)
 
   Debug (8, "resuming at ip=%llx via sigreturn(%p)\n",
              (unsigned long long) c->dwarf.ip, sc);
+
+  /* Pop 4 shadow stack frames:
+
+#0  _Ux86_64_sigreturn (cursor=0x7fffffffc990) at x86_64/Gos-linux.c:144
+#1  0x00007ffff7f9d23f in _Ux86_64_local_resume (
+    as=0x7ffff7fb63c0 <local_addr_space>, cursor=0x7fffffffc990, arg=0x2)
+    at x86_64/Gresume.c:50
+#2  0x00007ffff7f9d44b in _Ux86_64_resume (cursor=0x7fffffffc990)
+    at x86_64/Gresume.c:123
+#3  0x000000000040094b in handler (sig=10) at Gtest-resume-sig.c:127
+#4  <signal handler called>
+#5  0x00007ffff7d80e7b in kill () from /lib64/libc.so.6
+
+   */
+  POP_SHADOW_STACK_FRAMES (4);
+
   __asm__ __volatile__ ("mov %0, %%rsp;"
                         "mov %1, %%rax;"
                         "syscall"

--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -92,6 +92,8 @@ unw_step (unw_cursor_t *cursor)
       return ret;
     }
 
+  c->frames++;
+
   if (likely (ret >= 0))
     {
       /* x86_64 ABI specifies that end of call-chain is marked with a

--- a/src/x86_64/setcontext.S
+++ b/src/x86_64/setcontext.S
@@ -75,6 +75,25 @@ _Ux86_64_setcontext:
 	mov    UC_MCONTEXT_GREGS_RCX(%rdi),%rcx
 	mov    UC_MCONTEXT_GREGS_RSP(%rdi),%rsp
 
+	/* Pop 2 shadow stack frames:
+
+#0  _Ux86_64_local_resume (as=0x7ffff7fb63c0 <local_addr_space>,
+    cursor=0x7fffffffd7b0, arg=0xf) at x86_64/Gresume.c:58
+#1  0x00007ffff7f9d44b in _Ux86_64_resume (cursor=0x7fffffffd7b0)
+    at x86_64/Gresume.c:123
+#2  0x00000000004007a8 in raise_exception () at Gtest-exc.c:90
+#3  0x00000000004008a2 in b (n=16) at Gtest-exc.c:146
+#4  0x0000000000400818 in a (n=0) at Gtest-exc.c:120
+
+	 */
+	xor	%ecx,%ecx
+	rdsspq	%rcx
+	test	%rcx,%rcx
+	jz	2f
+	mov	$2, %ecx
+	incsspq	%rcx
+
+2:
         /* push the return address on the stack */
 	mov    UC_MCONTEXT_GREGS_RIP(%rdi),%rcx
 	push   %rcx

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -32,8 +32,11 @@ testdir = ${pkglibexecdir}
 AM_CPPFLAGS = $(UNW_DEBUG_CPPFLAGS) \
               $(UNW_REMOTE_CPPFLAGS) \
               $(UNW_TARGET_CPPFLAGS) \
+              $(UNW_CET_CFLAGS) \
               -I$(top_srcdir)/include -I$(top_srcdir)/include/tdep-$(arch) -I$(top_srcdir)/src
 AM_CFLAGS = $(UNW_EXTRA_CFLAGS) -g -fno-optimize-sibling-calls
+
+AM_LDFLAGS = $(LD_FLAGS_UNW_CET)
 
 LOG_DRIVER = $(SHELL) $(UNW_TESTDRIVER)
 
@@ -267,9 +270,11 @@ ppc64_test_plt_SOURCES = ppc64-test-plt.c
 
 
 Gx64_test_dwarf_expressions_SOURCES =  Gx64-test-dwarf-expressions.c \
-																			 x64-test-dwarf-expressions.S
+  x64-test-dwarf-expressions.S
 Lx64_test_dwarf_expressions_SOURCES =  Lx64-test-dwarf-expressions.c \
-																			 x64-test-dwarf-expressions.S
+  x64-test-dwarf-expressions.S
+Gx64_test_dwarf_expressions_CFLAGS = $(UNW_CET_CFLAGS)
+Lx64_test_dwarf_expressions_CFLAGS = $(UNW_CET_CFLAGS)
 
 Garm_test_debug_frame_bt_SOURCES = Garm-test-debug-frame-bt.c ident.c
 Larm_test_debug_frame_bt_SOURCES = Larm-test-debug-frame-bt.c ident.c


### PR DESCRIPTION
1. Add a configure option, --enable-cet, to compile libunwind with "-mshstk -fcf-protection" and link with -Wl,-z,cet-report=error.
2. Add a frames field to struct cursor and update unw_step to cont stack frames to pop.
3. Update x86_64_sigreturn to pop 4 shadow stack frames.
4. Update x86_64_local_resume to pop the same number of shadow stack frames as the regular stack frames.
5. Update _Ux86_64_setcontext to pop 2 shadow stack frames.

There are no failures with

$ ./configure --enable-cet
$ make -j12
$ GLIBC_TUNABLES=glibc.cpu.hwcaps=SHSTK make check

on Linux when shadow stack is enabled.