### PR TITLE
Fix unwinding through vDSO functions on aarch64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,7 +91,9 @@ tests/[GL]x64-test-dwarf-expressions
 tests/x64-unwind-badjmp-signal-frame
 tests/[GL]arm64-test-sve-signal
 tests/aarch64-test-plt
-tests/aarch64-test-frame-record
+tests/[GL]aarch64-test-frame-record
+tests/[GL]aarch64-test-frame-size
+tests/aarch64-test-lr-fallback
 tests/[GL]arm-test-debug-frame-bt
 tests/*.log
 tests/*.trs

--- a/src/aarch64/Gstep.c
+++ b/src/aarch64/Gstep.c
@@ -156,22 +156,389 @@ unw_is_plt_entry (unw_cursor_t *uc)
 	return _is_plt_entry (&((struct cursor *)uc)->dwarf);
 }
 
-/* Recognise when a frame record storing FP+LR has been created and whether FP
-   has been updated to point to the frame record. For example:
-  4183d4:       a9bd7bfd        stp     x29, x30, [sp,#-48]!    <= FP+LR stored
-  4183d8:       d2800005        mov     x5, #0x0
-  4183dc:       d2800004        mov     x4, #0x0
-  4183e0:       910003fd        mov     x29, sp                 <= FP updated
-  4183e4:       a90153f3        stp     x19, x20, [sp,#16]
-  ...
-  418444:       a94153f3        ldp     x19, x20, [sp,#16]
-  418448:       f94013f5        ldr     x21, [sp,#32]
-  41844c:       a8c37bfd        ldp     x29, x30, [sp],#48      <= FP+LR retrieved
-  418450:       d65f03c0        ret
-*/
+typedef enum
+  {
+    SP_UNCHANGED,
+    SP_ADJUSTED,
+    SP_UNKNOWN,
+  } sp_state_t;
+
+/* Detect a single straight-line stack decrement that has not been undone by a
+   matching restore or invalidated by ambiguous control flow.  When no frame
+   record is found, the SP adjustment is returned via the offset field so the
+   caller can correct the CFA for LR fallback.
+
+   From the linux aarch64 vDSO:
+
+      <__kernel_gettimeofday>:
+      d10043ff  sub  sp, sp, #0x10         <= SP adjusted
+      b4000680  cbz  x0, ...
+      ...
+      910043ff  add  sp, sp, #0x10         <= SP restored
+      d65f03c0  ret  */
+static void
+track_stack_pointer (uint32_t insn, sp_state_t *state, int32_t *offset)
+{
+  if (*state == SP_UNKNOWN)
+    return;
+
+  if (*state == SP_UNCHANGED
+      && ((insn & 0x7c000000) == 0x14000000       /* B, BL */
+          || (insn & 0xff000000) == 0x54000000    /* B.cond, BC.cond */
+          || (insn & 0x7e000000) == 0x34000000    /* CBZ, CBNZ */
+          || (insn & 0x7e000000) == 0x36000000    /* TBZ, TBNZ */
+          || (insn & 0xfe9fc000) == 0xd61f0000    /* BR, BLR, RET (+PAC) */
+          || (insn & 0xfe9f8000) == 0xd69f0000))  /* ERET, DRPS */
+    {
+      *state = SP_UNKNOWN;
+      *offset = 0;
+    }
+
+  /* SUB SP, SP, #imm
+
+     | 1 | 1 | 0 | 10001 | shift |     imm12     |   Rn  |   Rd  |
+
+     Rn == SP (x31) => 0b11111
+     Rd == SP (x31) => 0b11111.
+
+     Using a bitmask of 0xff0003ff, the masked instruction would be
+     0xd10003ff. */
+  else if ((insn & 0xff0003ff) == 0xd10003ff)
+    {
+      int32_t imm = (insn >> 10) & 0xfff;
+      if (insn & 0x00400000)  /* shift == 0b01 (LSL #12) */
+        imm <<= 12;
+      if (imm != 0)
+        {
+          if (*state != SP_UNCHANGED)
+            {
+              *state = SP_UNKNOWN;
+              *offset = 0;
+            }
+          else
+            {
+              *state = SP_ADJUSTED;
+              *offset = imm;
+            }
+        }
+    }
+
+  /* ADD SP, SP, #imm
+
+     | 1 | 0 | 0 | 10001 | shift |     imm12     |   Rn  |   Rd  |
+
+     Rn == SP (x31) => 0b11111
+     Rd == SP (x31) => 0b11111.
+
+     Using a bitmask of 0xff0003ff, the masked instruction would be
+     0x910003ff. */
+  else if ((insn & 0xff0003ff) == 0x910003ff)
+    {
+      int32_t imm = (insn >> 10) & 0xfff;
+      if (insn & 0x00400000)  /* shift == 0b01 (LSL #12) */
+        imm <<= 12;
+      if (imm != 0)
+        {
+          if (*state == SP_ADJUSTED && *offset == imm)
+            *state = SP_UNCHANGED;
+          else
+            *state = SP_UNKNOWN;
+          *offset = 0;
+        }
+    }
+
+  /* STP Xt1, Xt2, [SP, #-imm]!
+
+     | 10 | 101 | 0 | 011 | 0 |   imm7  |  Rt2  |   Rn  |   Rt  |
+
+     Rn == SP (x31) => 0b11111.
+
+     Using a bitmask of 0xffc003e0, the masked instruction would be
+     0xa98003e0. The offset value is (imm7 * 8) */
+  else if ((insn & 0xffc003e0) == 0xa98003e0)
+    {
+      /* STP x29, x30 is handled by track_frame_record, not here. */
+      if ((insn & 0x1f) == 0x1d && ((insn >> 10) & 0x1f) == 0x1e)
+        return;
+
+      int32_t imm = (insn >> 15) & 0x7f;
+      if (imm & 0x40)
+        imm |= ~0x7f;
+      if (imm < 0)
+        {
+          imm = -(imm * 8);
+          if (*state != SP_UNCHANGED)
+            {
+              *state = SP_UNKNOWN;
+              *offset = 0;
+            }
+          else
+            {
+              *state = SP_ADJUSTED;
+              *offset = imm;
+            }
+        }
+      else
+        {
+          *state = SP_UNKNOWN;
+          *offset = 0;
+        }
+    }
+
+  /* LDP Xt1, Xt2, [SP], #imm
+
+     | 10 | 101 | 0 | 011 | 1 |   imm7  |  Rt2  |   Rn  |   Rt  |
+
+     Rn == SP (x31) => 0b11111.
+
+     Using a bitmask of 0xffc003e0, the masked instruction would be
+     0xa8c003e0. The offset value is (imm7 * 8) */
+  else if ((insn & 0xffc003e0) == 0xa8c003e0)
+    {
+      /* LDP x29, x30 is handled by track_frame_record, not here. */
+      if ((insn & 0x1f) == 0x1d && ((insn >> 10) & 0x1f) == 0x1e)
+        return;
+
+      int32_t imm = (insn >> 15) & 0x7f;
+      if (imm & 0x40)
+        imm |= ~0x7f;
+      if (imm > 0 && *state == SP_ADJUSTED
+          && *offset == imm * 8)
+        {
+          *state = SP_UNCHANGED;
+          *offset = 0;
+        }
+      else
+        {
+          *state = SP_UNKNOWN;
+          *offset = 0;
+        }
+    }
+
+  /* STR Xt, [SP, #-imm]!
+
+     | 11 | 111 | 0 | 00 | 00 | 0 |   imm9  | 11 |   Rn  |   Rt  |
+
+     Rn == SP (x31) => 0b11111.
+
+     Using a bitmask of 0xffe00fe0, the masked instruction would be
+     0xf8000fe0. The offset value is (imm9) */
+  else if ((insn & 0xffe00fe0) == 0xf8000fe0)
+    {
+      int32_t imm = (insn >> 12) & 0x1ff;
+      if (imm & 0x100)
+        imm |= ~0x1ff;
+      if (imm < 0)
+        {
+          imm = -imm;
+          if (*state != SP_UNCHANGED)
+            {
+              *state = SP_UNKNOWN;
+              *offset = 0;
+            }
+          else
+            {
+              *state = SP_ADJUSTED;
+              *offset = imm;
+            }
+        }
+      else
+        {
+          *state = SP_UNKNOWN;
+          *offset = 0;
+        }
+    }
+
+  /* LDR Xt, [SP], #imm
+
+     | 11 | 111 | 0 | 00 | 01 | 0 |   imm9  | 01 |   Rn  |   Rt  |
+
+     Rn == SP (x31) => 0b11111.
+
+     Using a bitmask of 0xffe00fe0, the masked instruction would be
+     0xf84007e0. The offset value is (imm9) */
+  else if ((insn & 0xffe00fe0) == 0xf84007e0)
+    {
+      int32_t imm = (insn >> 12) & 0x1ff;
+      if (imm & 0x100)
+        imm |= ~0x1ff;
+      if (imm > 0 && *state == SP_ADJUSTED && *offset == imm)
+        *state = SP_UNCHANGED;
+      else
+        *state = SP_UNKNOWN;
+      *offset = 0;
+    }
+
+  /* ADD/SUB SP, x29, #imm
+
+     | 1 | op | 0 | 10001 | shift |     imm12     |   Rn  |   Rd  |
+
+     Rn == FP (x29) => 0b11101
+     Rd == SP (x31) => 0b11111.
+
+     MOV Rd, Rn is equivalent to ADD Rd, Rn, #0
+
+     Mask out op (bit 30), shift (bit 22), and imm12 (bits 10-21).
+     Using a bitmask of 0xbf0003ff, the masked instruction would be
+     0x910003bf. */
+  else if ((insn & 0xbf0003ff) == 0x910003bf)
+    {
+      *state = SP_UNKNOWN;
+      *offset = 0;
+    }
+
+  /* ADD/SUB SP, SP, Xm
+
+     | 1 | op | 0 | 01011 | 00 | 1 |  Rm  | option | imm3 |  Rn  |  Rd  |
+
+     Rn == SP (x31) => 0b11111
+     Rd == SP (x31) => 0b11111.
+
+     Mask out op (bit 30).  Using a bitmask of 0xdfe003ff, the masked
+     instruction would be 0x8b2003ff. */
+  else if ((insn & 0xdfe003ff) == 0x8b2003ff)
+    {
+      *state = SP_UNKNOWN;
+      *offset = 0;
+    }
+}
+
+/* Detect the STP/MOV/LDP sequence that creates and destroys a frame record,
+   tracking loc through NONE -> AT_SP_OFFSET -> AT_FP -> (back to NONE).
+
+   For example:
+
+      4183d4:  a9bd7bfd  stp  x29, x30, [sp,#-48]!   <= FP+LR stored
+      4183d8:  d2800005  mov  x5, #0x0
+      4183dc:  d2800004  mov  x4, #0x0
+      4183e0:  910003fd  mov  x29, sp                 <= FP updated
+      4183e4:  a90153f3  stp  x19, x20, [sp,#16]
+      ...
+      418444:  a94153f3  ldp  x19, x20, [sp,#16]
+      418448:  f94013f5  ldr  x21, [sp,#32]
+      41844c:  a8c37bfd  ldp  x29, x30, [sp],#48      <= FP+LR restored
+      418450:  d65f03c0  ret  */
+static void
+track_frame_record (uint32_t insn, unw_word_t insn_addr,
+                    frame_record_location_t *loc, int32_t *offset)
+{
+  if (*loc == NONE)
+    {
+      /* Check that a 64-bit store pair (STP) instruction storing FP
+         and LR has been executed, which would indicate that a frame
+         record has been created and that the LR value is saved therein.
+
+         From the ARM Architecture Reference Manual (ARMv8), the format
+         of the 64-bit STP instruction is
+
+         | 10 | 101 | 0 | 0XX | 0 |   imm7  |  Rt2  |   Rn  |   Rt  |
+
+         where X can be 0/1 above to indicate the instruction variant
+         (post-index, pre-index or signed offset).
+
+         Rt2 == LR (x30) => 0b11110
+         Rn  == SP (x31) => 0b11111
+         Rt  == FP (x29) => 0b11101.
+
+         So using a bitmask of 0xfe407fff, the masked instruction would
+         be 0xa8007bfd */
+      if ((insn & 0xfe407fff) == 0xa8007bfd)
+        {
+          *loc = AT_SP_OFFSET;
+
+          /* If the signed offset variant of the STP instruction is
+             detected, the frame record may not be currently pointed to
+             by SP. Extract the offset from the STP instruction.
+
+             The signed offset variant is
+
+             | 10 | 101 | 0 | 010 | 0 | imm7 | Rt2 | Rn | Rt |
+
+             So using a bitmask of 0xffc07fff, the masked instruction
+             would be 0xa9007bfd. The offset value is (imm7 * 8) */
+          if ((insn & 0xffc07fff) == 0xa9007bfd)
+            {
+              int32_t imm = (insn >> 15) & 0x7f;
+              if (imm & 0x40) imm |= ~0x7f;
+              *offset = imm * 8;
+            }
+          else
+            *offset = 0;
+
+          Debug (4, "ip=0x%lx => frame record stored at SP+0x%x\n",
+                 (long) insn_addr, *offset);
+        }
+    }
+  else if (*loc == AT_SP_OFFSET)
+    {
+      /* If the STP instruction has been executed, but not the
+         instruction to update FP, then the SP (with offset) should be
+         used to find the frame record, otherwise the FP should be used
+         as there are no guarantees that the SP is pointing to the frame
+         record after the FP has been updated.
+
+         Two methods for updating the FP have been seen in practice.
+         The first is a MOV instruction. The 64-bit MOV (to/from SP)
+         instruction to update FP (x29) is 0x910003fd.
+
+         The second is an ADD instruction taking SP and FP as the source
+         and destination registers, respectively. The 64-bit ADD
+         (immediate) instruction is
+
+         | 1 | 0 | 0 | 10001 | shift |     imm12     |   Rn  |   Rd  |
+
+         Rn == SP (x31) => 0b11111
+         Rd == FP (x29) => 0b11101.
+
+         So using a bitmask of 0xff0003ff, the masked instruction would
+         be 0x910003fd.
+
+         Since the MOV instruction is an alias for ADD, it is sufficient
+         to only check for the latter case. */
+      if ((insn & 0xff0003ff) == 0x910003fd)
+        {
+          *loc = AT_FP;
+          *offset = 0;
+
+          Debug (4, "ip=0x%lx => frame record stored at FP\n",
+                 (long) insn_addr);
+        }
+    }
+  else if (*loc == AT_FP)
+    {
+      /* Check that a 64-bit load pair (LDP) instruction to restore FP
+         and LR has been executed, which would indicate that a branch or
+         return instruction is about to be executed and that FP is
+         pointing to the caller's frame record instead.
+
+         The format of the 64-bit LDP instruction is
+
+         | 10 | 101 | 0 | 0XX | 1 |   imm7  |  Rt2  |   Rn  |   Rt  |
+
+         Rt2 == LR (x30) => 0b11110
+         Rn  == SP (x31) => 0b11111
+         Rt  == FP (x29) => 0b11101.
+
+         So using a bitmask of 0xfe407fff, the masked instruction would
+         be 0xa8407bfd */
+      if ((insn & 0xfe407fff) == 0xa8407bfd)
+        {
+          *loc = NONE;
+          *offset = 0;
+
+          Debug (4, "ip=0x%lx => frame record has been loaded, use LR\n",
+                 (long) insn_addr);
+        }
+    }
+}
+
+/* Scan instructions from the start of the current procedure up to the current
+   IP tracking the frame record and SP adjustment. */
 frame_state_t
 get_frame_state (unw_cursor_t *cursor)
 {
+  sp_state_t sp_state = SP_UNCHANGED;
+  int32_t sp_offset = 0;
   struct cursor *c = (struct cursor *) cursor;
   unw_accessors_t *a = unw_get_accessors (c->dwarf.as);
   unw_word_t w, start_ip, ip, offp;
@@ -183,7 +550,9 @@ get_frame_state (unw_cursor_t *cursor)
   if (_is_plt_entry (&c->dwarf))
     return fs;
 
-  /* Use get_proc_name to find start_ip of procedure */
+  /* Use get_proc_name to find start_ip of procedure.
+     For vDSO functions (the primary consumer of this fallback),
+     .dynsym is always available even though .eh_frame is discarded. */
   char name[128];
   if (((*a->get_proc_name) (c->dwarf.as, c->dwarf.ip, name, sizeof(name), &offp, c->dwarf.as_arg)) != 0)
     return fs;
@@ -198,150 +567,27 @@ get_frame_state (unw_cursor_t *cursor)
       if ((*a->access_mem) (c->dwarf.as, ip, &w, 0, c->dwarf.as_arg) < 0)
         return fs;
 
-      if (fs.loc == NONE)
+      uint32_t insns[2] = { w & 0xffffffff, w >> 32 };
+
+      for (int j = 0; j < 2; j++)
         {
-          /* Check that a 64-bit store pair (STP) instruction storing FP and LR
-             has been executed, which would indicate that a frame record has been
-             created and that the LR value is saved therein.
+          uint32_t insn = insns[j];
 
-             From the ARM Architecture Reference Manual (ARMv8), the format of the
-             64-bit STP instruction is
+          if (c->dwarf.ip <= ip + j * 4)
+            continue;
 
-             | 10 | 101 | 0 | 0XX | 0 |   imm7  |  Rt2  |   Rn  |   Rt  |
+          track_stack_pointer (insn, &sp_state, &sp_offset);
 
-             where X can be 0/1 above to indicate the instruction variant (post-
-             index, pre-index or signed offset). imm7 is a 7-bit signed immediate
-             offset. The following should be asserted for this check
-
-             Rt2 == LR (x30) => 0b11110
-             Rn  == SP (x31) => 0b11111
-             Rt  == FP (x29) => 0b11101.
-
-             Hence the bitmask should be constructed to assert that the instruction
-             is
-
-             | 10 | 101 | 0 | 0XX | 0 | XXXXXXX | 11110 | 11111 | 11101 |
-
-             So using a bitmask of 0xfe407fff, the masked instruction would be
-             0xa8007bfd */
-          if ((((w & 0xfe407fff00000000) == 0xa8007bfd00000000) && (c->dwarf.ip > ip + 4))
-           || (((w & 0x00000000fe407fff) == 0x00000000a8007bfd) && (c->dwarf.ip > ip)))
-            {
-              fs.loc = AT_SP_OFFSET;
-
-              /* If the signed offset variant of the STP instruction is detected,
-                 the frame record may not be currently pointed to by SP. Extract
-                 the offset from the STP instruction.
-
-                 From the ARM Architecture Reference Manual (ARMv8), the format of
-                 the signed offset variant of the 64-bit STP instruction is
-
-                 | 10 | 101 | 0 | 010 | 0 | imm7 | Rt2 | Rn | Rt |
-
-                 Hence the bitmask should be constructed to assert that the
-                 instruction is
-
-                 | 10 | 101 | 0 | 010 | 0 | XXXXXXX | 11110 | 11111 | 11101 |
-
-                 So using a bitmask of 0xffc07fff, the masked instruction would
-                 be 0xa9007bdf. The offset value is (imm7 * 8) */
-              if (((w & 0xffc07fff00000000) == 0xa9007bfd00000000) && (c->dwarf.ip > ip + 4))
-                {
-                  int32_t abs_offset = (w & 0x001f800000000000) >> 47;
-                  fs.offset = ((w & 0x0020000000000000)? -abs_offset : abs_offset) * 8;
-                }
-              else if (((w & 0x00000000ffc07fff) == 0x00000000a9007bfd) && (c->dwarf.ip > ip))
-                {
-                  int32_t abs_offset = (w & 0x00000000001f8000) >> 15;
-                  fs.offset = ((w & 0x0000000000200000)? -abs_offset : abs_offset) * 8;
-                }
-              else
-                fs.offset = 0;
-
-              Debug (4, "ip=0x%lx => frame record stored at SP+0x%x\n", ip, fs.offset);
-            }
-        }
-
-      if (fs.loc == AT_SP_OFFSET)
-        {
-          /* If the STP instruction has been executed, but not the instruction
-             to update FP, then the SP (with offset) should be used to find the
-             frame record, otherwise the FP should be used as there are no
-             guarantees that the SP is pointing to the frame record after the FP
-             has been updated.
-
-             Two methods for updating the FP have been seen in practice. The
-             first is a MOV instruction. From the ARM Architecture Reference
-             Manual (ARMv8), the 64-bit MOV (to/from SP) instruction to update
-             FP (x29) is 0x910003fd.
-
-             The second is an ADD instruction taking SP and FP as the source and
-             destination registers, respectively. From the ARM Architecture
-             Reference Manual (ARMv8), the 64-bit ADD (immediate) instruction is
-
-             | 1 | 0 | 0 | 10001 | shift |     imm12    |   Rn  |   Rd  |
-
-             where the values of shift and imm12 are irrelevant for this check.
-             The following should be asserted
-
-             Rn == SP (x31) => 0b11111
-             Rd == FP (x29) => 0b11101.
-
-             Hence the bitmask should be constructed to assert that the instruction
-             is
-
-             | 1 | 0 | 0 | 10001 |   XX  | XXXXXXXXXXXX | 11111 | 11101 |
-
-             So using a bitmask of 0xff0003ff, the masked instruction would be
-             0x910003fd.
-
-             Since the MOV instruction is an alias for ADD, it is sufficient to
-             only check for the latter case. */
-          if ((((w & 0xff0003ff00000000) == 0x910003fd00000000) && (c->dwarf.ip > ip + 4))
-           || (((w & 0x00000000ff0003ff) == 0x00000000910003fd) && (c->dwarf.ip > ip)))
-            {
-              fs.loc = AT_FP;
-              fs.offset = 0;
-
-              Debug (4, "ip=0x%lx => frame record stored at FP\n", ip);
-            }
-        }
-      else if (fs.loc == AT_FP)
-        {
-          /* Check that a 64-bit load pair (LDP) instruction to restore FP and LR has been
-             executed, which would indicate that a branch or return instruction is about to
-             be executed and that FP is pointing to the caller's frame record instead. The
-             LR should be examined for the return address. In this case, the RA must have
-             already been authenticated.
-
-             From the ARM Architecture Reference Manual (ARMv8), the format of the 64-bit
-             LDP instruction is
-
-             | 10 | 101 | 0 | 0XX | 1 |   imm7  |  Rt2  |   Rn  |   Rt  |
-
-             where X can be 0/1 above to indicate the instruction variant (post-index, pre-
-             index or signed offset). imm7 is a 7-bit signed immediate offset, which is
-             irrelevant for this check. However, the following should be asserted
-
-             Rt2 == LR (x30) => 0b11110
-             Rn  == SP (x31) => 0b11111
-             Rt  == FP (x29) => 0b11101.
-
-             Hence the bitmask should be constructed to assert that the instruction is
-
-             | 10 | 101 | 0 | 0XX | 1 | XXXXXXX | 11110 | 11111 | 11101 |
-
-             So using a bitmask of 0xfe407fff, the masked instruction would be 0xa8407bfd */
-          if ((((w & 0xfe407fff00000000) == 0xa8407bfd00000000) && (c->dwarf.ip > ip + 4))
-           || (((w & 0x00000000fe407fff) == 0x00000000a8407bfd) && (c->dwarf.ip > ip)))
-            {
-              fs.loc = NONE;
-              fs.offset = 0;
-
-              Debug (4, "ip=0x%lx => frame record has been loaded, use LR\n", ip);
-            }
+          /* Frame-record tracking.  Detects the STP/MOV/LDP sequence that
+             creates and destroys a frame record, tracking fs.loc through
+             NONE -> AT_SP_OFFSET -> AT_FP -> (back to NONE).  */
+          track_frame_record (insn, ip + j * 4, &fs.loc, &fs.offset);
         }
     }
