### PR TITLE
aarch64: Sanitizer fixes

### DIFF
--- a/include/tdep-aarch64/libunwind_i.h
+++ b/include/tdep-aarch64/libunwind_i.h
@@ -135,7 +135,7 @@ dwarf_getfp (struct dwarf_cursor *c UNUSED, dwarf_loc_t loc, unw_fpreg_t *val)
 {
   if (!DWARF_GET_LOC (loc))
     return -1;
-  *val = *(unw_fpreg_t *) DWARF_GET_LOC (loc);
+  memcpy (val, (void *) DWARF_GET_LOC (loc), sizeof (unw_fpreg_t));
   return 0;
 }
 
@@ -144,7 +144,7 @@ dwarf_putfp (struct dwarf_cursor *c UNUSED, dwarf_loc_t loc, unw_fpreg_t val)
 {
   if (!DWARF_GET_LOC (loc))
     return -1;
-  *(unw_fpreg_t *) DWARF_GET_LOC (loc) = val;
+  memcpy ((void *) DWARF_GET_LOC (loc), &val, sizeof (unw_fpreg_t));
   return 0;
 }
 

--- a/src/aarch64/Ginit.c
+++ b/src/aarch64/Ginit.c
@@ -196,11 +196,11 @@ access_fpreg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_fpreg_t *val,
     {
       Debug (12, "%s <- %08lx.%08lx.%08lx\n", unw_regname (reg),
              ((long *)val)[0], ((long *)val)[1], ((long *)val)[2]);
-      *(unw_fpreg_t *) addr = *val;
+      memcpy ((void *) addr, val, sizeof (unw_fpreg_t));
     }
   else
     {
-      *val = *(unw_fpreg_t *) addr;
+      memcpy (val, (void *) addr, sizeof (unw_fpreg_t));
       Debug (12, "%s -> %08lx.%08lx.%08lx\n", unw_regname (reg),
              ((long *)val)[0], ((long *)val)[1], ((long *)val)[2]);
     }

--- a/src/aarch64/Ginit.c
+++ b/src/aarch64/Ginit.c
@@ -194,15 +194,15 @@ access_fpreg (unw_addr_space_t as UNUSED, unw_regnum_t reg, unw_fpreg_t *val,
 
   if (write)
     {
-      Debug (12, "%s <- %08lx.%08lx.%08lx\n", unw_regname (reg),
-             ((long *)val)[0], ((long *)val)[1], ((long *)val)[2]);
+      Debug (12, "%s <- %08lx.%08lx\n", unw_regname (reg),
+             ((long *)val)[0], ((long *)val)[1]);
       memcpy ((void *) addr, val, sizeof (unw_fpreg_t));
     }
   else
     {
       memcpy (val, (void *) addr, sizeof (unw_fpreg_t));
-      Debug (12, "%s -> %08lx.%08lx.%08lx\n", unw_regname (reg),
-             ((long *)val)[0], ((long *)val)[1], ((long *)val)[2]);
+      Debug (12, "%s -> %08lx.%08lx\n", unw_regname (reg),
+             ((long *)val)[0], ((long *)val)[1]);
     }
   return 0;
 

--- a/tests/aarch64-test-frame-record.c
+++ b/tests/aarch64-test-frame-record.c
@@ -24,7 +24,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   const uintptr_t mem_end   = (uintptr_t) arg + mem_size;
   const uintptr_t paddr     = (uintptr_t) addr;
 
-  if (paddr < mem_start || paddr > mem_end)
+  if (paddr < mem_start || paddr + sizeof (*val) > mem_end)
     {
       return -1;
     }

--- a/tests/aarch64-test-frame-record.c
+++ b/tests/aarch64-test-frame-record.c
@@ -20,16 +20,16 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
     return -1;
 
   const size_t mem_size   = procedure_size * sizeof(uint32_t);
-  const void *mem_start   = arg;
-  const void *mem_end     = (const char*) arg + mem_size;
-  const unw_word_t *paddr = (const unw_word_t*) addr;
+  const uintptr_t mem_start = (uintptr_t) arg;
+  const uintptr_t mem_end   = (uintptr_t) arg + mem_size;
+  const uintptr_t paddr     = (uintptr_t) addr;
 
-  if ((void*) paddr < mem_start || (void*) paddr > mem_end)
+  if (paddr < mem_start || paddr > mem_end)
     {
       return -1;
     }
 
-  *val = *paddr;
+  memcpy (val, (const void *) paddr, sizeof (*val));
   return 0;
 }
 

--- a/tests/aarch64-test-plt.c
+++ b/tests/aarch64-test-plt.c
@@ -55,7 +55,7 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
   const uintptr_t mem_end   = (uintptr_t) arg + mem_size;
   const uintptr_t paddr     = (uintptr_t) addr;
 
-  if (paddr < mem_start || paddr > mem_end)
+  if (paddr < mem_start || paddr + sizeof (*val) > mem_end)
     {
       return -1;
     }

--- a/tests/aarch64-test-plt.c
+++ b/tests/aarch64-test-plt.c
@@ -51,16 +51,16 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
     return -1;
 
   const size_t mem_size   = ip_program_end * sizeof(uint32_t);
-  const void *mem_start   = arg;
-  const void *mem_end     = (const char*) arg + mem_size;
-  const unw_word_t *paddr = (const unw_word_t*) addr;
+  const uintptr_t mem_start = (uintptr_t) arg;
+  const uintptr_t mem_end   = (uintptr_t) arg + mem_size;
+  const uintptr_t paddr     = (uintptr_t) addr;
 
-  if ((void*) paddr < mem_start || (void*) paddr > mem_end)
+  if (paddr < mem_start || paddr > mem_end)
     {
       return -1;
     }
 
-  *val = *paddr;
+  memcpy (val, (const void *) paddr, sizeof (*val));
   return 0;
 }
 


### PR DESCRIPTION
Fixes for issues found with UBSan and ASan.

- aarch64: Use memcpy in dwarf_getfp/dwarf_putfp to avoid misaligned-load
- aarch64: Use memcpy in access_fpreg to avoid misaligned-load
- aarch64: Fix out-of-bounds read in access_fpreg debug print
- tests/aarch64: Use memcpy in mock access_mem to avoid misaligned-load
- tests/aarch64: Fix partial-overflow in mock access_mem bounds check