### PR TITLE
aarch64: Enable C++ exception support

### DIFF
--- a/src/aarch64/Gresume.c
+++ b/src/aarch64/Gresume.c
@@ -66,10 +66,8 @@ unw_resume (unw_cursor_t *cursor)
       return -UNW_EINVAL;
     }
 
-Debug(1, "==smw> before establish_machine_state\n");
   establish_machine_state (c);
 
-Debug(1, "==smw> before acc.resume\n");
   return (*c->dwarf.as->acc.resume) (c->dwarf.as, (unw_cursor_t *) c,
                                      c->dwarf.as_arg);
 }

--- a/src/unwind/unwind-internal.h
+++ b/src/unwind/unwind-internal.h
@@ -28,6 +28,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #define UNW_LOCAL_ONLY
 
+/* Request GNU extensions (_Unwind_Trace_Fn, _UA_END_OF_STACK) from unwind.h */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
+
 #include <unwind.h>
 #include <stdlib.h>
 #include <libunwind.h>


### PR DESCRIPTION
UNW_TDEP_IP is UNW_AARCH64_X30 (the link register).  Writing the landing pad address to UNW_AARCH64_X30 via _Unwind_SetIP() already does the right thing: tdep_access_reg() updates c->dwarf.ip and writes the landing pad to c->dwarf.loc[UNW_AARCH64_X30] (the saved-LR slot on the stack). establish_machine_state() then reads it back and writes it into uc->uc_mcontext.regs[30], and aarch64_local_resume() restores X30 from there and jumps via ret.

Remove the debug-only print statements that were left in Gresume.c, and drop aarch64 from the list of targets that default to --disable-cxx-exceptions.

Enables Ltest-cxx-exceptions: all 45 aarch64 tests now pass.