+
+  /* Use the SP offset if no frame record was found. */
+  if (fs.loc == NONE)
+    fs.offset = sp_offset;
 
   Debug (3, "[start_ip = 0x%lx, ip=0x%lx) => loc = %d, offset = %d\n",
             start_ip, c->dwarf.ip, fs.loc, fs.offset);
@@ -764,8 +1010,8 @@ unw_step (unw_cursor_t *cursor)
         }
 
       /* No frame record, fallback to link register (X30).  */
-      c->frame_info.cfa_reg_offset = 0;
-      c->frame_info.cfa_reg_sp = 0;
+      c->frame_info.cfa_reg_sp = (fs.offset > 0) ? 1 : 0;
+      c->frame_info.cfa_reg_offset = fs.offset;
       c->frame_info.fp_cfa_offset = -1;
       c->frame_info.lr_cfa_offset = -1;
       c->frame_info.sp_cfa_offset = -1;
@@ -779,7 +1025,16 @@ unw_step (unw_cursor_t *cursor)
               Debug (2, "failed to get pc from link register: %d\n", ret);
               return ret;
             }
-          Debug (2, "link register (x30) = 0x%016lx\n", c->dwarf.ip);
+          /* Undo the stack frame allocation so the CFA is correct for
+             the caller.  Without this adjustment, the next DWARF step
+             would compute register locations from the wrong SP.  */
+          if (fs.offset > 0)
+            {
+              c->dwarf.cfa += fs.offset;
+              Debug (2, "adjusted CFA by +%d for stack frame\n", fs.offset);
+            }
+          Debug (2, "link register (x30) = 0x%016lx, CFA = 0x%016lx\n",
+                 c->dwarf.ip, c->dwarf.cfa);
           ret = 1;
         }
       else

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -95,7 +95,9 @@ endif
 if ARCH_AARCH64
   check_PROGRAMS_arch += Garm64-test-sve-signal Larm64-test-sve-signal   \
                          aarch64-test-plt \
