### PR TITLE
 Fix `get_frame_state` on Aarch64 for an unusual assembly code layout

### DIFF
--- a/src/aarch64/Gstep.c
+++ b/src/aarch64/Gstep.c
@@ -559,6 +559,10 @@ get_frame_state (unw_cursor_t *cursor)
 
   start_ip = c->dwarf.ip - offp;
 
+  frame_state_t saved_fs;
+  saved_fs.loc = NONE;
+  saved_fs.offset = 0;
+
   /* Check for frame record instructions since the start of the procedure (start_ip).
    * access_mem reads WSIZE bytes, so two instructions are checked in each iteration
    */
@@ -581,7 +585,32 @@ get_frame_state (unw_cursor_t *cursor)
           /* Frame-record tracking.  Detects the STP/MOV/LDP sequence that
              creates and destroys a frame record, tracking fs.loc through
              NONE -> AT_SP_OFFSET -> AT_FP -> (back to NONE).  */
+          frame_record_location_t prev_loc = fs.loc;
+          int32_t prev_offset = fs.offset;
           track_frame_record (insn, ip + j * 4, &fs.loc, &fs.offset);
+
+          /* If track_frame_record detected an LDP (AT_FP -> NONE), save the
+             pre-LDP state so we can restore it if we later see a RET that
+             the IP is past (mid-function epilogue pattern). */
+          if (prev_loc == AT_FP && fs.loc == NONE)
+            {
+              saved_fs.loc = prev_loc;
+              saved_fs.offset = prev_offset;
+            }
+
+          /* Check for RET instruction (0xd65f03c0).  If IP is past a RET,
+             execution reached this point via a branch that skipped the
+             epilogue, so the frame record is still intact.  Restore the
+             state from before the epilogue. */
+          if (fs.loc == NONE && saved_fs.loc != NONE && insn == 0xd65f03c0)
+            {
+              fs = saved_fs;
+              saved_fs.loc = NONE;
+              saved_fs.offset = 0;
+
+              Debug (4, "ip=0x%lx => past RET, restoring frame state to loc=%d\n",
+                     (long)(ip + j * 4), fs.loc);
+            }
         }
     }
 

--- a/tests/Laarch64-test-mid-func-epilogue-test.c
+++ b/tests/Laarch64-test-mid-func-epilogue-test.c
@@ -1,0 +1,96 @@
+/* Deterministic test for the get_frame_state RET-detection fix.
+ *
+ * Construct a fake ucontext positioned in body part 2 of
+ * target_mid_func_epilogue (defined in Laarch64-test-mid-func-epilogue.S).
+ * That function has its epilogue (LDP+RET) placed mid-function, with a
+ * body-part-2 region that follows it and whose last instruction branches
+ * back to the epilogue. While the IP is in body part 2 the frame record
+ * is still intact on the stack — the LDP/RET haven't executed.
+ *
+ * unw_step must read the return address from the frame record at FP+8
+ * (AT_FP path), not from x30 (LR fallback). To make the two paths
+ * distinguishable we set ucontext.regs[30] to a value that DIFFERS from
+ * the saved return address at FP+8:
+ *
+ *   AT_FP path  (with fix):    unwound IP = FAKE_RET_ADDR
+ *   LR fallback (without fix): unwound IP = LR_GARBAGE
+ */
+
+#include "libunwind.h"
+#include <ucontext.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdint.h>
+
+extern int  target_mid_func_epilogue(int);
+extern char target_mid_func_epilogue_in_body2[];
+
+#define LR_GARBAGE      ((uint64_t)0xDEADBEEFCAFEBABEULL)
+#define FAKE_CALLER_X29 ((uint64_t)0x1111111111111111ULL)
+#define FAKE_RET_ADDR   ((uint64_t)0x2222222222222222ULL)
+
+int main(void)
+{
+    /* Build a fake stack hosting the frame record that
+     * target_mid_func_epilogue's prologue would have created.
+     * After 'stp x29,x30,[sp,#-16]!' and 'mov x29,sp':
+     *   x29 = SP = original_sp - 16
+     *   memory[x29 + 0] = saved caller x29
+     *   memory[x29 + 8] = saved return address (caller's x30)               */
+    static uint64_t fake_stack[64];
+    memset(fake_stack, 0, sizeof(fake_stack));
+
+    uint64_t *frame_record = &fake_stack[16];   /* arbitrary 16-byte-aligned slot */
+    frame_record[0] = FAKE_CALLER_X29;
+    frame_record[1] = FAKE_RET_ADDR;
+
+    uint64_t fp_x29  = (uint64_t)frame_record;        /* x29 in body part 2  */
+    uint64_t mid_sp  = fp_x29;                         /* SP not yet popped   */
+
+    ucontext_t uc;
+    memset(&uc, 0, sizeof(uc));
+    uc.uc_mcontext.pc       = (uint64_t)(void *)target_mid_func_epilogue_in_body2;
+    uc.uc_mcontext.sp       = mid_sp;
+    uc.uc_mcontext.regs[29] = fp_x29;
+    uc.uc_mcontext.regs[30] = LR_GARBAGE;              /* distinct from FP+8  */
+
+    unw_cursor_t c;
+    int ret = unw_init_local2(&c, (unw_context_t *)&uc, UNW_INIT_SIGNAL_FRAME);
+    if (ret < 0)
+    {
+        fprintf(stderr, "unw_init_local2 failed: %d\n", ret);
+        return 1;
+    }
+
+    ret = unw_step(&c);
+    if (ret < 0)
+    {
+        fprintf(stderr, "unw_step failed: %d\n", ret);
+        return 1;
+    }
+
+    unw_word_t ip = 0;
+    unw_get_reg(&c, UNW_REG_IP, &ip);
+
+    printf("mid-func-epilogue test:\n");
+    printf("  PC at body 2          = %p\n", (void *)target_mid_func_epilogue_in_body2);
+    printf("  unwound IP            = 0x%lx\n",  (unsigned long)ip);
+    printf("  expected (AT_FP)      = 0x%lx\n",  (unsigned long)FAKE_RET_ADDR);
+    printf("  LR fallback would give  0x%lx\n",  (unsigned long)LR_GARBAGE);
+
+    if ((uint64_t)ip == FAKE_RET_ADDR)
+    {
+        printf("PASS\n");
+        return 0;
+    }
+
+    if ((uint64_t)ip == LR_GARBAGE)
+        fprintf(stderr,
+                "FAIL: unw_step took the LR fallback path "
+                "(get_frame_state RET-detection fix missing)\n");
+    else
+        fprintf(stderr,
+                "FAIL: unw_step returned IP 0x%lx, expected 0x%lx\n",
+                (unsigned long)ip, (unsigned long)FAKE_RET_ADDR);
+    return 1;
+}

