### PR TITLE
mips: Fix O32/N32 unwinding and implement unw_resume()

### DIFF
--- a/.github/workflows/CI-linux-gnu.yml
+++ b/.github/workflows/CI-linux-gnu.yml
@@ -106,6 +106,8 @@ jobs:
           - {target: hppa,     host: hppa-linux-gnu,          qemu: hppa,     gccver: 14, container: ubuntu:26.04 }
           - {target: mips64el, host: mips64el-linux-gnuabi64, qemu: mips64el, gccver: 14, container: ubuntu:24.04 }
           - {target: mips64,   host: mips64-linux-gnuabi64,   qemu: mips64,   gccver: 14, container: ubuntu:24.04 }
+          - {target: mipsn32el, host: mips64el-linux-gnuabin32, qemu: mipsn32el, gccver: 14, container: ubuntu:24.04, cc: "mips64el-linux-gnuabi64-gcc-14 -mabi=n32", cxx: "mips64el-linux-gnuabi64-g++-14 -mabi=n32", packages: "g++-14-multilib-mips64el-linux-gnuabi64", cross_lib: "/usr/mips64el-linux-gnuabi64" }
+          - {target: mipsn32,   host: mips64-linux-gnuabin32,   qemu: mipsn32,   gccver: 14, container: ubuntu:24.04, cc: "mips64-linux-gnuabi64-gcc-14 -mabi=n32",   cxx: "mips64-linux-gnuabi64-g++-14 -mabi=n32",   packages: "g++-14-multilib-mips64-linux-gnuabi64",   cross_lib: "/usr/mips64-linux-gnuabi64" }
           - {target: mipsel,   host: mipsel-linux-gnu,        qemu: mipsel,   gccver: 14, container: ubuntu:24.04 }
           - {target: mips,     host: mips-linux-gnu,          qemu: mips,     gccver: 14, container: ubuntu:24.04 }
           - {target: ppc64,    host: powerpc64-linux-gnu,     qemu: ppc64,    gccver: 14, container: ubuntu:26.04 }
@@ -127,7 +129,7 @@ jobs:
       - name: Install ${{ matrix.config.host }} Toolchain
         run: |
           apt-get install -y autoconf automake libtool make \
-                             g++-${{ matrix.config.gccver }}-${{ matrix.config.host }} \
+                             ${{ matrix.config.packages || format('g++-{0}-{1}', matrix.config.gccver, matrix.config.host) }} \
                              qemu-user \
                              abigail-tools
         env:
@@ -144,8 +146,8 @@ jobs:
                        --with-testdriver="$(pwd)/libtool execute $(pwd)/../scripts/qemu-test-driver" \
                        --enable-debug
         env:
-          CC: ${{ matrix.config.host }}-gcc-${{ matrix.config.gccver }}
-          CXX: ${{ matrix.config.host }}-g++-${{ matrix.config.gccver }}
+          CC: ${{ matrix.config.cc || format('{0}-gcc-{1}', matrix.config.host, matrix.config.gccver) }}
+          CXX: ${{ matrix.config.cxx || format('{0}-g++-{1}', matrix.config.host, matrix.config.gccver) }}
 
       - name: Build
         run: |
@@ -177,7 +179,7 @@ jobs:
                      LDFLAGS="-L$CROSS_LIB/lib"
         env:
           UNW_DEBUG_LEVEL: 4
-          CROSS_LIB: "/usr/${{ matrix.config.host }}"
+          CROSS_LIB: ${{ matrix.config.cross_lib || format('/usr/{0}', matrix.config.host) }}
 
       - name: Upload Test Logs
         # This step only runs if the "Build and Test" step fails

