### PR TITLE
CI: Replace qemu-test-driver XFAIL mechanism with SKIP

### DIFF
--- a/.github/workflows/CI-linux-gnu.yml
+++ b/.github/workflows/CI-linux-gnu.yml
@@ -112,7 +112,7 @@ jobs:
           - {target: mipsn32,   host: mips64-linux-gnuabin32,   qemu: mipsn32,   gccver: 14, container: ubuntu:24.04, cc: "mips64-linux-gnuabi64-gcc-14 -mabi=n32",   cxx: "mips64-linux-gnuabi64-g++-14 -mabi=n32",   packages: "g++-14-multilib-mips64-linux-gnuabi64",   cross_lib: "/usr/mips64-linux-gnuabi64" }
           - {target: mipsel,   host: mipsel-linux-gnu,        qemu: mipsel,   gccver: 14, container: ubuntu:24.04 }
           - {target: mips,     host: mips-linux-gnu,          qemu: mips,     gccver: 14, container: ubuntu:24.04 }
-          - {target: ppc64,    host: powerpc64-linux-gnu,     qemu: ppc64,    gccver: 14, container: ubuntu:26.04, qemu_skip: &ppc64_qemu_skip "Gtest-bt:Gtest-concurrent:Gtest-resume-sig:Gtest-resume-sig-rt:Gtest-trace:Ltest-bt:Ltest-concurrent:Ltest-init-local-signal:Ltest-resume-sig:Ltest-resume-sig-rt:Ltest-sig-context:Ltest-trace" }
+          - {target: ppc64,    host: powerpc64-linux-gnu,     qemu: ppc64,    gccver: 14, container: ubuntu:26.04, qemu_skip: &ppc64_qemu_skip "Gtest-bt:Gtest-concurrent:Gtest-resume-sig:Gtest-resume-sig-rt:Gtest-trace:Ltest-bt:Ltest-concurrent:Ltest-init-local-signal:Ltest-resume-sig:Ltest-resume-sig-rt:Ltest-sig-context:Ltest-trace:test-async-sig" }
           - {target: ppc64le,  host: powerpc64le-linux-gnu,   qemu: ppc64le,  gccver: 14, container: ubuntu:26.04, qemu_skip: *ppc64_qemu_skip }
           - {target: ppc,      host: powerpc-linux-gnu,       qemu: ppc,      gccver: 14, container: ubuntu:26.04 }
           - {target: riscv64,  host: riscv64-linux-gnu,       qemu: riscv64,  gccver: 14, container: ubuntu:26.04 }

--- a/.github/workflows/CI-linux-gnu.yml
+++ b/.github/workflows/CI-linux-gnu.yml
@@ -112,8 +112,8 @@ jobs:
           - {target: mipsn32,   host: mips64-linux-gnuabin32,   qemu: mipsn32,   gccver: 14, container: ubuntu:24.04, cc: "mips64-linux-gnuabi64-gcc-14 -mabi=n32",   cxx: "mips64-linux-gnuabi64-g++-14 -mabi=n32",   packages: "g++-14-multilib-mips64-linux-gnuabi64",   cross_lib: "/usr/mips64-linux-gnuabi64" }
           - {target: mipsel,   host: mipsel-linux-gnu,        qemu: mipsel,   gccver: 14, container: ubuntu:24.04 }
           - {target: mips,     host: mips-linux-gnu,          qemu: mips,     gccver: 14, container: ubuntu:24.04 }
-          - {target: ppc64,    host: powerpc64-linux-gnu,     qemu: ppc64,    gccver: 14, container: ubuntu:26.04, qemu_xfail: &ppc64_qemu_xfail "Gtest-bt:Gtest-concurrent:Gtest-resume-sig:Gtest-resume-sig-rt:Gtest-trace:Ltest-bt:Ltest-concurrent:Ltest-init-local-signal:Ltest-resume-sig:Ltest-resume-sig-rt:Ltest-sig-context:Ltest-trace" }
-          - {target: ppc64le,  host: powerpc64le-linux-gnu,   qemu: ppc64le,  gccver: 14, container: ubuntu:26.04, qemu_xfail: *ppc64_qemu_xfail }
+          - {target: ppc64,    host: powerpc64-linux-gnu,     qemu: ppc64,    gccver: 14, container: ubuntu:26.04, qemu_skip: &ppc64_qemu_skip "Gtest-bt:Gtest-concurrent:Gtest-resume-sig:Gtest-resume-sig-rt:Gtest-trace:Ltest-bt:Ltest-concurrent:Ltest-init-local-signal:Ltest-resume-sig:Ltest-resume-sig-rt:Ltest-sig-context:Ltest-trace" }
+          - {target: ppc64le,  host: powerpc64le-linux-gnu,   qemu: ppc64le,  gccver: 14, container: ubuntu:26.04, qemu_skip: *ppc64_qemu_skip }
           - {target: ppc,      host: powerpc-linux-gnu,       qemu: ppc,      gccver: 14, container: ubuntu:26.04 }
           - {target: riscv64,  host: riscv64-linux-gnu,       qemu: riscv64,  gccver: 14, container: ubuntu:26.04 }
           - {target: s390x,    host: s390x-linux-gnu,         qemu: s390x,    gccver: 14, container: ubuntu:26.04 }
@@ -176,7 +176,7 @@ jobs:
           bash -c 'echo core.%p.%p > /proc/sys/kernel/core_pattern'
           ulimit -c unlimited
           cd build
