### PR TITLE
all: Fix strict-aliasing violations

### DIFF
--- a/.github/workflows/CI-linux-gnu.yml
+++ b/.github/workflows/CI-linux-gnu.yml
@@ -54,8 +54,8 @@ jobs:
         env:
           CC: ${{ matrix.toolchain.CC }}
           CXX: ${{ matrix.toolchain.CXX }}
-          CFLAGS: "${{ matrix.target.CFLAGS }} ${{ matrix.optimization.CFLAGS }} -g -Wall -Wextra"
-          CXXFLAGS: "${{ matrix.target.CFLAGS }} ${{ matrix.optimization.CFLAGS }} -g -Wall -Wextra"
+          CFLAGS: "${{ matrix.target.CFLAGS }} ${{ matrix.optimization.CFLAGS }} -g -Wall -Wextra -fstrict-aliasing -Wstrict-aliasing -Werror=strict-aliasing"
+          CXXFLAGS: "${{ matrix.target.CFLAGS }} ${{ matrix.optimization.CFLAGS }} -g -Wall -Wextra -fstrict-aliasing -Wstrict-aliasing -Werror=strict-aliasing"
           LDFLAGS: ${{ matrix.target.CFLAGS }}
 
       - name: Build
@@ -153,7 +153,7 @@ jobs:
         run: |
           make -C build -j
         env:
-          CFLAGS: "-Wall -Wextra -g -Og"
+          CFLAGS: "-Wall -Wextra -g -Og -fstrict-aliasing -Wstrict-aliasing -Werror=strict-aliasing"
 
       - name: ABI Check
         run: |

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -43,6 +43,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 # if (__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ > 2)
 #  define ALWAYS_INLINE inline __attribute__((always_inline))
 #  define HIDDEN        __attribute__((visibility ("hidden")))
+#  define MAY_ALIAS     __attribute__((may_alias))
 #  if __has_attribute(fallthrough)
 #    define FALLTHROUGH __attribute__((fallthrough))
 #  else
@@ -52,6 +53,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #  define ALWAYS_INLINE
 #  define HIDDEN
 #  define FALLTHROUGH
+#  define MAY_ALIAS
 # endif
 # define WEAK           __attribute__((weak))
 # if (__GNUC__ >= 3)
@@ -70,6 +72,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 # define ALIAS(name)
 # define HIDDEN
 # define FALLTHROUGH
+# define MAY_ALIAS
 # define WEAK
 # define likely(x)      (x)
 # define unlikely(x)    (x)

--- a/include/libunwind-common.h.in
+++ b/include/libunwind-common.h.in
@@ -111,7 +111,11 @@ typedef int unw_regnum_t;
    and is used to track the frame state as the unwinder steps from
    frame to frame.  It is safe to make (shallow) copies of variables
    of this type.  */
-typedef struct unw_cursor
+typedef struct
+#ifdef __GNUC__
+__attribute__((may_alias))
+#endif
+unw_cursor
   {
     unw_word_t opaque[UNW_TDEP_CURSOR_LEN];
   }

--- a/include/tdep-aarch64/libunwind_i.h
+++ b/include/tdep-aarch64/libunwind_i.h
@@ -89,7 +89,7 @@ struct unw_addr_space
     struct unw_debug_frame_list *debug_frames;
    };
 
-struct cursor
+struct MAY_ALIAS cursor
   {
     struct dwarf_cursor dwarf;          /* must be first */
 

--- a/include/tdep-alpha/libunwind_i.h
+++ b/include/tdep-alpha/libunwind_i.h
@@ -53,7 +53,7 @@ struct unw_addr_space
     struct unw_debug_frame_list *debug_frames;
    };
 
-struct cursor
+struct MAY_ALIAS cursor
   {
     struct dwarf_cursor dwarf;          /* must be first */
 

--- a/include/tdep-arm/libunwind_i.h
+++ b/include/tdep-arm/libunwind_i.h
@@ -75,7 +75,7 @@ struct unw_addr_space
     struct unw_debug_frame_list *debug_frames;
   };
 
-struct cursor
+struct MAY_ALIAS cursor
   {
     struct dwarf_cursor dwarf;          /* must be first */
 

--- a/include/tdep-hppa/libunwind_i.h
+++ b/include/tdep-hppa/libunwind_i.h
@@ -57,7 +57,7 @@ struct unw_addr_space
     struct unw_debug_frame_list *debug_frames;
    };
 
