### PR TITLE
CI: Use make -j$(nproc) consistently

### DIFF
--- a/.github/workflows/CI-freebsd.yml
+++ b/.github/workflows/CI-freebsd.yml
@@ -80,5 +80,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: logs-${{ matrix.architecture }}-freebsd${{ matrix.os_version }}-${{ matrix.compiler }}
-          path: '**/test-suite.log'
+          path: |
+            **/test-suite.log
+            **/config.log
           if-no-files-found: warn

--- a/.github/workflows/CI-freebsd.yml
+++ b/.github/workflows/CI-freebsd.yml
@@ -68,11 +68,11 @@ jobs:
             ./configure --enable-debug
             
             printf '\n Build \n'
-            make
+            make -j$(nproc)
 
             printf '\n Test \n'
             export UNW_DEBUG_LEVEL=7
-            make check
+            make check -j$(nproc)
 
       - name: Upload Test Logs
         # This step only runs if the "Build and Test" step fails

--- a/.github/workflows/CI-linux-gnu.yml
+++ b/.github/workflows/CI-linux-gnu.yml
@@ -83,7 +83,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: logs-${{ matrix.config.triple }}-${{ matrix.toolchain.compiler }}${{ matrix.optimization.CFLAGS }}
-          path: '**/test-suite.log'
+          path: |
+            **/test-suite.log
+            **/config.log
           if-no-files-found: warn
 
 
@@ -187,7 +189,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: logs-${{ matrix.config.host }}
-          path: '**/test-suite.log'
+          path: |
+            **/test-suite.log
+            **/config.log
           if-no-files-found: warn
-
-

--- a/.github/workflows/CI-linux-gnu.yml
+++ b/.github/workflows/CI-linux-gnu.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Build
         run: |
-          make -C build -j
+          make -C build -j$(nproc)
 
       - name: Check ABI
         if: ${{ success() }}
@@ -73,7 +73,7 @@ jobs:
           set -x
           sudo bash -c 'echo core.%p.%p > /proc/sys/kernel/core_pattern'
           ulimit -c unlimited
-          make -C build check -j8
+          make -C build check -j$(nproc)
         env:
           UNW_DEBUG_LEVEL: 4
 
@@ -153,7 +153,7 @@ jobs:
 
       - name: Build
         run: |
-          make -C build -j
+          make -C build -j$(nproc)
         env:
           CFLAGS: "-Wall -Wextra -g -Og -fstrict-aliasing -Wstrict-aliasing -Werror=strict-aliasing"
 
@@ -176,7 +176,7 @@ jobs:
           bash -c 'echo core.%p.%p > /proc/sys/kernel/core_pattern'
           ulimit -c unlimited
           cd build
-          make check LOG_DRIVER_FLAGS="--qemu-arch ${{ matrix.config.qemu }}${{ matrix.config.qemu_xfail && format(' --qemu-xfail={0}', matrix.config.qemu_xfail) || '' }}" \
+          make check -j$(nproc) LOG_DRIVER_FLAGS="--qemu-arch ${{ matrix.config.qemu }}${{ matrix.config.qemu_xfail && format(' --qemu-xfail={0}', matrix.config.qemu_xfail) || '' }}" \
                      QEMU_LD_PREFIX="$CROSS_LIB" \
                      LDFLAGS="-L$CROSS_LIB/lib"
         env:

--- a/.github/workflows/CI-linux-musl.yml
+++ b/.github/workflows/CI-linux-musl.yml
@@ -78,5 +78,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: logs-${{ matrix.arch }}-linux-musl
-          path: '**/test-suite.log'
+          path: |
+            **/test-suite.log
+            **/config.log
           if-no-files-found: warn

--- a/.github/workflows/CI-linux-musl.yml
+++ b/.github/workflows/CI-linux-musl.yml
@@ -61,13 +61,13 @@ jobs:
 
       - name: Build
         run: |