-                         Laarch64-test-frame-record Gaarch64-test-frame-record
+                         Laarch64-test-frame-record Gaarch64-test-frame-record \
+                         Laarch64-test-frame-size Gaarch64-test-frame-size \
+                         aarch64-test-lr-fallback
 endif
 
  check_PROGRAMS_cdep +=	Gtest-bt Ltest-bt				 \
@@ -277,6 +279,11 @@ Larm64_test_sve_signal_SOURCES = Larm64-test-sve-signal.c
 aarch64_test_plt_SOURCES = aarch64-test-plt.c
 Laarch64_test_frame_record_SOURCES = aarch64-test-frame-record.c
 Gaarch64_test_frame_record_SOURCES = aarch64-test-frame-record.c
+Laarch64_test_frame_size_SOURCES = aarch64-test-frame-size.c
+Gaarch64_test_frame_size_SOURCES = aarch64-test-frame-size.c
+aarch64_test_lr_fallback_CFLAGS = $(AM_CFLAGS) -DUNW_LOCAL_ONLY
+aarch64_test_lr_fallback_SOURCES = aarch64-test-lr-fallback.c \
+                                   aarch64-test-lr-fallback-asm.S
 
 if COMPILER_SUPPORTS_MARCH_ARMV8_A_SVE
  Garm64_test_sve_signal_CFLAGS = $(AM_CFLAGS) -fno-inline -march=armv8-a+sve $(UNW_EXTRA_SVE_FLAGS)
