### PR TITLE
tests: Suppress UBSan null-pointer errors in intentional SIGSEGV tests

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -56,6 +56,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #  define MAY_ALIAS
 # endif
 # define WEAK           __attribute__((weak))
+# if defined(__clang__)
+#  define NO_SANITIZE_NULL __attribute__((no_sanitize("null")))
+# else
+/* GCC ignores no_sanitize("null"); use "undefined" to suppress all UBSan checks
+ * in functions that intentionally dereference null pointers. */
+#  define NO_SANITIZE_NULL __attribute__((no_sanitize("undefined")))
+# endif
 # if (__GNUC__ >= 3)
 #  define likely(x)     __builtin_expect ((x), 1)
 #  define unlikely(x)   __builtin_expect ((x), 0)
@@ -74,6 +81,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 # define FALLTHROUGH
 # define MAY_ALIAS
 # define WEAK
+# define NO_SANITIZE_NULL
 # define likely(x)      (x)
 # define unlikely(x)    (x)
 #endif

--- a/tests/Gtest-bt.c
+++ b/tests/Gtest-bt.c
@@ -256,6 +256,13 @@ sighandler (int signal, siginfo_t *siginfo UNUSED, void *context)
   do_backtrace();
 }
 
+static NO_SANITIZE_NULL void
+do_null_deref (void)
+{
+  int *bad_ptr = NULL;
+  *bad_ptr = 0;
+}
+
 int
 main (int argc, char **argv UNUSED)
 {
@@ -289,11 +296,7 @@ main (int argc, char **argv UNUSED)
     panic ("sigaction: %s\n", strerror (errno));
 
   if (sigsetjmp (env, 1) == 0)
-  {
-    /* Make a NULL pointer dereference.  */
-    int *bad_ptr = NULL;
-    *bad_ptr = 0;
-  }
+    do_null_deref ();
 
 #ifdef HAVE_SIGALTSTACK
   if (verbose)

--- a/tests/Ltest-init-local-signal-lib.c
+++ b/tests/Ltest-init-local-signal-lib.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
+#include "compiler.h"
 
 /* To prevent inlining and optimizing away */
-int foo(volatile int* f) {
+NO_SANITIZE_NULL int foo(volatile int* f) {
   return *f;
 }


### PR DESCRIPTION
Gtest-bt and Ltest-init-local-signal deliberately dereference NULL to trigger SIGSEGV and test unwinding through signal frames. UBSan's null sanitizer intercepts these before the signal is delivered, causing test failures under -fsanitize=undefined -fno-sanitize-recover=all.

Add a NO_SANITIZE_NULL macro to compiler.h and apply it to the two functions that perform the intentional dereferences: do_null_deref() in Gtest-bt.c (extracted from main) and foo() in
Ltest-init-local-signal-lib.c.