### PR TITLE
Fix off-by-one in aarch64 unw_backtrace()

### DIFF
--- a/src/aarch64/Gtrace.c
+++ b/src/aarch64/Gtrace.c
@@ -573,7 +573,7 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       break;
 
     /* Record this address in stack trace. We skipped the first address. */
-    buffer[depth++] = (void *) (pc - d->use_prev_instr);
+    buffer[depth++] = (void *) pc;
   }
 
   Debug (1, "returning %d, depth %d\n", ret, depth);


### PR DESCRIPTION
The code was subtracting the `use_prev_instr` value twice, resulting in odd-numbered addresses for the IP in the returned array.

fixes #911 