--- a/tests/Laarch64-test-mid-func-epilogue.S
+++ b/tests/Laarch64-test-mid-func-epilogue.S
@@ -1,0 +1,72 @@
+/* Target function for the get_frame_state RET-detection fix.
+ *
+ * The epilogue (LDP+RET) is positioned mid-function: a body-part-1
+ * region precedes it, and a body-part-2 region follows it whose last
+ * instruction branches back to the epilogue. This is a perfectly normal
+ * compiler layout — e.g. clang/gcc may move a hot path so the common
+ * case falls through and a less common case branches forward into a
+ * tail of code that joins the epilogue with a backward branch.
+ *
+ * Layout (instructions are 4 bytes each):
+ *
+ *   target_mid_func_epilogue:      ; T+0
+ *      stp    x29, x30, [sp,-16]!  ; T+0   prologue
+ *      mov    x29, sp              ; T+4   prologue
+ *      cbnz   w0, .Lpart2          ; T+8   body part 1: jump to body part 2
+ *      mov    w0, #1               ; T+12  body part 1
+ *   .Lepilogue:
+ *      ldp    x29, x30, [sp], #16  ; T+16  epilogue (mid-function)
+ *      ret                         ; T+20  epilogue
+ *   .Lpart2:                       ; T+24  body part 2
+ *   target_mid_func_epilogue_in_body2:
+ *      mov    w0, #2               ; T+24  body part 2
+ *      b      .Lepilogue           ; T+28  body part 2: goto epilogue
+ *
+ * No .cfi_* directives: the function has no DWARF unwind info, so
+ * dwarf_step() returns -UNW_ENOINFO and unw_step() falls through to the
+ * get_frame_state() path that the fix targets.
+ *
+ * The bug condition is exposed when execution is in body part 2 (IP at
+ * or after T+24): the frame record on the stack is still intact because
+ * the LDP/RET at T+16/T+20 has not been executed. But get_frame_state
+ * walks the bytes from T to the current IP and sees both the LDP and
+ * the RET; without the fix it concludes fs.loc=NONE and unw_step takes
+ * the LR fallback (no CFA/FP update). With the fix, the RET-detection
+ * block restores fs.loc=AT_FP and unw_step uses the (still-valid)
+ * frame record at x29.
+ */
+
+    .text
+    .globl  target_mid_func_epilogue
+    .type   target_mid_func_epilogue, %function
+    .p2align 2
+
+target_mid_func_epilogue:
+    /* === Prologue === */
+    stp     x29, x30, [sp, #-16]!
+    mov     x29, sp
+
+    /* === Body part 1 === */
+    cbnz    w0, .Lpart2
+    mov     w0, #1
+
+    /* === Epilogue (mid-function) === */
+.Lepilogue:
+    ldp     x29, x30, [sp], #16
+    ret
+
+    /* === Body part 2 ===
+     * Reached via the cbnz above. While IP is in this region the
+     * LDP/RET have not run: x29 still equals (original_sp - 16) and
+     * the frame record [caller_x29, return_addr] is still on the stack.
+     *
+     * Exported as a plain label (no %function type) so get_proc_name
+     * still resolves the enclosing target_mid_func_epilogue for any IP
+     * in body part 2. */
+    .globl  target_mid_func_epilogue_in_body2
+target_mid_func_epilogue_in_body2:
+.Lpart2:
+    mov     w0, #2
+    b       .Lepilogue          /* last instruction: goto epilogue */
+
+    .size   target_mid_func_epilogue, . - target_mid_func_epilogue


### PR DESCRIPTION
 ## Summary

 Improve `get_frame_state` when function assembly code layout is unusual. This was observe on aarch64/musl-libc function.

  ## The problem

  On aarch64, when DWARF unwind info is unavailable for a function (e.g. hand- written assembly with no `.cfi_*` directives, or stripped binaries), `unw_step`  falls back to `get_frame_state` (`src/aarch64/Gstep.c`). That routine performs  a static instruction walk from the function's entry to the current IP and classifies the state of the FP/LR frame record:

  - `STP x29, x30, [sp, …]` → `fs.loc = AT_SP_OFFSET`
  - `mov x29, sp` → `fs.loc = AT_FP`
  - `LDP x29, x30, [sp …]` → `fs.loc = NONE` (frame record popped)

  The walk is purely textual — it does not model control flow. So if the IP is  in a region of the function that lies *past the bytes of the epilogue* but  the epilogue has not actually been executed, the walk wrongly concludes the  frame record is gone.

  A common compiler layout that triggers this is a **mid-function epilogue**:
```
  target:
      stp  x29, x30, [sp, #-16]!     ; prologue
      mov  x29, sp
      cbnz w0, .Lpart2               ; conditional jump forward
      mov  w0, #1
  .Lepilogue:
      ldp  x29, x30, [sp], #16       ; epilogue (mid-function)
      ret
  .Lpart2:                            ; body part 2 — reached via the cbnz above
      mov  w0, #2
      b    .Lepilogue                ; loop back to the (single) epilogue
```
  When IP is anywhere in body part 2, the LDP+RET *bytes* sit between  `start_ip` and IP, but the LDP+RET have not run. The frame record at `x29`  is still valid. Without the fix, `get_frame_state` returns  `fs.loc = NONE`, and `unw_step` takes the LR fallback path which does **not**  update CFA/FP — leading to a wrong/stale unwind state on subsequent steps.

  ## The fix

  `src/aarch64/Gstep.c`, `get_frame_state`:

  1. Introduce a `saved_fs` snapshot.
  2. Before clearing `fs` on LDP detection, copy it into `saved_fs`.
  3. Add a new check at the end of the per-instruction loop body: if we now see
     a `RET` (`0xd65f03c0`) opcode that the IP is strictly past, and we have a
     non-empty `saved_fs`, restore `fs = saved_fs`. This says "the LDP+RET
     bytes are textually behind the IP but execution did not flow through
     them — the frame record is still intact at FP."

  ## Test

  New deterministic test in `tests/`:

  - `Laarch64-test-mid-func-epilogue.S` — assembly target laid out exactly as  shown above. No `.cfi_*` directives, so `dwarf_step` returns `-UNW_ENOINFO`  and the `get_frame_state` fallback is exercised. The exported label
    `target_mid_func_epilogue_in_body2` lets the test pin the IP inside body  part 2.

  - `Laarch64-test-mid-func-epilogue-test.c` — builds a fake `ucontext`  positioned at the body-2 label, populates a fake stack with a frame record  `[caller_x29, return_addr]`, and crucially sets `regs[30]` (the LR) to a
    sentinel value distinct from the saved return address. This makes the two  unwind paths produce **different** outputs:

    | Path                    | Unwound IP                   |
    | ----------------------- | ---------------------------- |
    | `AT_FP` (with fix)      | saved return addr at FP+8    |
    | LR fallback (w/o fix)   | `regs[30]` sentinel (garbage)|

    After `unw_init_local2(UNW_INIT_SIGNAL_FRAME)` + `unw_step`, the test  asserts the unwound IP equals the saved return addr.

  ## Verification

  - **With fix applied**: test prints `PASS` and exits 0 — `unwound IP = 0x2222…2222`  (read from FP+8).
  - **With fix temporarily removed**: test prints  `FAIL: unw_step took the LR fallback path` and exits 1 — `unwound IP =
    0xdeadbeefcafebabe` (read from `regs[30]`).