### PR TITLE
alpha, mips: Always inline unw_tdep_getcontext

### DIFF
--- a/include/libunwind-alpha.h
+++ b/include/libunwind-alpha.h
@@ -176,8 +176,11 @@ extern int unw_tdep_is_fpreg (int);
    across a shared library boundary with lazy PLT binding, the dynamic
    linker's PLT resolver trashes GP before getcontext can save it.
    This inline wrapper captures GP before the cross-module call and
-   fixes up the saved value afterward.  */
-static inline int
+   fixes up the saved value afterward.
+
+   The wrapper must be always_inline so that _Ualpha_getcontext captures
+   the caller's $26 (pc) and $30 (sp), not the wrapper's.  */
+static __attribute__((always_inline)) inline int
 unw_tdep_getcontext (unw_tdep_context_t *uc)
 {
     unsigned long saved_gp;

--- a/include/libunwind-mips.h
+++ b/include/libunwind-mips.h
@@ -165,8 +165,11 @@ extern int unw_tdep_is_fpreg (int);
    When getcontext is called across a shared library boundary with lazy PLT
    binding, the dynamic linker's PLT resolver trashes GP before getcontext
    can save it.  This inline wrapper captures GP before the cross-module
-   call and fixes up the saved value afterward.  */
-static inline int
+   call and fixes up the saved value afterward.
+
+   The wrapper must be always_inline so that _Umips_getcontext captures
+   the caller's $31 (ra/pc) and $sp, not the wrapper's.  */
+static __attribute__((always_inline)) inline int
 unw_tdep_getcontext (ucontext_t *uc)
 {
     unsigned long saved_gp;


### PR DESCRIPTION
```
alpha: Always inline unw_tdep_getcontext

When inlining is suppressed (e.g. at -O0), the wrapper acquires its own
stack frame, causing _Ualpha_getcontext to capture two wrong values:

  sc_pc = $26 pointing back into the wrapper (not the caller's call
          site), so the unwinder starts from the wrong IP.

  sc_regs[30] = the wrapper's SP, which is 48 bytes below the caller's
                SP.  dwarf_step uses this as r30 when computing the
                CFA (CFA = r30 + frame_size), producing a CFA that is
                48 bytes too low.  The saved return address is then read
                from below the current stack top, which has been
                overwritten by the unw_step call chain itself.

Add __attribute__((always_inline)) to eliminate the wrapper frame.
When inlined, the JSR to _Ualpha_getcontext is emitted at the true
call site, so both $26 and $30 are captured correctly.
```

```
mips: Always inline unw_tdep_getcontext

The MIPS wrapper has the identical structure: save $28 (GP), call
_Umips_getcontext via PLT, restore GP.  _Umips_getcontext saves $31
(ra) as PC and $sp as the stack pointer.  If the wrapper is not inlined
(e.g. at -O0), both values reflect the wrapper's frame rather than the
caller's, breaking dwarf_step CFA computation in the same way as the
Alpha bug fixed in the previous commit.

Add __attribute__((always_inline)) to eliminate the wrapper frame.
```
