### PR TITLE
arm: Sanitizer fixes

### DIFF
--- a/include/tdep-arm/libunwind_i.h
+++ b/include/tdep-arm/libunwind_i.h
@@ -96,9 +96,17 @@ struct cursor
     unw_word_t sigcontext_sp;
     unw_word_t sigcontext_pc;
     int validate;
+    unw_tdep_context_t *uc;
   };
 
 #define DWARF_GET_LOC(l)        ((l).val)
+
+static inline unw_tdep_context_t *
+dwarf_get_uc(const struct dwarf_cursor *cursor)
+{
+  const struct cursor *c = (const struct cursor *) cursor->as_arg;
+  return c->uc;
+}
 
 #ifdef UNW_LOCAL_ONLY
 # define DWARF_NULL_LOC         DWARF_LOC (0, 0)
@@ -106,10 +114,10 @@ struct cursor
 # define DWARF_LOC(r, t)        ((dwarf_loc_t) { .val = (r) })
 # define DWARF_IS_REG_LOC(l)    0
 # define DWARF_REG_LOC(c,r)     (DWARF_LOC((unw_word_t)                      \
-                                 tdep_uc_addr((c)->as_arg, (r)), 0))
+                                 tdep_uc_addr(dwarf_get_uc(c), (r)), 0))
 # define DWARF_MEM_LOC(c,m)     DWARF_LOC ((m), 0)
 # define DWARF_FPREG_LOC(c,r)   (DWARF_LOC((unw_word_t)                      \
-                                 tdep_uc_addr((c)->as_arg, (r)), 0))
+                                 tdep_uc_addr(dwarf_get_uc(c), (r)), 0))
 
 static inline int
 dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)

--- a/include/tdep-arm/libunwind_i.h
+++ b/include/tdep-arm/libunwind_i.h
@@ -142,7 +142,12 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
 {
   if (!DWARF_GET_LOC (loc))
     return -1;
-  *val = *(unw_word_t *) DWARF_GET_LOC (loc);
+  unw_word_t addr = DWARF_GET_LOC (loc);
+  const struct cursor *cursor = (const struct cursor *) c->as_arg;
+  if (likely (cursor != NULL) && unlikely (cursor->validate)
+      && unlikely (!unw_address_is_valid (addr, sizeof (unw_word_t))))
+    return -1;
+  *val = *(unw_word_t *) addr;
   return 0;
 }
 

--- a/src/arm/Gex_tables.c
+++ b/src/arm/Gex_tables.c
@@ -68,7 +68,7 @@ prel31_to_addr (unw_addr_space_t as, void *arg, unw_word_t prel31,
   if ((*as->acc.access_mem)(as, prel31, &offset, 0, arg) < 0)
     return -UNW_EINVAL;
 
-  offset = ((long)offset << 1) >> 1;
+  offset = (unw_word_t)((int32_t)(offset << 1) >> 1);
   *val = prel31 + offset;
 
   return 0;

--- a/src/arm/Ginit.c
+++ b/src/arm/Ginit.c
@@ -104,7 +104,7 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
             void *arg)
 {
   unw_word_t *addr;
-  unw_tdep_context_t *uc = arg;
+  unw_tdep_context_t *uc = ((struct cursor *) arg)->uc;
 
   if (unw_is_fpreg (reg))
     goto badreg;
@@ -133,7 +133,7 @@ static int
 access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
               int write, void *arg)
 {
-  unw_tdep_context_t *uc = arg;
+  unw_tdep_context_t *uc = ((struct cursor *) arg)->uc;
   unw_fpreg_t *addr;
 
   if (!unw_is_fpreg (reg))

--- a/src/arm/Ginit_local.c
+++ b/src/arm/Ginit_local.c
@@ -47,7 +47,8 @@ unw_init_local_common (unw_cursor_t *cursor, unw_context_t *uc, unsigned use_pre
   Debug (1, "(cursor=%p)\n", c);
 
   c->dwarf.as = unw_local_addr_space;
-  c->dwarf.as_arg = uc;
+  c->dwarf.as_arg = c;
+  c->uc = uc;
 
   return common_init (c, use_prev_instr);
 }

--- a/src/arm/Ginit_remote.c
+++ b/src/arm/Ginit_remote.c
@@ -43,7 +43,16 @@ unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
   Debug (1, "(cursor=%p)\n", c);
 
   c->dwarf.as = as;
-  c->dwarf.as_arg = as_arg;
+  if (as == unw_local_addr_space)
+    {
+      c->dwarf.as_arg = c;
+      c->uc = as_arg;
+    }
+  else
+    {
+      c->dwarf.as_arg = as_arg;
+      c->uc = NULL;
+    }
   return common_init (c, 0);
 #endif /* !UNW_LOCAL_ONLY */
 }

--- a/src/arm/Gresume.c
+++ b/src/arm/Gresume.c
@@ -34,7 +34,7 @@ arm_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
 {
 #ifdef __linux__
   struct cursor *c = (struct cursor *) cursor;
-  unw_tdep_context_t *uc = c->dwarf.as_arg;
+  unw_tdep_context_t *uc = c->uc;
 
   if (c->sigcontext_format == ARM_SCF_NONE)
     {


### PR DESCRIPTION
Fixes for issues found with UBSan and ASan.

- arm: store cursor as as_arg; keep uc pointer in cursor struct
- arm: validate addresses in dwarf_get using cursor->validate
- arm: fix signed-shift UB in prel31_to_addr