### PR TITLE
mips/getcontext: set nomips16

### DIFF
--- a/src/mips/getcontext.S
+++ b/src/mips/getcontext.S
@@ -26,6 +26,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "offsets.h"
 
 	.text
+	.set nomips16
 
 #if _MIPS_SIM == _ABIO32
 # if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__


### PR DESCRIPTION
This assembly is incompatible with mips16.

Fixes compilation when mips16 is enabled.