### PR TITLE
libunwind-ppc: include sys/reg.h

### DIFF
--- a/include/libunwind-ppc32.h
+++ b/include/libunwind-ppc32.h
@@ -38,6 +38,7 @@ extern "C" {
 
 #include <inttypes.h>
 #include <stdint.h>
+#include <sys/reg.h>
 #include <ucontext.h>
 
 #ifndef UNW_EMPTY_STRUCT

--- a/include/libunwind-ppc64.h
+++ b/include/libunwind-ppc64.h
@@ -38,6 +38,7 @@ extern "C" {
 
 #include <inttypes.h>
 #include <stdint.h>
+#include <sys/reg.h>
 #include <ucontext.h>
 
 #ifndef UNW_EMPTY_STRUCT


### PR DESCRIPTION
Needed for a definition of __WORDSIZE under musl.