-          make -j
+          make -j$(nproc)
         shell: alpine.sh {0}
 
       - name: Test
         if: ${{ success() }}
         run: |
-          make check
+          make check -j$(nproc)
         env:
           UNW_DEBUG_LEVEL: 5
         shell: alpine.sh {0}


### PR DESCRIPTION
Replace bare make -j (unlimited parallelism), make (serial), and
make check -j8 (hardcoded) with make -j$(nproc) throughout all three
Linux/FreeBSD CI workflows.

Measured on PR #1001:

| Job                                    |       Before |  After |  Delta |
| ---------------------------------------|-------------:|-------:|-------:|
| build-freebsd (15.0, clang, aarch64)   |       15m02s | 10m00s | -5m02s |
| build-freebsd (14.3, clang, aarch64)   |       11m40s |  8m13s | -3m27s |
| aarch64-linux-musl (native)            |        9m43s |  8m02s | -1m41s |
| riscv64-linux-musl (native)            |        8m19s |  6m33s | -1m46s |
| ppc64le-linux-musl (native)            |        8m12s |  5m45s | -2m27s |
| build-freebsd (15.0, clang, x86_64)    |        1m58s |  1m29s | -0m29s |
| build-freebsd (15.0, gcc, x86_64)      |        1m43s |  1m19s | -0m24s |
| arm-linux-gnueabi (cross)              |        1m46s |  1m42s | -0m04s |
| powerpc64-linux-gnu (cross)            |        1m42s |  1m17s | -0m25s |
| arm-linux-gnueabihf (cross)            |        1m41s |  1m29s | -0m12s |
| x86_64-pc-linux-gnu (native) gcc -O3   |        1m41s |  1m22s | -0m19s |
| build-freebsd (14.3, gcc, x86_64)      |        1m38s |  1m19s | -0m19s |
| aarch64-linux-gnu (cross)              |        1m38s |  1m23s | -0m15s |
| powerpc-linux-gnu (cross)              |        1m37s |  1m11s | -0m26s |
| riscv64-linux-gnu (cross)              |        1m33s |  1m12s | -0m21s |
| mips64el-linux-gnuabin32 (cross)       |        1m32s |  1m08s | -0m24s |
| mips64el-linux-gnuabi64 (cross)        |        1m30s |  1m03s | -0m27s |
| alpha-linux-gnu (cross)                |        1m28s |  1m06s | -0m22s |
| powerpc64le-linux-gnu (cross)          |        1m26s |  1m07s | -0m19s |
| mips-linux-gnu (cross)                 |        1m25s |  1m10s | -0m15s |
| build-freebsd (14.3, clang, x86_64)    |        1m24s |  1m08s | -0m16s |
| s390x-linux-gnu (cross)                |        1m22s |  1m17s | -0m05s |
| mips64-linux-gnuabin32 (cross)         |        1m21s |  1m01s | -0m20s |
| hppa-linux-gnu (cross)                 |        1m20s |  1m11s | -0m09s |
| mipsel-linux-gnu (cross)               |        1m17s |  1m14s | -0m03s |
| x86_64-pc-linux-gnu (native) clang -O0 |        1m17s |  1m14s | -0m03s |
| x86_64-pc-linux-gnu (native) gcc -O0   |        1m17s |  1m01s | -0m16s |
| i686-pc-linux-gnu (native) clang -O0   |        1m16s |  0m58s | -0m18s |
| x86_64-linux-musl (native)             |        1m14s |  1m06s | -0m08s |
| mips64-linux-gnuabi64 (cross)          |        1m13s |  1m17s | +0m04s |
| i686-pc-linux-gnu (native) gcc -O3     |        1m12s |  1m04s | -0m08s |
| i686-pc-linux-gnu (native) clang -O3   |        1m05s |  1m08s | +0m03s |
| x86_64-pc-linux-gnu (native) clang -O3 |        1m00s |  1m01s | +0m01s |
| i686-pc-linux-gnu (native) gcc -O0     |        0m59s |  0m46s | -0m13s |
