### PR TITLE
s390x: fix unwinding through signal frames

### DIFF
--- a/src/s390x/Gstep.c
+++ b/src/s390x/Gstep.c
@@ -94,6 +94,8 @@ unw_step (unw_cursor_t *cursor)
 {
   struct cursor *c = (struct cursor *) cursor;
   int ret = 0, val = c->validate, sig;
+  unw_word_t old_ip = c->dwarf.ip;
+  unw_word_t old_cfa = c->dwarf.cfa;
 
 #if CONSERVATIVE_CHECKS
   c->validate = 1;
@@ -144,6 +146,13 @@ unw_step (unw_cursor_t *cursor)
 
   if (unlikely (ret > 0 && c->dwarf.ip == 0))
     return 0;
+
+  if (unlikely (ret > 0 && c->dwarf.ip == old_ip && c->dwarf.cfa <= old_cfa))
+    {
+      Dprintf ("%s: ip unchanged and cfa not advancing; stopping\n",
+               __FUNCTION__);
+      return 0;
+    }
 
   return ret;
 }

--- a/src/s390x/Gstep.c
+++ b/src/s390x/Gstep.c
@@ -104,6 +104,18 @@ unw_step (unw_cursor_t *cursor)
   Debug (1, "(cursor=%p, ip=0x%016lx, cfa=0x%016lx)\n",
          c, c->dwarf.ip, c->dwarf.cfa);
 
+  /* Check if this is a signal frame before trying DWARF-based unwinding. The
+   * vDSO may provide DWARF info for the signal trampoline that doesn't
+   * correctly describe how to unwind through the signal frame. Checking first
+   * ensures we always use our signal frame handler which correctly parses the
+   * sigcontext.  */
+  sig = unw_is_signal_frame (cursor);
+  if (sig > 0)
+    {
+      c->sigcontext_format = sig;
+      return s390x_handle_signal_frame (cursor);
+    }
+
   /* Try DWARF-based unwinding... */
   c->sigcontext_format = S390X_SCF_NONE;
   ret = dwarf_step (&c->dwarf);
@@ -114,34 +126,14 @@ unw_step (unw_cursor_t *cursor)
 
   if (unlikely (ret == -UNW_ENOINFO))
     {
-      /* GCC doesn't currently emit debug information for signal
-         trampolines on s390x so we check for them explicitly.
-
-         If there isn't debug information available we could also
+      /* If there isn't debug information available we could also
          try using the backchain (if available).
 
          Other platforms also detect PLT entries here. That's
          tricky to do reliably on s390x so I've left it out for
          now.  */
-
-      /* Memory accesses here are quite likely to be unsafe. */
-      c->validate = 1;
-
-      /* Check if this is a signal frame. */
-      sig = unw_is_signal_frame (cursor);
-      if (sig > 0)
-        {
-          c->sigcontext_format = sig;
-          ret = s390x_handle_signal_frame (cursor);
-        }
-      else
-        {
-          c->dwarf.ip = 0;
-          ret = 0;
-        }
-
-      c->validate = val;
-      return ret;
+      c->dwarf.ip = 0;
+      return 0;
     }
 
   if (unlikely (ret > 0 && c->dwarf.ip == 0))


### PR DESCRIPTION
- Detect infinite loops in `unw_step()` when DWARF info produces unchanged IP with a bogus CFA, preventing CI timeouts (fixes Gtest-bt)
- Check for signal frames before `dwarf_step()` so the s390x signal frame handler is always used instead of relying on vDSO DWARF info that doesn't correctly describe how to unwind through signal frames (fixes Gtest-resume-sig, Ltest-resume-sig, Ltest-concurrent)