### PR TITLE
mi: Use memcpy in LOCAL_ONLY fetch16/fetch32/fetchw to avoid misaligned loads

### DIFF
--- a/include/remote.h
+++ b/include/remote.h
@@ -7,11 +7,13 @@
 
 #ifdef UNW_LOCAL_ONLY
 
+#include <string.h>
+
 static inline int
 fetch8 (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED,
         unw_word_t *addr, int8_t *valp, void *arg UNUSED)
 {
-  *valp = *(int8_t *) (uintptr_t) *addr;
+  memcpy (valp, (void *) (uintptr_t) *addr, sizeof (*valp));
   *addr += 1;
   return 0;
 }
@@ -20,7 +22,7 @@ static inline int
 fetch16 (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED,
          unw_word_t *addr, int16_t *valp, void *arg UNUSED)
 {
-  *valp = *(int16_t *) (uintptr_t) *addr;
+  memcpy (valp, (void *) (uintptr_t) *addr, sizeof (*valp));
   *addr += 2;
   return 0;
 }
@@ -29,7 +31,7 @@ static inline int
 fetch32 (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED,
          unw_word_t *addr, int32_t *valp, void *arg UNUSED)
 {
-  *valp = *(int32_t *) (uintptr_t) *addr;
+  memcpy (valp, (void *) (uintptr_t) *addr, sizeof (*valp));
   *addr += 4;
   return 0;
 }
@@ -38,7 +40,7 @@ static inline int
 fetchw (unw_addr_space_t as UNUSED, unw_accessors_t *a UNUSED,
         unw_word_t *addr, unw_word_t *valp, void *arg UNUSED)
 {
-  *valp = *(unw_word_t *) (uintptr_t) *addr;
+  memcpy (valp, (void *) (uintptr_t) *addr, sizeof (*valp));
   *addr += sizeof (unw_word_t);
   return 0;
 }


### PR DESCRIPTION
The LOCAL_ONLY versions of fetch16, fetch32, and fetchw used direct pointer casts to dereference the target address:
```
  *valp = *(int32_t *) (uintptr_t) *addr;
```
UBSan flags this as a misaligned load when the address is not naturally aligned for the type.  Replace the casts with memcpy(), which copies the bytes without imposing alignment requirements and compiles to the same efficient load instruction on architectures that support unaligned access.