### PR TITLE
alpha: Enable C++ exception support

### DIFF
--- a/src/alpha/Gregs.c
+++ b/src/alpha/Gregs.c
@@ -72,6 +72,15 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
     case UNW_ALPHA_R28:
     case UNW_ALPHA_R29:
     case UNW_ALPHA_PC:
+      if (write)
+        {
+          c->dwarf.ip = *valp;
+          /* Alpha landing pads reconstruct GP via `ldah gp,X($ra); lda gp,Y(gp)`,
+             so $ra must equal the landing pad address.  Mirror aarch64's approach:
+             write the new IP into the saved-$ra location so that
+             establish_machine_state() restores $ra = landing pad automatically.  */
+          dwarf_put (&c->dwarf, c->dwarf.loc[UNW_ALPHA_R26], *valp);
+        }
       loc = c->dwarf.loc[reg];
       break;
 

--- a/src/alpha/Gresume.c
+++ b/src/alpha/Gresume.c
@@ -37,10 +37,10 @@ alpha_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
   struct cursor *c = (struct cursor *) cursor;
   ucontext_t uc = *c->uc;
 
-  uc.uc_mcontext.sc_pc = c->dwarf.ip;
-
   /* Ensure c->pi is up-to-date.  */
   dwarf_make_proc_info (&c->dwarf);
+
+  uc.uc_mcontext.sc_pc = c->dwarf.ip;
 
   switch (c->sigcontext_format)
     {


### PR DESCRIPTION
Alpha landing pads reconstruct GP via `ldah gp,X($ra); lda gp,Y(gp)`, which requires $ra to equal the landing pad address at entry.

When _Unwind_SetIP() writes the landing pad to UNW_ALPHA_PC, also write it to the saved-$ra location (c->dwarf.loc[UNW_ALPHA_R26]) so that establish_machine_state() restores $ra = landing pad automatically. This mirrors how aarch64 handles UNW_AARCH64_X30 (the return address register): writing UNW_TDEP_IP updates both c->dwarf.ip and the saved-link-register location on the stack.

Also update c->dwarf.ip when writing UNW_ALPHA_PC so that alpha_local_resume() uses the correct sc_pc = landing pad (rather than the stale value from unw_getcontext that establish_machine_state leaves in c->uc->uc_mcontext.sc_pc).

Enables Ltest-cxx-exceptions: all 38 alpha tests now pass.