@@ -410,3 +417,7 @@ aarch64_test_plt_LDADD = $(LIBUNWIND)
 Laarch64_test_frame_record_CFLAGS = $(AM_CFLAGS) -DUNW_LOCAL_ONLY
 Laarch64_test_frame_record_LDADD = $(LIBUNWIND_internal)
 Gaarch64_test_frame_record_LDADD = $(LIBUNWIND_arch)
+Laarch64_test_frame_size_CFLAGS = $(AM_CFLAGS) -DUNW_LOCAL_ONLY
+Laarch64_test_frame_size_LDADD = $(LIBUNWIND_internal)
+Gaarch64_test_frame_size_LDADD = $(LIBUNWIND_arch)
+aarch64_test_lr_fallback_LDADD = $(LIBUNWIND_local) $(PTHREADS_LIB)

--- a/tests/aarch64-test-frame-record.c
+++ b/tests/aarch64-test-frame-record.c
@@ -180,7 +180,7 @@ main ()
       0xd65f03c0, // ret
                   // some instructions skipped
       0x34ffffa4, // cbz     w4, 41838c <indenterror+0x1c>
-      0xa9be7bfd, // stp     x29, x30, [sp,#-32]      <= FP+LR stored
+      0xa9be7bfd, // stp     x29, x30, [sp,#-32]!     <= FP+LR stored
       0x910003fd, // mov     x29, sp                  <= FP updated
       0xf9000bf3, // str     x19, [sp,#16]
       0xf9400bf3, // ldr     x19, [sp,#16]
@@ -251,10 +251,12 @@ main ()
     fs = get_frame_state(&cursor);
     if (fs.loc != NONE || fs.offset != 0) return -1;
 
-    /* IP is pointing to instruction that stores FP and LR */
+    /* IP is pointing to instruction that stores FP and LR.  fs.offset
+       is the frame size (0x20) and comes from the immediate in the
+       sub sp, sp, #0x20 instruction. */
     c->dwarf.ip = (unw_word_t) (instructions+IpStp);
     fs = get_frame_state(&cursor);
-    if (fs.loc != NONE || fs.offset != 0) return -1;
+    if (fs.loc != NONE || fs.offset != 0x20) return -1;
 
     /* IP is pointing to instruction that updates the FP */
     c->dwarf.ip = (unw_word_t) (instructions+IpAdd);
@@ -289,7 +291,7 @@ main ()
       0xd2800007, // mov     x7, #0x0                        // #0
                   // some instructions skipped
       0xd2800003, // mov     x3, #0x0                        // #0
-      0xa9217bfd, // stp     x29, x30, [sp,#-16]
+      0xa93f7bfd, // stp     x29, x30, [sp,#-16]
       0x910043fd, // add     x29, sp, #0x10
       0xb90003ff, // str     wzr, [sp]
                   // some instructions skipped
