### PR TITLE
x86_64: validate cur_rbp >= CFA before dereferencing in _try_rbp_frame_walk

### DIFF
--- a/src/x86_64/Gstep.c
+++ b/src/x86_64/Gstep.c
@@ -209,6 +209,17 @@ _try_rbp_frame_walk(struct cursor *c)
       return ret;
     }
 
+  /* cur_rbp must be >= CFA: on x86_64, the frame pointer is always above
+     (or equal to) the stack pointer.  If it's below, it's not a real frame
+     pointer (e.g. a general-purpose register value or a fake stack address
+     inserted by sanitizers), so bail before dereferencing it. */
+  if (cur_rbp < c->dwarf.cfa)
+    {
+      Debug (1, "cur_rbp %#010lx is below CFA %#010lx, not a frame pointer\n",
+             cur_rbp, c->dwarf.cfa);
+      return -UNW_EBADFRAME;
+    }
+
   /* Get the calling frame's %rbp. */
   unw_word_t new_rbp = 0;
   ret = dwarf_get (&c->dwarf, DWARF_MEM_LOC (c, cur_rbp), &new_rbp);


### PR DESCRIPTION
When DWARF unwinding fails and the fallback rbp-frame-walk is used, cur_rbp may not be a traditional frame pointer.  For example, ASAN's use-after-return detection allocates locals on a fake stack and stores the fake-stack base in %rbp, which on x86_64 lies far below the real stack (CFA).  Dereferencing such a value hits a poisoned red zone.

Add the same sanity check that already exists for new_rbp: bail with -UNW_EBADFRAME if cur_rbp < CFA, since a valid frame pointer must always be >= the stack pointer on x86_64.