### PR TITLE
[v1.8] Fix off-by-one in aarch64 unw_backtrace()

### DIFF
--- a/src/aarch64/Gtrace.c
+++ b/src/aarch64/Gtrace.c
@@ -572,7 +572,7 @@ tdep_trace (unw_cursor_t *cursor, void **buffer, int *size)
       break;
 
     /* Record this address in stack trace. We skipped the first address. */
-    buffer[depth++] = (void *) (pc - d->use_prev_instr);
+    buffer[depth++] = (void *) pc;
   }
 
 #if UNW_DEBUG


### PR DESCRIPTION
The code was subtracting the `use_prev_instr` value twice, resulting in odd-numbered addresses for the IP in the returned array.

(cherry picked from commit 3c4658cb973b7bf57cb40de1271965b4f5803555 on branch `master`)

fixes #912 