@@ -306,10 +308,12 @@ main ()
     fs = get_frame_state(&cursor);
     if (fs.loc != NONE || fs.offset != 0) return -1;
 
-    /* IP is pointing to instruction that stores FP and LR */
+    /* IP is pointing to instruction that stores FP and LR.  fs.offset
+       is the frame size (0x20) and comes from the immediate in the
+       sub sp, sp, #0x20 instruction. */
     c->dwarf.ip = (unw_word_t) (instructions+IpStp);
     fs = get_frame_state(&cursor);
-    if (fs.loc != NONE || fs.offset != 0) return -1;
+    if (fs.loc != NONE || fs.offset != 0x20) return -1;
 
     /* IP is pointing to instruction that updates the FP */
     c->dwarf.ip = (unw_word_t) (instructions+IpAdd);
@@ -327,6 +331,141 @@ main ()
     if (fs.loc != AT_FP || fs.offset != 0) return -1;
 
     /* IP is pointing to instruction after FP and LR are retrieved */
+    c->dwarf.ip = (unw_word_t) (instructions+IpLdp+1);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != NONE || fs.offset != 0) return -1;
+  }
+
+  /* STP_POST_INDEX procedure: verify post-index STP is detected */
+  {
+    int IpStp  = 0;
+    int IpMov  = 1;
+    int IpLdp  = 4;
+
+    unsigned int instructions[6] = {
+      0xa8827bfd, // stp     x29, x30, [sp], #32        <= FP+LR stored (post-index)
+      0x910003fd, // mov     x29, sp                    <= FP updated
+      0xa90153f3, // stp     x19, x20, [sp,#16]
+                  // some instructions skipped
+      0xa94153f3, // ldp     x19, x20, [sp,#16]
+      0xa8c27bfd, // ldp     x29, x30, [sp],#32         <= FP+LR retrieved
+      0xd65f03c0, // ret
+    };
+    procedure_size = 6;
+
+    c->dwarf.as_arg = &instructions;
+
+    /* IP is pointing to instruction that stores FP and LR */
+    c->dwarf.ip = (unw_word_t) (instructions+IpStp);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != NONE || fs.offset != 0) return -1;
+
+    /* IP is pointing to instruction that updates the FP */
+    c->dwarf.ip = (unw_word_t) (instructions+IpMov);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != AT_SP_OFFSET || fs.offset != 0) return -1;
+
+    /* IP is pointing to instruction after FP was updated */
+    c->dwarf.ip = (unw_word_t) (instructions+IpMov+1);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != AT_FP || fs.offset != 0) return -1;
+
+    /* IP is pointing to instruction that retrieves FP and LR */
+    c->dwarf.ip = (unw_word_t) (instructions+IpLdp);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != AT_FP || fs.offset != 0) return -1;
+
+    /* IP is pointing to instruction after retrieval of FP and LR */
+    c->dwarf.ip = (unw_word_t) (instructions+IpLdp+1);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != NONE || fs.offset != 0) return -1;
+  }
+
+  /* LDP_SIGNED_OFFSET procedure: verify signed-offset LDP is detected */
+  {
+    int IpStp  = 0;
+    int IpMov  = 1;
+    int IpLdp  = 4;
+
+    unsigned int instructions[6] = {
+      0xa9be7bfd, // stp     x29, x30, [sp,#-32]!       <= FP+LR stored (pre-index)
+      0x910003fd, // mov     x29, sp                    <= FP updated
+      0xa90153f3, // stp     x19, x20, [sp,#16]
+                  // some instructions skipped
+      0xa94153f3, // ldp     x19, x20, [sp,#16]
+      0xa9427bfd, // ldp     x29, x30, [sp,#32]         <= FP+LR retrieved (signed offset)
+      0xd65f03c0, // ret
+    };
+    procedure_size = 6;
+
+    c->dwarf.as_arg = &instructions;
+
+    /* IP is pointing to instruction that stores FP and LR */
+    c->dwarf.ip = (unw_word_t) (instructions+IpStp);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != NONE || fs.offset != 0) return -1;
+
+    /* IP is pointing to instruction that updates the FP */
+    c->dwarf.ip = (unw_word_t) (instructions+IpMov);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != AT_SP_OFFSET || fs.offset != 0) return -1;
+
+    /* IP is pointing to instruction after FP was updated */
+    c->dwarf.ip = (unw_word_t) (instructions+IpMov+1);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != AT_FP || fs.offset != 0) return -1;
+
+    /* IP is pointing to instruction that retrieves FP and LR */
+    c->dwarf.ip = (unw_word_t) (instructions+IpLdp);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != AT_FP || fs.offset != 0) return -1;
+
+    /* IP is pointing to instruction after retrieval of FP and LR */
+    c->dwarf.ip = (unw_word_t) (instructions+IpLdp+1);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != NONE || fs.offset != 0) return -1;
+  }
+
+  /* LDP_PRE_INDEX procedure: verify pre-index LDP is detected */
+  {
+    int IpStp  = 0;
+    int IpMov  = 1;
+    int IpLdp  = 4;
+
+    unsigned int instructions[6] = {
+      0xa9be7bfd, // stp     x29, x30, [sp,#-32]!       <= FP+LR stored (pre-index)
+      0x910003fd, // mov     x29, sp                    <= FP updated
+      0xa90153f3, // stp     x19, x20, [sp,#16]
+                  // some instructions skipped
+      0xa94153f3, // ldp     x19, x20, [sp,#16]
+      0xa9c27bfd, // ldp     x29, x30, [sp,#32]!        <= FP+LR retrieved (pre-index)
+      0xd65f03c0, // ret
+    };
+    procedure_size = 6;
+
+    c->dwarf.as_arg = &instructions;
+
+    /* IP is pointing to instruction that stores FP and LR */
+    c->dwarf.ip = (unw_word_t) (instructions+IpStp);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != NONE || fs.offset != 0) return -1;
+
+    /* IP is pointing to instruction that updates the FP */
+    c->dwarf.ip = (unw_word_t) (instructions+IpMov);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != AT_SP_OFFSET || fs.offset != 0) return -1;
+
+    /* IP is pointing to instruction after FP was updated */
+    c->dwarf.ip = (unw_word_t) (instructions+IpMov+1);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != AT_FP || fs.offset != 0) return -1;
+
+    /* IP is pointing to instruction that retrieves FP and LR */
+    c->dwarf.ip = (unw_word_t) (instructions+IpLdp);
+    fs = get_frame_state(&cursor);
+    if (fs.loc != AT_FP || fs.offset != 0) return -1;
+
+    /* IP is pointing to instruction after retrieval of FP and LR */
     c->dwarf.ip = (unw_word_t) (instructions+IpLdp+1);
     fs = get_frame_state(&cursor);
     if (fs.loc != NONE || fs.offset != 0) return -1;

