### PR TITLE
Made -nostdlib depend on exception support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,17 +81,6 @@ AC_CHECK_TYPES([struct elf_prstatus, struct prstatus, procfs_status, elf_fpregse
 
 dnl Checks for libraries.
 AC_MSG_NOTICE([--- Checking for libraries ---])
-save_LDFLAGS="$LDFLAGS"
-save_LIBS="$LIBS"
-LDFLAGS="${LDFLAGS} -nostdlib"
-AC_SEARCH_LIBS([_Unwind_Resume], [gcc_s gcc],
-               [AS_IF([test "$ac_cv_search__Unwind_Resume" != "none required"],
-                      [AC_SUBST([LIBCRTS], ["$ac_cv_search__Unwind_Resume"])])],
-               [],
-               [-lc]
-)
-LIBS="$save_LIBS"
-LDFLAGS="$save_LDFLAGS"
 AC_SEARCH_LIBS([__uc_get_grs], [uca])
 AC_SEARCH_LIBS([getcontext], [ucontext])
 
@@ -299,7 +288,7 @@ AC_ARG_ENABLE([debug],
 )
 AC_MSG_RESULT([$enable_debug])
 
-AC_MSG_CHECKING([if C++ exception support shouldm  be built])
+AC_MSG_CHECKING([if C++ exception support should be built])
 AC_ARG_ENABLE([cxx_exceptions],
               [AS_HELP_STRING([--enable-cxx-exceptions],
                               [use libunwind to handle C++ exceptions
@@ -314,6 +303,16 @@ AS_IF([test $enable_cxx_exceptions = check],
 )
 AC_MSG_RESULT([$enable_cxx_exceptions])
 AM_CONDITIONAL([SUPPORT_CXX_EXCEPTIONS], [test x$enable_cxx_exceptions = xyes])
+AM_COND_IF([SUPPORT_CXX_EXCEPTIONS],
+           [save_LDFLAGS="$LDFLAGS"
+            LDFLAGS="${LDFLAGS} -nostdlib"
+            AC_SEARCH_LIBS([_Unwind_Resume], [gcc_s gcc],
+                           [AS_IF([test "$ac_cv_search__Unwind_Resume" != "none required"],
+                                  [AC_SUBST([UNW_CRT_LIBADD],  ["-lc $ac_cv_search__Unwind_Resume"])
+                                   AC_SUBST([UNW_CRT_LDFLAGS], ["-WCClinker -nostdlib"])])]
+                           [-lc])
+            LDFLAGS="$save_LDFLAGS"]
+)
 
 AC_MSG_CHECKING([if documentation should be built])
 AC_ARG_ENABLE([documentation],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -127,7 +127,7 @@ endif
 # If local unwinding is being built, link in the local unwinding functions
 libunwind_libadd =
 if !REMOTE_ONLY
-  libunwind_libadd += libunwind.la -lc
+  libunwind_libadd += libunwind.la
 endif
 
 ### pkg-config:
@@ -1264,10 +1264,13 @@ endif
 # Don't link with standard libraries, because those may mention
 # libunwind already.
 #
-libunwind_la_LDFLAGS =	$(COMMON_SO_LDFLAGS) -XCClinker -nostdlib \
-			$(LDFLAGS_STATIC_LIBCXA) -version-info $(SOVERSION)
-libunwind_la_LIBADD  += -lc $(LIBCRTS)
-libunwind_la_LIBADD += $(LIBLZMA) $(LIBZ)
+libunwind_la_LDFLAGS = $(COMMON_SO_LDFLAGS) \
+                       $(UNW_CRT_LDFLAGS) \
+                       $(LDFLAGS_STATIC_LIBCXA) \
+                       -version-info $(SOVERSION)
+libunwind_la_LIBADD += $(UNW_CRT_LIBADD) \
+                       $(LIBLZMA) \
+                       $(LIBZ)
 
 noinst_HEADERS += unwind/unwind-internal.h
 


### PR DESCRIPTION
When libunwind is configured to provide the Itanium Level 1 Exception Support it needs to avoid linking in any compiler runtime libraries that already provide that support (for example, libgcc_s.so) in order to avoid duplicate symbols or ODR violations.  This caused a problem on more recent GCC editions because of some dark magic in which libgcc_s.so is actually a linker script instead of a shared object so the library will be underlinked on some platforms.

The use of `-nostdlib` should be limited to only the case in which the optional exception support is selected at configure time. When that is the case, we can assume the developer knows what they're doing (they're writing their own exception handling stack) and can pass the right LDADD explcitly as required.

This changes makes the use of `-nostdlib` and `-lc -lgcc_s` dependent on the configure-time `--enable-cxx-exceptions=yes`, which is not the default.

Closes #907 
Closes #693 