--- a/include/tdep-mips/libunwind_i.h
+++ b/include/tdep-mips/libunwind_i.h
@@ -148,9 +148,24 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
 static inline int
 read_s32 (struct dwarf_cursor *c, unw_word_t addr, unw_word_t *val)
 {
-  int offset = addr & 4;
   int ret;
   unw_word_t memval;
+
+  if (sizeof (unw_word_t) == 4)
+    {
+      /* Native O32: access_mem reads 32-bit values, and signal frame
+         addresses are already adjusted for endianness in Gstep.c.  */
+      ret = (*c->as->acc.access_mem) (c->as, addr, &memval, 0, c->as_arg);
+      if (ret < 0)
+        return ret;
+
+      *val = (int32_t) memval;
+      return 0;
+    }
+
+  /* Cross-ABI (64-bit host unwinding O32 target): access_mem reads
+     64-bit values, so extract the correct 32-bit half.  */
+  int offset = addr & 4;
 
   ret = (*c->as->acc.access_mem) (c->as, addr - offset, &memval, 0, c->as_arg);
   if (ret < 0)
@@ -167,18 +182,29 @@ read_s32 (struct dwarf_cursor *c, unw_word_t addr, unw_word_t *val)
 static inline int
 write_s32 (struct dwarf_cursor *c, unw_word_t addr, const unw_word_t *val)
 {
-  int offset = addr & 4;
   int ret;
   unw_word_t memval;
+
+  if (sizeof (unw_word_t) == 4)
+    {
+      /* Native O32: access_mem writes 32-bit values, and signal frame
+         addresses are already adjusted for endianness in Gstep.c.  */
+      memval = (int32_t) *val;
+      return (*c->as->acc.access_mem) (c->as, addr, &memval, 1, c->as_arg);
+    }
+
+  /* Cross-ABI (64-bit host unwinding O32 target): access_mem reads/writes
+     64-bit values, so update the correct 32-bit half.  */
+  int offset = addr & 4;
 
   ret = (*c->as->acc.access_mem) (c->as, addr - offset, &memval, 0, c->as_arg);
   if (ret < 0)
     return ret;
 
   if ((offset != 0) == tdep_big_endian (c->as))
-    memval = (memval & ~0xffffffffLL) | (uint32_t) *val;
+    memval = (memval & ~(unw_word_t) 0xffffffffU) | (uint32_t) *val;
   else
-    memval = (memval & 0xffffffffLL) | (uint32_t) (*val << 32);
+    memval = (memval & (unw_word_t) 0xffffffffU) | ((unw_word_t) (uint32_t) *val << 32);
 
   return (*c->as->acc.access_mem) (c->as, addr - offset, &memval, 1, c->as_arg);
 }

--- a/src/mips/Ginit.c
+++ b/src/mips/Ginit.c
@@ -218,7 +218,7 @@ mips_local_addr_space_init (void)
   local_addr_space.acc.access_mem = access_mem;
   local_addr_space.acc.access_reg = access_reg;
   local_addr_space.acc.access_fpreg = access_fpreg;
-  local_addr_space.acc.resume = NULL;  /* mips_local_resume?  FIXME!  */
+  local_addr_space.acc.resume = mips_local_resume;
   local_addr_space.acc.get_proc_name = get_static_proc_name;
   local_addr_space.acc.get_elf_filename = get_static_elf_filename;
   unw_flush_cache (&local_addr_space, 0, 0);

--- a/src/mips/Ginit.c
+++ b/src/mips/Ginit.c
@@ -110,7 +110,7 @@ static int
 access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
             void *arg)
 {
-  unw_word_t *addr;
+  void *addr;
   ucontext_t *uc = arg;
 
   if (unw_is_fpreg (reg))
@@ -120,14 +120,17 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
   if (!(addr = uc_addr (uc, reg)))
     goto badreg;
 
+  /* uc_addr() returns a pointer to a 64-bit greg_t slot, even on O32 where
+     registers are 32 bits.  Read/write the full 64-bit value with sign
+     extension so setcontext() restores the correct value.  */
   if (write)
     {
-      *(unw_word_t *) (intptr_t) addr = (mips_reg_t) *val;
+      *(unsigned long long *) addr = (long long) (mips_reg_t) *val;
       Debug (12, "%s <- %llx\n", unw_regname (reg), (long long) *val);
     }
   else
     {
-      *val = (mips_reg_t) *(unw_word_t *) (intptr_t) addr;
+      *val = (mips_reg_t) *(unsigned long long *) addr;
       Debug (12, "%s -> %llx\n", unw_regname (reg), (long long) *val);
     }
   return 0;

--- a/src/mips/Gis_signal_frame.c
+++ b/src/mips/Gis_signal_frame.c
@@ -28,19 +28,19 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 /* Read a 32-bit MIPS instruction from addr via access_mem.
  *
- * On N64/N32, unw_word_t is 64 bits but MIPS instructions are 32 bits.
+ * On N64, unw_word_t is 64 bits but MIPS instructions are 32 bits.
  * access_mem does a 64-bit load, so addr must be 8-byte aligned.  Since MIPS
  * instructions are only guaranteed 4-byte aligned, use the same trick as
  * read_s32(): align addr down to 8 bytes, do one aligned load, then extract
  * the correct 32-bit half based on endianness and the original offset.
  *
- * On O32, unw_word_t is 32 bits, so access_mem reads exactly one instruction
- * and any MIPS-instruction-aligned address is fine.  */
+ * On O32 and N32, unw_word_t is 32 bits, so access_mem reads exactly one
+ * instruction and any MIPS-instruction-aligned address is fine.  */
 static int
 read_mips_instr (unw_addr_space_t as, unw_accessors_t *a,
                  unw_word_t addr, unw_word_t *val, void *arg)
 {
-#if _MIPS_SIM == _ABI64 || _MIPS_SIM == _ABIN32
+#if _MIPS_SIM == _ABI64
   int offset = addr & 4;
   unw_word_t word;
   int ret;
@@ -94,6 +94,14 @@ unw_is_signal_frame (unw_cursor_t *cursor)
           return 1;
         case 0x24021017:
           return 2;
+        default:
+          return 0;
+        }
+    case UNW_MIPS_ABI_N32:
+      switch (w0 & 0xffffffff)
+        {
+        case 0x24021843:
+          return 1;
         default:
           return 0;
         }

--- a/src/mips/Gresume.c
+++ b/src/mips/Gresume.c
@@ -22,8 +22,6 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
-/* FIXME for MIPS.  */
-
 #include <stdlib.h>
 
 #include "unwind_i.h"
@@ -33,13 +31,54 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 HIDDEN inline int
 mips_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
 {
+  struct cursor *c = (struct cursor *) cursor;
+  ucontext_t *uc = (ucontext_t *) c->dwarf.as_arg;
+
+  Debug (8, "resuming at ip=%llx via setcontext()\n",
+         (unsigned long long) c->dwarf.ip);
+  setcontext (uc);
   return -UNW_EINVAL;
 }
 
 #endif /* !UNW_REMOTE_ONLY */
 
+static inline void
+establish_machine_state (struct cursor *c)
+{
+  unw_addr_space_t as = c->dwarf.as;
+  void *arg = c->dwarf.as_arg;
+  unw_word_t val;
+  int reg;
+
+  Debug (8, "copying out cursor state\n");
+
+  for (reg = UNW_MIPS_R0; reg <= UNW_MIPS_R31; ++reg)
+    {
+      Debug (16, "copying %s %d\n", unw_regname (reg), reg);
+      if (tdep_access_reg (c, reg, &val, 0) >= 0)
+        as->acc.access_reg (as, reg, &val, 1, arg);
+    }
+
+  /* Set the PC from the cursor's IP */
+  val = c->dwarf.ip;
+  as->acc.access_reg (as, UNW_MIPS_PC, &val, 1, arg);
+}
+
 int
 unw_resume (unw_cursor_t *cursor)
 {
-  return -UNW_EINVAL;
+  struct cursor *c = (struct cursor *) cursor;
+
+  Debug (1, "(cursor=%p)\n", c);
+
+  if (!c->dwarf.ip)
+    {
+      Debug (1, "refusing to resume execution at address 0\n");
+      return -UNW_EINVAL;
+    }
+
+  establish_machine_state (c);
+
+  return (*c->dwarf.as->acc.resume) (c->dwarf.as, (unw_cursor_t *) c,
+                                     c->dwarf.as_arg);
 }

--- a/src/mips/Gstep.c
+++ b/src/mips/Gstep.c
@@ -119,18 +119,19 @@ mips_handle_signal_frame (unw_cursor_t *cursor)
 
 
 
+#define FP_REG UNW_MIPS_R30
+#define SP_REG UNW_MIPS_R29
+#define RA_REG UNW_MIPS_R31
+
+#if _MIPS_SIM == _ABI64
+
 static inline
 int is_valid_fp_val(unw_word_t cfa_val, unw_word_t fp_val)
 {
   return fp_val > 0 && cfa_val > 0 && fp_val >cfa_val && (fp_val - cfa_val < 0x4000);
 }
-
 static int _step_n64(struct cursor *c)
 {
-  #define FP_REG UNW_MIPS_R30
-  #define SP_REG UNW_MIPS_R29
-  #define RA_REG UNW_MIPS_R31
-
   //TODO:handle plt entry
   int ret;
   unw_word_t current_fp_val = 0;
@@ -206,6 +207,7 @@ static int _step_n64(struct cursor *c)
   }
   return (c->dwarf.ip == 0) ? 0 : 1;
 }
