### PR TITLE
Disable C++ exception report for HPPA by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -298,7 +298,7 @@ AC_ARG_ENABLE([cxx_exceptions],
 )
 AS_IF([test $enable_cxx_exceptions = check],
       [AS_CASE([$target_arch],
-               [aarch64*|arm*|mips*|x86*|s390x*|loongarch64], [enable_cxx_exceptions=no],
+               [aarch64*|arm*|hppa*|mips*|x86*|s390x*|loongarch64], [enable_cxx_exceptions=no],
                [enable_cxx_exceptions=yes])]
 )
 AC_MSG_RESULT([$enable_cxx_exceptions])


### PR DESCRIPTION
`Ltest-cxx-exceptions` doesn't work, better off not buildinging it by default.

Patch due to danglin44
fixes #889 