### PR TITLE
Build aarch64 SVE tests at -O0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -532,6 +532,11 @@ if test x$GCC = xyes -a x$intel_compiler != xyes; then
     AC_SUBST([UNW_EXTRA_CFLAGS],["-fexceptions -Wall -Wsign-compare"])
 fi
 
+# Workaround for code generation bug in certain GCC versions for aarch64+sve
+if test x$GCC = xyes; then
+    AC_SUBST([UNW_EXTRA_SVE_FLAGS],["-fno-stack-clash-protection -fno-ipa-sra"])
+fi
+
 AC_MSG_CHECKING([for QCC compiler])
 AS_CASE([$CC], [qcc*|QCC*], [qcc_compiler=yes], [qcc_compiler=no])
 AC_MSG_RESULT([$qcc_compiler])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -286,11 +286,11 @@ Laarch64_test_frame_record_SOURCES = aarch64-test-frame-record.c
 Gaarch64_test_frame_record_SOURCES = aarch64-test-frame-record.c
 
 if COMPILER_SUPPORTS_MARCH_ARMV8_A_SVE
- Garm64_test_sve_signal_CFLAGS = $(AM_CFLAGS) -fno-inline -march=armv8-a+sve
- Larm64_test_sve_signal_CFLAGS = $(AM_CFLAGS) -fno-inline -march=armv8-a+sve
+ Garm64_test_sve_signal_CFLAGS = $(AM_CFLAGS) -fno-inline -march=armv8-a+sve $(UNW_EXTRA_SVE_FLAGS)
+ Larm64_test_sve_signal_CFLAGS = $(AM_CFLAGS) -fno-inline -march=armv8-a+sve $(UNW_EXTRA_SVE_FLAGS)
 endif
 # https://github.com/libunwind/libunwind/issues/512
-XFAIL_TESTS += Garm64-test-sve-signal Larm64-test-sve-signal
+# XFAIL_TESTS += Garm64-test-sve-signal Larm64-test-sve-signal
 
 Gtest_init_SOURCES = Gtest-init.cxx
 Ltest_init_SOURCES = Ltest-init.cxx

--- a/tests/unw_test.h
+++ b/tests/unw_test.h
@@ -28,6 +28,10 @@
 #ifndef LIBUNWIND_UNW_TEST_H
 #define LIBUNWIND_UNW_TEST_H 1
 
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+
 /**
  * Exit values for test programs.
  * Based on https://www.gnu.org/software/automake/manual/html_node/Scripts_002dbased-Testsuites.html
@@ -36,12 +40,82 @@
  * CTest, or automake).
  */
 enum {
-  UNW_TEST_EXIT_PASS        =  0,  /* Item under test is a PASS */
-  UNW_TEST_EXIT_FAIL        =  1,  /* Item under test is a FAIL */
-  UNW_TEST_EXIT_BAD_COMMAND =  2,  /* Test program is invoked with invalid arguments */
-  UNW_TEST_EXIT_SKIP        = 77,  /* Test should be skipped */
-  UNW_TEST_EXIT_HARD_ERROR  = 99   /* Test program itself has failed */
+  UNW_TEST_EXIT_PASS        =  0,  /**< Item under test is a PASS */
+  UNW_TEST_EXIT_FAIL        =  1,  /**< Item under test is a FAIL */
+  UNW_TEST_EXIT_BAD_COMMAND =  2,  /**< Test program is invoked with invalid arguments */
+  UNW_TEST_EXIT_SKIP        = 77,  /**< Test should be skipped */
+  UNW_TEST_EXIT_HARD_ERROR  = 99   /**< Test program itself has failed */
 };
+
+/**
+ * libunwind test assertion macro
+ *
+ * Use for testing a condition and printing out a useful error message when that
+ * condition does not hold.
+ *
+ * Prints out the error message and exits the prohram with UNW_TEST_EXIT_FAIL.
+ *
+ * Example:
+ * ```
+ * UNW_TEST_ASSERT(retval > 0, "unw_step() failed at frame %d\n", frame_number);
+ * ```
+ */
+#define UNW_TEST_ASSERT(cond, fmt, ...) cond \
+    ? (void)0 \
+    : _unw_test_fail_assertion(#cond, __FILE__, __LINE__, fmt __VA_OPT__(,) __VA_ARGS__)
+
+/**
+ * libunwind test check macro
+ *
+ * Use for testing a condition and printing out a useful error message when that
+ * condition does not hold.
+ *
+ * Prints out the error message and continues.
+ *
+ * Example:
+ * ```
+ * UNW_TEST_CHECK(retval > 0, "unw_step() failed at frame %d\n", frame_number);
+ * ```
+ */
+#define UNW_TEST_CHECK(cond, fmt, ...) cond \
+    ? (void)0 \
+    : _unw_test_fail_check(#cond, __FILE__, __LINE__, fmt __VA_OPT__(,) __VA_ARGS__)
+
+/**
+ * Maximum length of the formatted error string printed by UNW_TEST_ASSERT.
+ */
+#define UNW_TEST_MAX_ERRSTRING_LEN 1024
+
+static inline void
+_unw_test_fail_assertion(char const * const cond_str,
+                         char const * const file,
+                         int                line,
+                         char const * const fmt, ...)
+{
+  char err_str[UNW_TEST_MAX_ERRSTRING_LEN];
+
+  va_list args;
+  va_start(args, fmt);
+  vsnprintf(err_str, UNW_TEST_MAX_ERRSTRING_LEN, fmt, args);
+  va_end(args);
+  fprintf(stderr, "%s:%d ASSERTION FAIL '%s': %s\n", file, line, cond_str, err_str);
+  exit(UNW_TEST_EXIT_FAIL);
+}
+
+static inline void
+_unw_test_fail_check(char const * const cond_str,
+                         char const * const file,
+                         int                line,
+                         char const * const fmt, ...)
+{
+  char err_str[UNW_TEST_MAX_ERRSTRING_LEN];
+
+  va_list args;
+  va_start(args, fmt);
+  vsnprintf(err_str, UNW_TEST_MAX_ERRSTRING_LEN, fmt, args);
+  va_end(args);
+  fprintf(stderr, "%s:%d CHECK FAIL '%s': %s\n", file, line, cond_str, err_str);
+}
 
 #endif /* LIBUNWIND_UNW_TEST_H */
 


### PR DESCRIPTION
There appear to be a bug in GCC when SVE-related instructions are in use such that the DWARF frame-info code emitted is incorrect and the call frame address gets munged. This only happens when the optimizer is used, so force the SVE tests to be built at -O0.

This change required refactoring the default CFLAGS set by configure to come earlier in the sequence because they will contain -O2. The user can still specify -O2 (or whatever) in CFLAGS and it will be picked up and possibly cause the SVE tests to fail.

As a result of investigating this problem I also refactored the test code itself to give more meaningful error messages. The unw_test.h macros will be useful elsewhere too.

fixes #512