+#endif /* _MIPS_SIM == _ABI64 */
 
 int
 unw_step (unw_cursor_t *cursor)

--- a/src/mips/Gstep.c
+++ b/src/mips/Gstep.c
@@ -209,6 +209,60 @@ static int _step_n64(struct cursor *c)
 }
 #endif /* _MIPS_SIM == _ABI64 */
 
+#if _MIPS_SIM != _ABI64
+/* Fallback when DWARF info is missing (O32 and N32).  When dwarf_step()
+   fails, use $ra to determine the return address.  */
+static int _step_ra_fallback(struct cursor *c)
+{
+  int ret;
+  unw_word_t current_ra_val = 0;
+
+  ret = dwarf_get (&c->dwarf, c->dwarf.loc[RA_REG], &current_ra_val);
+  if (ret < 0)
+    {
+      /* Can't read $ra -- if the location is null, treat as end of chain. */
+      if (DWARF_IS_NULL_LOC (c->dwarf.loc[RA_REG]))
+        {
+          Debug (2, "NULL %%ra loc, returning 0\n");
+          c->dwarf.ip = 0;
+          return 0;
+        }
+      Debug (2, "returning %d [RA=0x%lx]\n", ret,
+             DWARF_GET_LOC (c->dwarf.loc[RA_REG]));
+      return ret;
+    }
+
+  Debug (2, "ra fallback: CFA=0x%lx IP=0x%lx RA=0x%lx\n",
+         (unsigned long)c->dwarf.cfa, (unsigned long)c->dwarf.ip,
+         (unsigned long)current_ra_val);
+
+  /* $ra == 0 means end of call chain (e.g., kernel sets $ra = 0 for _start,
+     though typically $ra == ip is hit first -- see below). */
+  if (current_ra_val == 0)
+    {
+      c->dwarf.ip = 0;
+      return 0;
+    }
+
+  /* $ra == ip means the frame did not change the return address -- we cannot
+     make progress.  This is the common end-of-chain case: at __start, the
+     DWARF step from __libc_start_main restored $ra to the same address as
+     the current IP. */
+  if (current_ra_val == c->dwarf.ip)
+    {
+      Debug (2, "RA == IP, end of chain\n");
+      c->dwarf.ip = 0;
+      return 0;
+    }
+
+  /* Use $ra as the next IP. */
+  c->dwarf.ip = current_ra_val;
+  c->dwarf.use_prev_instr = 1;
+
+  return 1;
+}
+#endif /* _MIPS_SIM != _ABI64 */
+
 int
 unw_step (unw_cursor_t *cursor)
 {
@@ -228,7 +282,7 @@ unw_step (unw_cursor_t *cursor)
 #if _MIPS_SIM == _ABI64
       return _step_n64(c);
 #else
-      return ret;
+      return _step_ra_fallback(c);
 #endif
     }
 


