### PR TITLE
Increase timeouts in CI-linux-gnu

### DIFF
--- a/.github/workflows/CI-linux-gnu.yml
+++ b/.github/workflows/CI-linux-gnu.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   build-gnu-native:
     runs-on: ubuntu-24.04
-    timeout-minutes: 15 # Anything more than about 15 minutes is likely a testsuite hang.
+    timeout-minutes: 20 # Anything more than about 20 minutes is likely a testsuite hang.
     name: ${{ matrix.target.triple }} (native) ${{ matrix.toolchain.compiler }} ${{ matrix.optimization.CFLAGS }}
 
     strategy:
@@ -92,7 +92,7 @@ jobs:
     container:
       image: ${{ matrix.config.container }}
       options: --privileged
-    timeout-minutes: 20 # Anything more than about 20 minutes is likely a testsuite hang.
+    timeout-minutes: 30 # Anything more than about 30 minutes is likely a testsuite hang.
     name: ${{ matrix.config.host }} (cross)
 
     strategy:


### PR DESCRIPTION
After moving to a container-in-container-based build the CI builds take longer and some have started consistently timing out. Adding 5 minutes to the timeout in the hopes it is enough.