### PR TITLE
arm: Fix XFAILs

### DIFF
--- a/src/arm/Ginit_local.c
+++ b/src/arm/Ginit_local.c
@@ -25,6 +25,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #include "unwind_i.h"
 #include "init.h"
+#include "offsets.h"
 
 #ifdef UNW_REMOTE_ONLY
 
@@ -53,6 +54,73 @@ unw_init_local_common (unw_cursor_t *cursor, unw_context_t *uc, unsigned use_pre
   return common_init (c, use_prev_instr);
 }
 
+#ifdef __linux__
+static int
+unw_init_local_signal (unw_cursor_t *cursor, unw_context_t *uc)
+{
+  struct cursor *c = (struct cursor *) cursor;
+  int ret, i;
+
+  if (!atomic_load(&tdep_init_done))
+    tdep_init ();
+
+  Debug (1, "(cursor=%p)\n", c);
+
+  c->dwarf.as = unw_local_addr_space;
+  c->dwarf.as_arg = c;
+  c->uc = uc;
+
+  /* uc is a ucontext_t* from the signal handler; its layout differs from
+     unw_tdep_context_t, so we cannot use common_init/uc_addr here.
+     Compute the sigcontext base and set each register location directly,
+     mirroring arm_handle_signal_frame in Gos-linux.c.  */
+  unw_word_t sc_addr = (unw_word_t) uc + LINUX_UC_MCONTEXT_OFF;
+
+  for (i = 0; i < DWARF_NUM_PRESERVED_REGS; ++i)
+    c->dwarf.loc[i] = DWARF_NULL_LOC;
+
+  c->dwarf.loc[UNW_ARM_R0]  = DWARF_LOC (sc_addr + LINUX_SC_R0_OFF,  0);
+  c->dwarf.loc[UNW_ARM_R1]  = DWARF_LOC (sc_addr + LINUX_SC_R1_OFF,  0);
+  c->dwarf.loc[UNW_ARM_R2]  = DWARF_LOC (sc_addr + LINUX_SC_R2_OFF,  0);
+  c->dwarf.loc[UNW_ARM_R3]  = DWARF_LOC (sc_addr + LINUX_SC_R3_OFF,  0);
+  c->dwarf.loc[UNW_ARM_R4]  = DWARF_LOC (sc_addr + LINUX_SC_R4_OFF,  0);
+  c->dwarf.loc[UNW_ARM_R5]  = DWARF_LOC (sc_addr + LINUX_SC_R5_OFF,  0);
+  c->dwarf.loc[UNW_ARM_R6]  = DWARF_LOC (sc_addr + LINUX_SC_R6_OFF,  0);
+  c->dwarf.loc[UNW_ARM_R7]  = DWARF_LOC (sc_addr + LINUX_SC_R7_OFF,  0);
+  c->dwarf.loc[UNW_ARM_R8]  = DWARF_LOC (sc_addr + LINUX_SC_R8_OFF,  0);
+  c->dwarf.loc[UNW_ARM_R9]  = DWARF_LOC (sc_addr + LINUX_SC_R9_OFF,  0);
+  c->dwarf.loc[UNW_ARM_R10] = DWARF_LOC (sc_addr + LINUX_SC_R10_OFF, 0);
+  c->dwarf.loc[UNW_ARM_R11] = DWARF_LOC (sc_addr + LINUX_SC_FP_OFF,  0);
+  c->dwarf.loc[UNW_ARM_R12] = DWARF_LOC (sc_addr + LINUX_SC_IP_OFF,  0);
+  c->dwarf.loc[UNW_ARM_R13] = DWARF_LOC (sc_addr + LINUX_SC_SP_OFF,  0);
+  c->dwarf.loc[UNW_ARM_R14] = DWARF_LOC (sc_addr + LINUX_SC_LR_OFF,  0);
+  c->dwarf.loc[UNW_ARM_R15] = DWARF_LOC (sc_addr + LINUX_SC_PC_OFF,  0);
+
+  ret = dwarf_get (&c->dwarf, c->dwarf.loc[UNW_ARM_R15], &c->dwarf.ip);
+  if (ret < 0)
+    return ret;
+
+  ret = dwarf_get (&c->dwarf, c->dwarf.loc[UNW_ARM_R13], &c->dwarf.cfa);
+  if (ret < 0)
+    return ret;
+
+  c->sigcontext_format = ARM_SCF_NONE;
+  c->sigcontext_addr = 0;
+  c->sigcontext_sp = 0;
+  c->sigcontext_pc = 0;
+
+  c->dwarf.args_size = 0;
+  c->dwarf.stash_frames = 0;
+  c->dwarf.use_prev_instr = 0;
+  c->dwarf.pi_valid = 0;
+  c->dwarf.pi_is_dynamic = 0;
+  c->dwarf.hint = 0;
+  c->dwarf.prev_rs = 0;
+
+  return 0;
+}
+#endif /* __linux__ */
+
 int
 unw_init_local (unw_cursor_t *cursor, unw_context_t *uc)
 {
@@ -68,7 +136,11 @@ unw_init_local2 (unw_cursor_t *cursor, unw_context_t *uc, int flag)
     }
   else if (flag == UNW_INIT_SIGNAL_FRAME)
     {
+#ifdef __linux__
+      return unw_init_local_signal (cursor, uc);
+#else
       return unw_init_local_common(cursor, uc, 0);
+#endif
     }
   else
     {

--- a/src/arm/Gstep.c
+++ b/src/arm/Gstep.c
@@ -148,9 +148,25 @@ unw_step (unw_cursor_t *cursor)
 #endif /* CONFIG_DEBUG_FRAME */
 
   c->validate = validate;
-  // Before trying the fallback, if any unwind info tell us to stop, do that.
+  /* CANTUNWIND means the function never modified LR (it's a leaf).
+     Use LR as the return address rather than stopping; if LR is zero
+     or unreadable then this is genuinely the end of the stack. */
   if (has_stopunwind)
-    return -UNW_ESTOPUNWIND;
+    {
+      unw_word_t lr;
+      if (dwarf_get (&c->dwarf, c->dwarf.loc[UNW_ARM_R14], &lr) >= 0
+          && lr != 0)
+        {
+          c->dwarf.ip = lr;
+          /* Prevent looping: if the next frame is also CANTUNWIND we must
+             stop rather than re-reading the same stale LR location. */
+          c->dwarf.loc[UNW_ARM_R14] = DWARF_NULL_LOC;
+          c->dwarf.use_prev_instr = 1;
+          c->dwarf.pi_valid = 0;
+          return 1;
+        }
+      return 0;
+    }
 
   /* Fall back on APCS frame parsing.
      Note: This won't work in case the ARM EABI is used. */

--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -522,7 +522,7 @@ setup_fde (struct dwarf_cursor *c, dwarf_state_record_t *sr)
   for (i = 0; i < DWARF_NUM_PRESERVED_REGS + 2; ++i)
     set_reg (sr, i, DWARF_WHERE_SAME, 0);
 
-#if !defined(UNW_TARGET_ARM) && !(defined(UNW_TARGET_MIPS) && _MIPS_SIM == _ABI64) \
+#if !(defined(UNW_TARGET_MIPS) && _MIPS_SIM == _ABI64) \
     && !defined(UNW_TARGET_S390X)
   /* SP defaults to CFA. s390x excluded: CFA = R15+160, so this default gives
      caller's R15 = CFA instead of R15, breaking frameless functions like kill

--- a/src/dwarf/Gparser.c
+++ b/src/dwarf/Gparser.c
@@ -522,8 +522,11 @@ setup_fde (struct dwarf_cursor *c, dwarf_state_record_t *sr)
   for (i = 0; i < DWARF_NUM_PRESERVED_REGS + 2; ++i)
     set_reg (sr, i, DWARF_WHERE_SAME, 0);
 
-#if !defined(UNW_TARGET_ARM) && !(defined(UNW_TARGET_MIPS) && _MIPS_SIM == _ABI64)
-  // SP defaults to CFA (but is overridable)
+#if !defined(UNW_TARGET_ARM) && !(defined(UNW_TARGET_MIPS) && _MIPS_SIM == _ABI64) \
+    && !defined(UNW_TARGET_S390X)
+  /* SP defaults to CFA. s390x excluded: CFA = R15+160, so this default gives
+     caller's R15 = CFA instead of R15, breaking frameless functions like kill
+     that never emit DW_CFA_offset for R15. */
   set_reg (sr, TDEP_DWARF_SP, DWARF_WHERE_CFA, 0);
 #endif
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -214,8 +214,6 @@ endif
 if ARCH_ARM
 # ARM Linux kernel >=2.6.39 removed PTRACE_SINGLESTEP emulation
 XFAIL_TESTS += $(XFAIL_TESTS_PTRACE_SINGLESTEP)
-# UNW_INIT_SIGNAL_FRAME is not implemented on ARM
-XFAIL_TESTS += Ltest-init-local-signal Gtest-sig-context Ltest-sig-context
 endif
 
 if ARCH_LOONGARCH64


### PR DESCRIPTION
- dwarf: don't default SP to CFA on s390x
- dwarf: remove ARM exclusion from SP=CFA default
- arm: fix infinite loop when CANTUNWIND frame has no caller
- arm: implement unw_init_local2(UNW_INIT_SIGNAL_FRAME) on Linux
- tests: remove ARM XFAILs