### PR DESCRIPTION
Fix several MIPS unwinding bugs across O32, N32, and N64, implement the previously-stubbed `unw_resume()`, and add N32 CI coverage.

### O32 fixes
- Fix undefined behavior in DWARF access path (`read_s32`/`write_s32` shifted 32-bit values by 32, which is UB on native O32 where `unw_word_t` is `uint32_t`)
- Fix `access_reg()` to use full 64-bit `greg_t` slots (on big-endian O32, writing only 32 bits landed in the wrong half of the 64-bit slot, causing `setcontext()` to restore garbage)
- Implement `unw_resume()` (was a stub returning `-UNW_EINVAL`; now copies cursor state back to ucontext and calls `setcontext()`)

### Unwinding improvements (O32 and N32)
- Guard `_step_n64()` with `#if _MIPS_SIM == _ABI64` and move register defines to file scope (prep for fallback function)
- Add `$ra`-based fallback when DWARF unwinding fails (O32/N32 previously returned the raw error instead of gracefully terminating the unwind chain)

### N32 fixes
- Fix N32 signal frame detection (`read_mips_instr()` incorrectly used the N64 code path assuming 64-bit `unw_word_t`, and `unw_is_signal_frame()` had no N32 case with the correct `rt_sigreturn` syscall number)

### CI
- Add MIPS N32 cross-build and test targets (both little-endian and big-endian)