--- a/tests/aarch64-test-frame-size.c
+++ b/tests/aarch64-test-frame-size.c
@@ -1,0 +1,498 @@
+/* libunwind - a platform-independent unwind library
+
+This file is part of libunwind.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+/* Unit test for AArch64 get_frame_state SP and frame-record tracking.  */
+
+#include "dwarf.h"
+#include "libunwind_i.h"
+#include "compiler.h"
+#include "unw_test.h"
+#include <stdio.h>
+
+int unw_is_signal_frame (unw_cursor_t *cursor UNUSED) { return 0; }
+int dwarf_step (struct dwarf_cursor *c UNUSED) { return 0; }
+
+static int procedure_size;
+int verbose;
+
+static int
+access_mem (unw_addr_space_t as UNUSED, unw_word_t addr, unw_word_t *val,
+            int write, void *arg)
+{
+  if (write != 0)
+    return -1;
+
+  if ((void *) addr < arg ||
+      (char *) addr > (const char *) arg + procedure_size * sizeof(uint32_t))
+    return -1;
+
+  *val = *(const unw_word_t *) addr;
+  return 0;
+}
+
+static int
+get_proc_name (unw_addr_space_t as UNUSED, unw_word_t ip, char *buf UNUSED,
+               size_t len UNUSED, unw_word_t *offp, void *arg)
+{
+  *offp = ip - (unw_word_t) arg;
+  return 0;
+}
+
+/* Stub that always fails, simulating dladdr lock contention. */
+static int
+get_proc_name_fail (unw_addr_space_t as UNUSED, unw_word_t ip UNUSED,
+                    char *buf UNUSED, size_t len UNUSED,
+                    unw_word_t *offp UNUSED, void *arg UNUSED)
+{
+  return -UNW_ENOINFO;
+}
+
+int
+main (int argc, char **argv UNUSED)
+{
+  struct unw_addr_space mock_address_space;
+  mock_address_space.acc.access_mem = &access_mem;
+  mock_address_space.acc.get_proc_name = &get_proc_name;
+
+  verbose = argc > 1;
+
+  frame_state_t fs;
+  unw_cursor_t cursor;
+  struct cursor *c = (struct cursor *) &cursor;
+  c->dwarf.as = &mock_address_space;
+
+  /* SUB SP, SP, #imm */
+  /*
+   * Matches vdso __kernel_clock_gettime prologue:
+   *   sub sp, sp, #0x20
+   *   stp x20, x19, [sp, #16]
+   *   ...
+   */
+  {
+    uint32_t instructions[] = {
+      0xd10083ff, /* sub sp, sp, #0x20 */
+      0xa9014ff4, /* stp x20, x19, [sp, #16] */
+      0x71003c1f, /* cmp w0, #0xf */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    /* Before SUB: offset should be 0 */
+    c->dwarf.ip = (unw_word_t) (instructions);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+
+    /* After SUB: offset should be 32 */
+    c->dwarf.ip = (unw_word_t) (instructions + 1);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 32, "fs.offset was %d", fs.offset);
+
+    /* At end: offset should still be 32 */
+    c->dwarf.ip = (unw_word_t) (instructions + 3);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 32, "fs.offset was %d", fs.offset);
+  }
+
+  /* SUB SP, SP, #imm with LSL #12 shift */
+  {
+    uint32_t instructions[] = {
+      0xd14007ff, /* sub sp, sp, #0x1, lsl #12 */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 1);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 1 << 12, "fs.offset was %d", fs.offset);
+  }
+
+  /* STP Xt1, Xt2, [SP, #-imm]! */
+  /*
+   * Matches a common prologue pattern:
+   *   stp x29, x30, [sp, #-48]!
+   */
+  {
+    uint32_t instructions[] = {
+      0xa9bd7bfd, /* stp x29, x30, [sp, #-48]! */
+      0x910003fd, /* mov x29, sp */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    /* Before STP: offset should be 0 */
+    c->dwarf.ip = (unw_word_t) (instructions);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 0,
+		     "before STP, fs.offset was %d", fs.offset);
+
+    /* After STP x29,x30: frame record detected at SP+0. Pre-index
+       decrements SP before storing, so the frame record is at the new SP. */
+    c->dwarf.ip = (unw_word_t) (instructions + 1);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.loc == AT_SP_OFFSET, "fs.loc was %d", fs.loc);
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+  }
+
+  /* STP x29, x30, [SP, #-16]! */
+  {
+    uint32_t instructions[] = {
+      0xa9bf7bfd, /* stp x29, x30, [sp, #-16]! */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 1);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.loc == AT_SP_OFFSET, "fs.loc was %d", fs.loc);
+  }
+
+  /* STP x20, x19, [SP, #-32]! */
+  {
+    uint32_t instructions[] = {
+      0xa9be4ff4, /* stp x20, x19, [sp, #-32]! */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 1);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 32, "fs.offset was %d", fs.offset);
+  }
+
+  /* STR Xt, [SP, #-imm]! */
+  /*
+   * Matches vdso __kernel_clock_gettime on some kernels:
+   *   str x19, [sp, #-16]!
+   */
+  {
+    uint32_t instructions[] = {
+      0xf81f0ff3, /* str x19, [sp, #-16]! */
+      0xd503201f, /* nop */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    /* Before STR: offset should be 0 */
+    c->dwarf.ip = (unw_word_t) (instructions);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+
+    /* After STR: offset should be 16 */
+    c->dwarf.ip = (unw_word_t) (instructions + 1);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 16, "fs.offset was %d", fs.offset);
+  }
+
+  /* STR x20, [SP, #-32]! */
+  {
+    uint32_t instructions[] = {
+      0xf81e0ff4, /* str x20, [sp, #-32]! */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 1);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 32, "fs.offset was %d", fs.offset);
+  }
+
+  /* SUB SP, SP, #imm
+     STP x29, x30, [SP, #-imm]! */
+  {
+    uint32_t instructions[] = {
+      0xd10083ff, /* sub sp, sp, #0x20 */
+      0xa9bf7bfd, /* stp x29, x30, [sp, #-16]! */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 2);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.loc == AT_SP_OFFSET, "fs.loc was %d", fs.loc);
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+  }
+
+  /* ADD SP, SP, #imm */
+  {
+    uint32_t instructions[] = {
+      0xd10083ff, /* sub sp, sp, #0x20 */
+      0xd503201f, /* nop */
+      0x910083ff, /* add sp, sp, #0x20 */
+      0xd65f03c0, /* ret */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 2);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 32, "fs.offset was %d", fs.offset);
+
+    c->dwarf.ip = (unw_word_t) (instructions + 3);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+  }
+
+  /* LDP x29, x30, [SP], #imm */
+  {
+    uint32_t instructions[] = {
+      0xa9bd7bfd, /* stp x29, x30, [sp, #-48]! */
+      0x910003fd, /* mov x29, sp */
+      0xd503201f, /* nop */
+      0xa8c37bfd, /* ldp x29, x30, [sp], #48 */
+      0xd65f03c0, /* ret */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+
+    c->dwarf.as_arg = &instructions;
+
+    /* Before LDP: STP+MOV detected, so loc=AT_FP.  SP tracking offset
+       is not observable via offset when the frame-record path is active. */
+    c->dwarf.ip = (unw_word_t) (instructions + 3);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.loc == AT_FP, "fs.loc was %d", fs.loc);
+
+    c->dwarf.ip = (unw_word_t) (instructions + 4);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+  }
+
+  /* SUB SP, SP, #imm
+     B.EQ */
+  {
+    uint32_t instructions[] = {
+      0xd10083ff, /* sub sp, sp, #0x20 */
+      0x54000000, /* b.eq */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 2);
+    fs = get_frame_state(&cursor);
+    /* sp adjustment should not be affected by the branch */
+    UNW_TEST_ASSERT (fs.offset == 32, "fs.offset was %d", fs.offset);
+  }
+
+  /* MOV SP, x29 */
+  {
+    uint32_t instructions[] = {
+      0xd10083ff, /* sub sp, sp, #0x20 */
+      0x910003bf, /* mov sp, x29 */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 2);
+    fs = get_frame_state(&cursor);
+    /* sp adjustment should be invalidated by mov sp, x29 */
+    UNW_TEST_ASSERT (fs.loc == NONE, "fs.loc was %d", fs.loc);
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+  }
+
+  /* ADD SP, x29, #imm */
+  {
+    uint32_t instructions[] = {
+      0xd10083ff, /* sub sp, sp, #0x20 */
+      0x910043bf, /* add sp, x29, #0x10 */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 2);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.loc == NONE, "fs.loc was %d", fs.loc);
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+  }
+
+  /* SUB SP, x29, #imm */
+  {
+    uint32_t instructions[] = {
+      0xd10083ff, /* sub sp, sp, #0x20 */
+      0xd14043bf, /* sub sp, x29, #0x10 */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 2);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.loc == NONE, "fs.loc was %d", fs.loc);
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+  }
+
+  /* get_proc_name failure */
+  {
+    mock_address_space.acc.get_proc_name = &get_proc_name_fail;
+
+    uint32_t instructions[] = {
+      0xd10083ff, /* sub sp, sp, #0x20 */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+    c->dwarf.ip = (unw_word_t) (instructions + 1);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+
+    /* Restore for subsequent tests */
+    mock_address_space.acc.get_proc_name = &get_proc_name;
+  }
+
+  /* Leaf function */
+  {
+    uint32_t instructions[] = {
+      0xb0001641, /* adrp x1, 0x2c9000 */
+      0x90000d00, /* adrp x0, 0x1a0000 */
+      0xd65f03c0, /* ret */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 2);
+    fs = get_frame_state(&cursor);
+    /* Nothing affects SP or FP */
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+  }
+
+  /* BL after SUB SP, SP, #imm */
+  {
+    uint32_t instructions[] = {
+      0xd10083ff, /* sub sp, sp, #0x20 */
+      0x94000000, /* bl <label> */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 2);
+    fs = get_frame_state(&cursor);
+    /* should be unaffected by BL */
+    UNW_TEST_ASSERT (fs.offset == 32, "fs.offset was %d", fs.offset);
+  }
+
+  /* CBZ after SUB SP, SP, #imm */
+  {
+    uint32_t instructions[] = {
+      0xd10083ff, /* sub sp, sp, #0x20 */
+      0xb4000000, /* cbz x0, <label> */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 2);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 32, "fs.offset was %d", fs.offset);
+  }
+
+  /* TBNZ after SUB SP, SP, #imm */
+  {
+    uint32_t instructions[] = {
+      0xd10083ff, /* sub sp, sp, #0x20 */
+      0x37000000, /* tbnz w0, #0, <label> */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 2);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 32, "fs.offset was %d", fs.offset);
+  }
+
+  /* B.cond before SUB SP, SP, #imm */
+  {
+    uint32_t instructions[] = {
+      0x54000000, /* b.eq <label> */
+      0xd10083ff, /* sub sp, sp, #0x20 */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 2);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+  }
+
+  /* SUB SP, SP, Xm */
+  {
+    uint32_t instructions[] = {
+      0xcb2263ff, /* sub sp, sp, x2, uxtx */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 1);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+  }
+
+  /* ADD SP, SP, Xm */
+  {
+    uint32_t instructions[] = {
+      0xd10083ff, /* sub sp, sp, #0x20 */
+      0x8b2263ff, /* add sp, sp, x2, uxtx */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 2);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+  }
+
+  /* SUB SP, SP, #imm followed by STP x29, x30, [SP, #-imm]! and LDP */
+  {
+    uint32_t instructions[] = {
+      0xd10083ff, /* sub sp, sp, #0x20 */
+      0xa9bf7bfd, /* stp x29, x30, [sp, #-16]! */
+      0xa8c37bfd, /* ldp x29, x30, [sp], #48 */
+      0xd503201f, /* nop */
+    };
+    procedure_size = ARRAY_SIZE (instructions);
+    c->dwarf.as_arg = &instructions;
+
+    c->dwarf.ip = (unw_word_t) (instructions + 3);
+    fs = get_frame_state(&cursor);
+    UNW_TEST_ASSERT (fs.loc == AT_SP_OFFSET, "fs.loc was %d", fs.loc);
+    UNW_TEST_ASSERT (fs.offset == 0, "fs.offset was %d", fs.offset);
+  }
+
+  if (verbose)
+    printf ("SUCCESS\n");
+
+  return UNW_TEST_EXIT_PASS;
+}

