### PR TITLE
alpha: Fix getcontext saving wrong GP due to PLT lazy binding

### DIFF
--- a/include/libunwind-alpha.h
+++ b/include/libunwind-alpha.h
@@ -166,11 +166,27 @@ unw_tdep_proc_info_t;
 #include "libunwind-dynamic.h"
 #include "libunwind-common.h"
 
-#define unw_tdep_getcontext             UNW_ARCH_OBJ(getcontext)
 #define unw_tdep_is_fpreg               UNW_ARCH_OBJ(is_fpreg)
 
-extern int unw_tdep_getcontext (unw_tdep_context_t *);
+extern int UNW_ARCH_OBJ(getcontext) (unw_tdep_context_t *);
 extern int unw_tdep_is_fpreg (int);
+
+/* On Alpha, GP ($29) is set up in each function's prologue from the
+   procedure value register ($27/t12).  When _Ualpha_getcontext is called
+   across a shared library boundary with lazy PLT binding, the dynamic
+   linker's PLT resolver trashes GP before getcontext can save it.
+   This inline wrapper captures GP before the cross-module call and
+   fixes up the saved value afterward.  */
+static inline int
+unw_tdep_getcontext (unw_tdep_context_t *uc)
+{
+    unsigned long saved_gp;
+    int ret;
+    __asm__ __volatile__ ("mov $29, %0" : "=r" (saved_gp));
+    ret = UNW_ARCH_OBJ(getcontext) (uc);
+    uc->uc_mcontext.sc_regs[29] = saved_gp;
+    return ret;
+}
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }

--- a/include/libunwind-mips.h
+++ b/include/libunwind-mips.h
@@ -156,11 +156,26 @@ unw_tdep_proc_info_t;
 /* There is no getcontext() on MIPS.  Use a stub version which only saves GP
    registers.  FIXME: Not ideal, may not be sufficient for all libunwind
    use cases.  */
-#define unw_tdep_getcontext UNW_ARCH_OBJ(getcontext)
-extern int unw_tdep_getcontext (ucontext_t *uc);
+extern int UNW_ARCH_OBJ(getcontext) (ucontext_t *uc);
 
 #define unw_tdep_is_fpreg               UNW_ARCH_OBJ(is_fpreg)
 extern int unw_tdep_is_fpreg (int);
+
+/* On MIPS, GP ($28) is set up in each function's prologue from $25 (t9).
+   When getcontext is called across a shared library boundary with lazy PLT
+   binding, the dynamic linker's PLT resolver trashes GP before getcontext
+   can save it.  This inline wrapper captures GP before the cross-module
+   call and fixes up the saved value afterward.  */
+static inline int
+unw_tdep_getcontext (ucontext_t *uc)
+{
+    unsigned long saved_gp;
+    int ret;
+    __asm__ __volatile__ ("move %0, $28" : "=r" (saved_gp));
+    ret = UNW_ARCH_OBJ(getcontext) (uc);
+    uc->uc_mcontext.gregs[28] = saved_gp;
+    return ret;
+}
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -110,7 +110,8 @@ endif
 			test-iterate-phdr-reentry			 \
 			test-iterate-phdr-cache-null			 \
 			test-mem test-reg-state Ltest-varargs		 \
-			Ltest-nomalloc Ltest-nocalloc Lrs-race
+			Ltest-nomalloc Ltest-nocalloc Lrs-race \
+			test-getcontext-gp
  noinst_PROGRAMS_cdep += forker Gperf-simple Lperf-simple \
 			Gperf-trace Lperf-trace
 
@@ -354,6 +355,8 @@ test_eh_frame_hdr_sdata8_SOURCES = test-eh-frame-hdr-sdata8.c
 test_eh_frame_hdr_sdata8_LDADD =
 Lrs_race_LDADD = $(LIBUNWIND_local) $(PTHREADS_LIB)
 Ltest_varargs_LDADD = $(LIBUNWIND_local)