-struct cursor
+struct MAY_ALIAS cursor
   {
     struct dwarf_cursor dwarf;          /* must be first */
 

--- a/include/tdep-ia64/libunwind_i.h
+++ b/include/tdep-ia64/libunwind_i.h
@@ -119,7 +119,7 @@ struct unw_addr_space
 #define ABI_MARKER_LINUX_SIGTRAMP       ((3 << 8) | 's')
 #define ABI_MARKER_LINUX_INTERRUPT      ((3 << 8) | 'i')
 
-struct cursor
+struct MAY_ALIAS cursor
   {
     void *as_arg;               /* argument to address-space callbacks */
     unw_addr_space_t as;        /* reference to per-address-space info */

--- a/include/tdep-loongarch64/libunwind_i.h
+++ b/include/tdep-loongarch64/libunwind_i.h
@@ -59,7 +59,7 @@ struct unw_addr_space
 /* LoongArch64 supports only little-endian. */
 #define tdep_big_endian(as)             0
 
-struct cursor
+struct MAY_ALIAS cursor
   {
     struct dwarf_cursor dwarf;          /* must be first */
 

--- a/include/tdep-mips/libunwind_i.h
+++ b/include/tdep-mips/libunwind_i.h
@@ -67,7 +67,7 @@ struct unw_addr_space
 
 #define tdep_big_endian(as)             ((as)->big_endian)
 
-struct cursor
+struct MAY_ALIAS cursor
   {
     struct dwarf_cursor dwarf;          /* must be first */
     unw_word_t sigcontext_addr;

--- a/include/tdep-ppc32/libunwind_i.h
+++ b/include/tdep-ppc32/libunwind_i.h
@@ -64,7 +64,7 @@ struct unw_addr_space
   int validate;
 };
 
-struct cursor
+struct MAY_ALIAS cursor
 {
   struct dwarf_cursor dwarf;    /* must be first */
 

--- a/include/tdep-ppc64/libunwind_i.h
+++ b/include/tdep-ppc64/libunwind_i.h
@@ -66,7 +66,7 @@ struct unw_addr_space
   int validate;
 };
 
-struct cursor
+struct MAY_ALIAS cursor
 {
   struct dwarf_cursor dwarf;    /* must be first */
 

--- a/include/tdep-riscv/libunwind_i.h
+++ b/include/tdep-riscv/libunwind_i.h
@@ -73,7 +73,7 @@ struct unw_addr_space
 
 #define tdep_big_endian(as)             ((as)->big_endian)
 
-struct cursor
+struct MAY_ALIAS cursor
   {
     struct dwarf_cursor dwarf;          /* must be first */
     enum

--- a/include/tdep-s390x/libunwind_i.h
+++ b/include/tdep-s390x/libunwind_i.h
@@ -53,7 +53,7 @@ struct unw_addr_space
     struct unw_debug_frame_list *debug_frames;
    };
 
-struct cursor
+struct MAY_ALIAS cursor
   {
     struct dwarf_cursor dwarf;          /* must be first */
 

--- a/include/tdep-sh/libunwind_i.h
+++ b/include/tdep-sh/libunwind_i.h
@@ -58,7 +58,7 @@ struct unw_addr_space
     struct unw_debug_frame_list *debug_frames;
   };
 
-struct cursor
+struct MAY_ALIAS cursor
   {
     struct dwarf_cursor dwarf;          /* must be first */
     enum

--- a/include/tdep-x86/libunwind_i.h
+++ b/include/tdep-x86/libunwind_i.h
@@ -57,7 +57,7 @@ struct unw_addr_space
     struct unw_debug_frame_list *debug_frames;
    };
 
-struct cursor
+struct MAY_ALIAS cursor
   {
     struct dwarf_cursor dwarf;          /* must be first */
 

--- a/include/tdep-x86_64/libunwind_i.h
+++ b/include/tdep-x86_64/libunwind_i.h
@@ -76,7 +76,7 @@ struct unw_addr_space
     struct unw_debug_frame_list *debug_frames;
    };
 
-struct cursor
+struct MAY_ALIAS cursor
   {
     struct dwarf_cursor dwarf;          /* must be first */
 

--- a/src/arm/Gresume.c
+++ b/src/arm/Gresume.c
@@ -54,7 +54,7 @@ arm_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
 
       struct regs_overlay {
               char x[sizeof(regs)];
-      };
+      } MAY_ALIAS;
 
       __asm__ __volatile__ (
         "ldmia %0, {r4-r12, lr}\n"


### PR DESCRIPTION
libunwind's public API requires users to allocate unw_cursor_t (an opaque
buffer), which the library internally accesses as struct cursor. Casting
between these two unrelated struct types is a strict-aliasing violation.

Mark both struct cursor (in all tdep headers) and struct unw_cursor (in
libunwind-common.h.in) with `__attribute__((may_alias))` so that compilers
know pointers to these types may alias one another.

Also mark struct regs_overlay in src/arm/Gresume.c with may_alias, as it
is used to alias an unsigned long array for an inline asm memory input
constraint.

Closes: https://github.com/libunwind/libunwind/issues/730