### PR TITLE
tests: Add minimum frame count checks to detect silent unwind failures

### DIFF
--- a/tests/Gtest-concurrent.c
+++ b/tests/Gtest-concurrent.c
@@ -55,7 +55,7 @@ handler (int sig UNUSED, siginfo_t *siginfo UNUSED, void *context UNUSED)
   unw_word_t ip;
   unw_context_t uc;
   unw_cursor_t c;
-  int ret;
+  int ret, num_frames = 0;
 
   unw_getcontext (&uc);
   unw_init_local (&c, &uc);
@@ -64,6 +64,7 @@ handler (int sig UNUSED, siginfo_t *siginfo UNUSED, void *context UNUSED)
       unw_get_reg (&c, UNW_REG_IP, &ip);
       if (verbose)
 	printf ("%lx: IP=%lx\n", (long) pthread_self (), (unsigned long) ip);
+      ++num_frames;
     }
   while ((ret = unw_step (&c)) > 0);
 
@@ -73,6 +74,9 @@ handler (int sig UNUSED, siginfo_t *siginfo UNUSED, void *context UNUSED)
 #endif
   if (ret < 0)
     panic ("unw_step() returned %d\n", ret);
+
+  if (num_frames < 3)
+    panic ("FAILURE: only found %d frames\n", num_frames);
 }
 
 void *

--- a/tests/Gtest-init.cxx
+++ b/tests/Gtest-init.cxx
@@ -53,7 +53,7 @@ do_backtrace (void)
   unw_word_t ip, offset, file_offset;
   unw_cursor_t cursor;
   unw_context_t uc;
-  int ret, count = 0;
+  int ret, count = 0, num_frames = 0;
 
   unw_getcontext (&uc);
   unw_init_local (&cursor, &uc);
@@ -75,6 +75,8 @@ do_backtrace (void)
 
       if (++count > 32)
         panic ("FAILURE: didn't reach beginning of unwind-chain\n");
+
+      ++num_frames;
     }
   while ((ret = unw_step (&cursor)) > 0);
 
@@ -85,6 +87,9 @@ do_backtrace (void)
 
   if (ret < 0)
     panic ("FAILURE: unw_step() returned %d\n", ret);
+
+  if (num_frames < 3)
+    panic ("FAILURE: only found %d frames\n", num_frames);
 }
 
 static void

--- a/tests/Gtest-trace.c
+++ b/tests/Gtest-trace.c
@@ -182,6 +182,11 @@ do_backtrace (void)
       printf ("FAILURE: unw_step() returned %d for ip=%#010lx\n", ret, (long) ip);
       ++num_errors;
     }
+  if (unw_step_depth < 3)
+    {
+      printf ("FAILURE: only found %zu frames\n", unw_step_depth);
+      ++num_errors;
+    }
   dump_backtrace(unw_step_depth, TEST_UNW_STEP);
 
   /*
@@ -247,6 +252,11 @@ do_backtrace_with_context(void *context)
     {
       unw_get_reg (&cursor, UNW_REG_IP, &ip);
       printf ("FAILURE: unw_step() returned %d for ip=%#010lx\n", ret, (long) ip);
+      ++num_errors;
+    }
+  if (unw_step_depth < 3)
+    {
+      printf ("FAILURE: only found %d frames\n", unw_step_depth);
       ++num_errors;
     }
   dump_backtrace(unw_step_depth, TEST_UNW_STEP);

--- a/tests/test-async-sig.c
+++ b/tests/test-async-sig.c
@@ -126,6 +126,9 @@ do_backtrace (int may_print, int get_proc_name)
     }
   while (ret > 0);
 
+  if (depth < 3)
+    panic ("FAILURE: only found %d frames\n", depth);
+
   recurcount -= 1;
 }
 

--- a/tests/test-init-remote.c
+++ b/tests/test-init-remote.c
@@ -51,7 +51,7 @@ do_backtrace (void)
   unw_word_t ip, sp, off;
   unw_cursor_t cursor;
   unw_context_t uc;
-  int ret;
+  int ret, num_frames = 0;
 
   unw_getcontext (&uc);
   if (unw_init_remote (&cursor, unw_local_addr_space, &uc) < 0)
@@ -89,8 +89,16 @@ do_backtrace (void)
 		  ret, (long) ip);
 	  return -1;
 	}
+
+      ++num_frames;
     }
   while (ret > 0);
+
+  if (num_frames < 3)
+    {
+      printf ("FAILURE: only found %d frames\n", num_frames);
+      return -1;
+    }
 
   return 0;
 }

--- a/tests/test-mem.c
+++ b/tests/test-mem.c
@@ -46,7 +46,7 @@ do_backtrace (void)
   unw_cursor_t cursor;
   unw_word_t ip, sp;
   unw_context_t uc;
-  int ret;
+  int ret, num_frames = 0;
 
   unw_getcontext (&uc);
   if (unw_init_local (&cursor, &uc) < 0)
@@ -60,10 +60,12 @@ do_backtrace (void)
       if (verbose)
 	printf ("%016lx (sp=%016lx)\n", (long) ip, (long) sp);
 
+      ++num_frames;
+
       ret = unw_step (&cursor);
 #ifdef UNW_TARGET_ARM
       if (ret == -UNW_ESTOPUNWIND)
-        return;
+        break;
 #endif
       if (ret < 0)
 	{
@@ -73,6 +75,9 @@ do_backtrace (void)
 	}
     }
   while (ret > 0);
+
+  if (num_frames < 3)
+    panic ("FAILURE: only found %d frames\n", num_frames);
 }
 
 int


### PR DESCRIPTION
Several tests only checked if unw_step() returned a negative error code, but not whether a reasonable number of frames were found. When a bug caused unw_step() to silently return 0 (end-of-chain) after just 1 frame, these tests passed despite the unwinder being broken.

Add minimum frame count checks (>= 3 frames) to tests that lacked them, matching the existing pattern in Gtest-bt.c. This ensures that bugs which cause premature unwind termination are caught rather than silently producing false passes.