--- a/tests/aarch64-test-lr-fallback-asm.S
+++ b/tests/aarch64-test-lr-fallback-asm.S
@@ -1,0 +1,88 @@
+/* libunwind - a platform-independent unwind library
+
+This file is part of libunwind.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+/*
+ * Assembly functions for the AArch64 LR fallback end-to-end test.
+ *
+ * Each function uses a different prologue pattern and has NO .cfi directives,
+ * so DWARF unwinding will fail and libunwind's LR fallback path is exercised.
+ * Each function spins on an atomic bool until it becomes false.
+ *
+ * The test sends a signal while the thread is inside one of these functions,
+ * then verifies the unwinder can produce a complete backtrace.
+ */
+
+    .text
+
+/*
+ * void no_eh_frame_sub_sp(std::atomic<bool> *flag)
+ *
+ * Prologue pattern: SUB SP, SP, #imm
+ *   sub sp, sp, #0x20
+ */
+    .global no_eh_frame_sub_sp
+    .type no_eh_frame_sub_sp, %function
+no_eh_frame_sub_sp:
+    sub sp, sp, #0x20
+1:
+    ldarb w1, [x0]
+    cbnz  w1, 1b
+    add sp, sp, #0x20
+    ret
+    .size no_eh_frame_sub_sp, .-no_eh_frame_sub_sp
+
+/*
+ * void no_eh_frame_stp_pre_index(std::atomic<bool> *flag)
+ *
+ * Prologue pattern: STP Xt1, Xt2, [SP, #-imm]!
+ *   stp x20, x19, [sp, #-32]!
+ */
+    .global no_eh_frame_stp_pre_index
+    .type no_eh_frame_stp_pre_index, %function
+no_eh_frame_stp_pre_index:
+    stp x20, x19, [sp, #-32]!
+1:
+    ldarb w1, [x0]
+    cbnz  w1, 1b
+    ldp x20, x19, [sp], #32
+    ret
+    .size no_eh_frame_stp_pre_index, .-no_eh_frame_stp_pre_index
+
+/*
+ * void no_eh_frame_str_pre_index(std::atomic<bool> *flag)
+ *
+ * Prologue pattern: STR Xt, [SP, #-imm]!
+ *   str x19, [sp, #-16]!
+ */
+    .global no_eh_frame_str_pre_index
+    .type no_eh_frame_str_pre_index, %function
+no_eh_frame_str_pre_index:
+    mov x9, x19
+    str x19, [sp, #-16]!
+1:
+    ldarb w1, [x0]
+    cbnz  w1, 1b
+    ldr x19, [sp], #16
+    mov x19, x9
+    ret
+    .size no_eh_frame_str_pre_index, .-no_eh_frame_str_pre_index

--- a/tests/aarch64-test-lr-fallback.c
+++ b/tests/aarch64-test-lr-fallback.c
@@ -1,0 +1,251 @@
+/* libunwind - a platform-independent unwind library
+
+This file is part of libunwind.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+/* End-to-end test for AArch64 LR fallback unwinding.
+
+   Tests that libunwind can unwind through functions without .eh_frame
+   (no DWARF unwind info) using the link register fallback path.  Exercises
+   three prologue patterns:
+     1) SUB SP, SP, #imm
+     2) STP Xt1, Xt2, [SP, #-imm]!
+     3) STR Xt, [SP, #-imm]!
+
+   Each test variant:
+     - Spawns a worker thread that calls the assembly stub in a loop
+     - Main thread sends SIGUSR1 to the worker
+     - Signal handler unwinds with unw_init_local2 + UNW_INIT_SIGNAL_FRAME
+     - Verifies the backtrace reaches the outer caller function
+     - Verifies unw_backtrace2() matches unw_step() through the same frames  */
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <ucontext.h>
+#include <unistd.h>
+#include <stdatomic.h>
+#include <dlfcn.h>
+
+#include "compiler.h"
+#include "unw_test.h"
+
+#include <libunwind.h>
+
+/* Assembly functions from aarch64-test-lr-fallback-asm.S */
+extern void no_eh_frame_sub_sp(atomic_bool *flag);
+extern void no_eh_frame_stp_pre_index(atomic_bool *flag);
+extern void no_eh_frame_str_pre_index(atomic_bool *flag);
+
+/* Target function that the test expects to find in the backtrace. */
+static const char *expected_caller = NULL;
+
+/* Result communicated from signal handler to main thread. */
+static volatile int handler_result = -1;  /* -1=not run, 0=pass, 1=fail */
+static volatile int handler_frame_count = 0;
+
+int verbose;
+
+enum { MAX_BT_DEPTH = 20 };
+
+static void
+signal_handler (int sig UNUSED, siginfo_t *info UNUSED, void *ucontext)
+{
+  unw_cursor_t cursor;
+  unw_word_t ip;
+  char sym[256];
+  unw_word_t offset;
+  int found = 0;
+  int frames = 0;
+  void *step_ips[MAX_BT_DEPTH];
+  void *bt2_ips[MAX_BT_DEPTH];
+  int bt2_depth;
+
+  if (unw_init_local2 (&cursor, (unw_context_t *) ucontext,
+                        UNW_INIT_SIGNAL_FRAME) != 0)
+    {
+      handler_result = 1;
+      return;
+    }
+
+  unw_get_reg (&cursor, UNW_REG_IP, &ip);
+  step_ips[frames] = (void *) ip;
+  frames++;
+
+  /* Walk the stack looking for expected_caller, saving IPs. */
+  while (unw_step (&cursor) > 0 && frames < MAX_BT_DEPTH)
+    {
+      unw_get_reg (&cursor, UNW_REG_IP, &ip);
+      step_ips[frames] = (void *) ip;
+      frames++;
+
+      if (unw_get_proc_name (&cursor, sym, sizeof (sym), &offset) == 0)
+        {
+          if (expected_caller && strstr (sym, expected_caller))
+            found = 1;
+        }
+    }
+
+  handler_frame_count = frames;
+
+  if (!found)
+    {
+      handler_result = 1;
+      return;
+    }
+
+  /* Now call unw_backtrace2() on the same context and compare. */
+  bt2_depth = unw_backtrace2 (bt2_ips, MAX_BT_DEPTH,
+                              (unw_context_t *) ucontext,
+                              UNW_INIT_SIGNAL_FRAME);
+
+  if (bt2_depth != frames)
+    {
+      if (verbose)
+        fprintf (stderr,
+                 "FAILURE: unw_step depth (%d) != unw_backtrace2 depth (%d)\n",
+                 frames, bt2_depth);
+      handler_result = 1;
+      return;
+    }
+
+  for (int i = 0; i < frames; i++)
+    {
+      if (labs ((long) step_ips[i] - (long) bt2_ips[i]) > 1)
+        {
+          if (verbose)
+            fprintf (stderr,
+                     "FAILURE: IPs differ at frame %d: step=%p bt2=%p\n",
+                     i, step_ips[i], bt2_ips[i]);
+          handler_result = 1;
+          return;
+        }
+    }
+
+  handler_result = 0;
+}
+
+typedef void (*stub_fn)(atomic_bool *);
+
+static atomic_bool worker_running;
+static stub_fn worker_stub;
+
+static NOINLINE void
+outer_caller (void)
+{
+  while (atomic_load (&worker_running))
+    worker_stub (&worker_running);
+}
+
+static void *
+worker_thread (void *arg UNUSED)
+{
+  outer_caller ();
+  return NULL;
+}
+
+/*
+ * Run a single test variant.
+ */
+static int
+run_test (const char *name, stub_fn fn)
+{
+  pthread_t tid;
+  int attempts;
+
+  expected_caller = "outer_caller";
+  worker_stub = fn;
+  atomic_store (&worker_running, 1);
+
+  if (pthread_create (&tid, NULL, worker_thread, NULL) != 0)
+    {
+      fprintf (stderr, "FAILURE: %s: pthread_create failed\n", name);
+      return UNW_TEST_EXIT_HARD_ERROR;
+    }
+
+  /* Give the worker time to enter the spin loop. */
+  usleep (10000);
+
+  /* Send signals until the handler runs successfully or we give up. */
+  for (attempts = 0; attempts < 10000; attempts++)
+    {
+      handler_result = -1;
+      handler_frame_count = 0;
+      pthread_kill (tid, SIGUSR1);
+      usleep (100);
+
+      if (handler_result == 0)
+        break;
+    }
+
+  atomic_store (&worker_running, 0);
+  pthread_join (tid, NULL);
+
+  if (handler_result == 0)
+    {
+      if (verbose)
+        printf ("  %-30s PASS (%d frames, %d attempts)\n",
+                name, handler_frame_count, attempts + 1);
+      return UNW_TEST_EXIT_PASS;
+    }
+
+  fprintf (stderr,
+           "FAILURE: %s: outer_caller not found in %d frames after %d attempts\n",
+           name, handler_frame_count, attempts + 1);
+  return UNW_TEST_EXIT_FAIL;
+}
+
+int
+main (int argc, char **argv UNUSED)
+{
+  int ret;
+  struct sigaction sa;
+
+  verbose = argc > 1;
+
+  sa.sa_sigaction = signal_handler;
+  sa.sa_flags = SA_SIGINFO;
+  sigemptyset (&sa.sa_mask);
+  if (sigaction (SIGUSR1, &sa, NULL) != 0)
+    {
+      fprintf (stderr, "FAILURE: sigaction failed\n");
+      return UNW_TEST_EXIT_HARD_ERROR;
+    }
+
+  ret = run_test ("sub_sp_imm", no_eh_frame_sub_sp);
+  if (ret != UNW_TEST_EXIT_PASS)
+    return ret;
+
+  ret = run_test ("stp_pre_index", no_eh_frame_stp_pre_index);
+  if (ret != UNW_TEST_EXIT_PASS)
+    return ret;
+
+  ret = run_test ("str_pre_index", no_eh_frame_str_pre_index);
+  if (ret != UNW_TEST_EXIT_PASS)
+    return ret;
+
+  if (verbose)
+    printf ("SUCCESS\n");
+
+  return UNW_TEST_EXIT_PASS;
+}


### PR DESCRIPTION
This PR adds stack pointer tracking to the existing forward scan that
tracks the frame record in order to determine the frame state.
                                                                                
The .eh_frame and .eh_frame_hdr information for vDSO functions is
discarded by the Linux kernel
                                                                                
https://github.com/torvalds/linux/blob/46b513250491a7bfc97d98791dbe6a10bcc8129d/arch/arm64/kernel/vdso/vdso.lds.S#L77-L80                                 
                                                                                
and vDSO functions are also compiled without frame pointers. That
combination means that unwinding through an interrupted vDSO call can
leave the CFA in the wrong location, leading subsequent unwind steps
to use the wrong offsets for the register state and causing a SIGSEGV.