+test_getcontext_gp_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
+test_getcontext_gp_LDFLAGS = $(AM_LDFLAGS) -Wl,-z,lazy
 Ltest_init_local_signal_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)
 
 Gtest_bt_LDADD = $(LIBUNWIND) $(LIBUNWIND_local)

--- a/tests/test-getcontext-gp.c
+++ b/tests/test-getcontext-gp.c
@@ -1,0 +1,91 @@
+/* libunwind - a platform-independent unwind library
+   Copyright (C) 2025 Matt Turner <mattst88@gmail.com>
+
+This file is part of libunwind.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+/* Verify that unw_getcontext saves the correct GP register value.
+
+   On Alpha and MIPS, the global pointer register is set up per-module
+   in each function's prologue.  When getcontext is called across a
+   shared library boundary with lazy PLT binding, the dynamic linker's
+   PLT resolver can trash GP before the assembly getcontext function
+   can save it.
+
+   The inline wrapper in unw_tdep_getcontext captures GP before the
+   cross-module call and overwrites the saved value afterward.  This test
+   verifies that the saved GP matches the caller's actual value.
+
+   This test is linked with -Wl,-z,lazy to exercise the lazy PLT binding
+   path where the bug manifests.  */
+
+#include <libunwind.h>
+#include <stdio.h>
+
+#include "unw_test.h"
+
+#if defined(__alpha__)
+
+int
+main (void)
+{
+  unw_context_t uc;
+  unsigned long my_gp;
+
+  __asm__ __volatile__ ("mov $29, %0" : "=r" (my_gp));
+  unw_getcontext (&uc);
+
+  UNW_TEST_ASSERT((unsigned long) uc.uc_mcontext.sc_regs[29] == my_gp,
+    "saved GP=0x%lx, expected 0x%lx\n",
+    (unsigned long) uc.uc_mcontext.sc_regs[29], my_gp);
+
+  printf ("PASSED: getcontext saved correct GP (0x%lx)\n", my_gp);
+  return UNW_TEST_EXIT_PASS;
+}
+
+#elif defined(__mips__)
+
+int
+main (void)
+{
+  unw_context_t uc;
+  unsigned long my_gp;
+
+  __asm__ __volatile__ ("move %0, $28" : "=r" (my_gp));
+  unw_getcontext (&uc);
+
+  UNW_TEST_ASSERT((unsigned long) uc.uc_mcontext.gregs[28] == my_gp,
+    "saved GP=0x%lx, expected 0x%lx\n",
+    (unsigned long) uc.uc_mcontext.gregs[28], my_gp);
+
+  printf ("PASSED: getcontext saved correct GP (0x%lx)\n", my_gp);
+  return UNW_TEST_EXIT_PASS;
+}
+
+#else
+
+int
+main (void)
+{
+  return UNW_TEST_EXIT_SKIP;
+}
+
+#endif


### PR DESCRIPTION
On Alpha, GP ($29) is set up in each function's prologue from the procedure value register ($27/t12). When _Ualpha_getcontext is called across a shared library boundary with lazy PLT binding, the dynamic linker's PLT resolver modifies GP before getcontext can save it. The getcontext assembly function has no GP-setup prologue (it immediately saves all registers), so it captures the corrupted GP value.

Later, unw_resume restores this wrong GP via setcontext. The resumed code then performs GP-relative GOT accesses using a shared library's GP instead of the application's GP, causing a SIGSEGV.

Fix this by replacing the unw_tdep_getcontext macro (which directly called the assembly function) with a static inline wrapper that:
1. Captures GP via inline asm before the cross-module call
2. Calls the assembly _Ualpha_getcontext (which may go through PLT)
3. Overwrites the (potentially wrong) saved GP with the correct value

Since the wrapper is static inline in the header, it compiles in the caller's translation unit where GP is still valid.

This was not caught during development on Gentoo because Gentoo links with -Wl,-z,now by default, which forces eager PLT binding and avoids the lazy resolution that trashes GP.

Fixes: Gtest-exc and Ltest-exc SIGSEGV on alpha-linux-gnu CI.