-          make check -j$(nproc) LOG_DRIVER_FLAGS="--qemu-arch ${{ matrix.config.qemu }}${{ matrix.config.qemu_xfail && format(' --qemu-xfail={0}', matrix.config.qemu_xfail) || '' }}" \
+          make check -j$(nproc) LOG_DRIVER_FLAGS="--qemu-arch ${{ matrix.config.qemu }}${{ matrix.config.qemu_skip && format(' --qemu-skip={0}', matrix.config.qemu_skip) || '' }}" \
                      QEMU_LD_PREFIX="$CROSS_LIB" \
                      LDFLAGS="-L$CROSS_LIB/lib"
         env:

--- a/scripts/qemu-test-driver
+++ b/scripts/qemu-test-driver
@@ -58,8 +58,8 @@ color_tests=no
 enable_hard_errors=yes
 verbose=no
 qemu_arch=
-qemu_xfail_list=          # colon-separated test basenames to XFAIL under QEMU
-qemu_xfail_before_ver=    # X.Y.Z: only XFAIL if running QEMU < this version
+qemu_skip_list=           # colon-separated test basenames to SKIP under QEMU
+qemu_skip_before_ver=     # X.Y.Z: only SKIP if running QEMU < this version
 while test $# -gt 0; do
   case $1 in
   --help) print_usage; exit $?;;
@@ -72,10 +72,10 @@ while test $# -gt 0; do
   --enable-hard-errors) enable_hard_errors=$2; shift;;
   --qemu-arch) qemu_arch=$2; shift;;
   --qemu-arch=*) qemu_arch=${1#--qemu-arch=};;
-  --qemu-xfail) qemu_xfail_list=$2; shift;;
-  --qemu-xfail=*) qemu_xfail_list=${1#--qemu-xfail=};;
-  --qemu-xfail-before-version) qemu_xfail_before_ver=$2; shift;;
-  --qemu-xfail-before-version=*) qemu_xfail_before_ver=${1#--qemu-xfail-before-version=};;
+  --qemu-skip) qemu_skip_list=$2; shift;;
+  --qemu-skip=*) qemu_skip_list=${1#--qemu-skip=};;
+  --qemu-skip-before-version) qemu_skip_before_ver=$2; shift;;
+  --qemu-skip-before-version=*) qemu_skip_before_ver=${1#--qemu-skip-before-version=};;
   --verbose) verbose=$2; shift;;
   --) shift; break;;
   -*) usage_error "invalid option: '$1'";;
@@ -110,25 +110,26 @@ qemu_version_lt ()
   }'
 }
 
-# If --qemu-xfail was given, check whether the current test is listed and
-# whether any version gate allows it to pass.  Promote expect_failure=yes
-# when the test is known to fail under this QEMU but pass on real hardware.
-if test -n "$qemu_xfail_list"; then
+# If --qemu-skip was given, check whether the current test is listed and
+# whether any version gate applies.  Emit a SKIP result without running the
+# test when the test is known to be unreliable under this QEMU.
+skip_test=no
+if test -n "$qemu_skip_list"; then
   test_basename=$(basename "$test_name")
   qemu_cmd_tmp="qemu-${qemu_arch}"
   IFS_save="$IFS"
   IFS=:
-  for entry in $qemu_xfail_list; do
+  for entry in $qemu_skip_list; do
     if test "$test_basename" = "$entry"; then
-      if test -n "$qemu_xfail_before_ver"; then
+      if test -n "$qemu_skip_before_ver"; then
         qemu_ver=$("$qemu_cmd_tmp" --version 2>/dev/null \
                    | sed -n 's/.*version \([0-9][0-9.]*\).*/\1/p' \
                    | head -1)
-        if qemu_version_lt "$qemu_ver" "$qemu_xfail_before_ver"; then
-          expect_failure=yes
+        if qemu_version_lt "$qemu_ver" "$qemu_skip_before_ver"; then
+          skip_test=yes
         fi
       else
-        expect_failure=yes
+        skip_test=yes
       fi
       break
     fi
@@ -138,6 +139,22 @@ fi
 
 if test $# -eq 0; then
   usage_error "missing argument"
+fi
+
+if test $skip_test = yes; then
+  if test $color_tests = yes; then
+    blu='[1;34m'
+    std='[m'
+  else
+    blu= std=
+  fi
+  echo "SKIP $test_name" > "$log_file"
+  echo "${blu}SKIP${std}: $test_name"
+  echo ":test-result: SKIP" > "$trs_file"
+  echo ":global-test-result: SKIP" >> "$trs_file"
+  echo ":recheck: no" >> "$trs_file"
+  echo ":copy-in-global-log: yes" >> "$trs_file"
+  exit 0
 fi
 
 if test $color_tests = yes; then


### PR DESCRIPTION
Two commits:

- CI: Replace qemu-test-driver XFAIL mechanism with SKIP
- CI: Skip test-async-sig on ppc64/ppc64le

The `test-async-sig` test intermittently fails on ppc64/ppc64le when run under QEMU without [this fix](https://github.com/qemu/qemu/commit/654dce6c523612d38e8d53818dbc7c03cbe535a3).

In order to avoid noise in CI results, we modify `qemu-test-driver` to skip rather than xfail tests and then add `test-async-sig` to the list.

(Also, Meson doesn't have a way to xfail tests in a wrapper like this, so this will simplify things for Meson)