### PR TITLE
Avoid C4319 warnings from UNW_ALIGN

### DIFF
--- a/include/libunwind_i.h
+++ b/include/libunwind_i.h
@@ -431,6 +431,6 @@ static inline void invalidate_edi (struct elf_dyn_info *edi)
 # define DWARF_VAL_LOC(c,v)     DWARF_NULL_LOC
 #endif
 
-#define UNW_ALIGN(x,a) (((x)+(a)-1UL)&~((a)-1UL))
+#define UNW_ALIGN(x,a) (((size_t)(x) + (size_t)(a) - 1) & ~((size_t)(a) - 1))
 
 #endif /* libunwind_i_h */


### PR DESCRIPTION
MSVC 19.44.35221.0 now warns on some uses, the added casts avoid it.
```
src\mi\mempool.c(96): warning C4319: '~': zero extending 'unsigned long' to 'size_t' of greater size
src\mi\mempool.c(127): warning C4319: '~': zero extending 'unsigned long' to 'size_t' of greater size
```

cc: @am11