### PR TITLE
mips: Enable C++ exception support

### DIFF
--- a/include/libunwind-mips.h
+++ b/include/libunwind-mips.h
@@ -117,7 +117,7 @@ typedef enum
 
     UNW_TDEP_IP = UNW_MIPS_R31,
     UNW_TDEP_SP = UNW_MIPS_R29,
-    UNW_TDEP_EH = UNW_MIPS_R0   /* FIXME.  */
+    UNW_TDEP_EH = UNW_MIPS_R4
   }
 mips_regnum_t;
 
@@ -129,7 +129,7 @@ typedef enum
   }
 mips_abi_t;
 
-#define UNW_TDEP_NUM_EH_REGS    2       /* FIXME for MIPS.  */
+#define UNW_TDEP_NUM_EH_REGS    2
 
 typedef struct unw_tdep_save_loc
   {

--- a/src/mips/Gregs.c
+++ b/src/mips/Gregs.c
@@ -34,12 +34,31 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
   
   switch (reg)
     {
+    case UNW_MIPS_R4:
+    case UNW_MIPS_R5:
+      {
+        unsigned int n = reg - UNW_MIPS_R4;
+        unsigned int mask = 1 << n;
+        if (write)
+          {
+            c->dwarf.eh_args[n] = *valp;
+            c->dwarf.eh_valid_mask |= mask;
+            return 0;
+          }
+        else if ((c->dwarf.eh_valid_mask & mask) != 0)
+          {
+            *valp = c->dwarf.eh_args[n];
+            return 0;
+          }
+        else
+          loc = c->dwarf.loc[reg - UNW_MIPS_R0];
+      }
+      break;
+
     case UNW_MIPS_R0:
     case UNW_MIPS_R1:
     case UNW_MIPS_R2:
     case UNW_MIPS_R3:
-    case UNW_MIPS_R4:
-    case UNW_MIPS_R5:
     case UNW_MIPS_R6:
     case UNW_MIPS_R7:
     case UNW_MIPS_R8:

--- a/src/mips/Gregs.c
+++ b/src/mips/Gregs.c
@@ -65,7 +65,12 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
     case UNW_MIPS_R28:
 
     case UNW_MIPS_R30:
+      loc = c->dwarf.loc[reg - UNW_MIPS_R0];
+      break;
+
     case UNW_MIPS_R31:
+      if (write)
+        c->dwarf.ip = *valp;            /* update the IP cache */
       loc = c->dwarf.loc[reg - UNW_MIPS_R0];
       break;
 

--- a/src/mips/Gresume.c
+++ b/src/mips/Gresume.c
@@ -36,6 +36,9 @@ mips_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
 
   Debug (8, "resuming at ip=%llx via setcontext()\n",
          (unsigned long long) c->dwarf.ip);
+  /* _Umips_getcontext doesn't save the FP CSR (fpc_csr); stale cause+enable
+     bits would make setcontext's ctc1 raise SIGFPE immediately. */
+  uc->uc_mcontext.fpc_csr = 0;
   setcontext (uc);
   return -UNW_EINVAL;
 }

--- a/src/mips/init.h
+++ b/src/mips/init.h
@@ -48,6 +48,7 @@ common_init (struct cursor *c, unsigned use_prev_instr)
   /* FIXME: Initialisation for other registers.  */
 
   c->dwarf.args_size = 0;
+  c->dwarf.eh_valid_mask = 0;
   c->dwarf.stash_frames = 0;
   c->dwarf.use_prev_instr = use_prev_instr;
   c->dwarf.pi_valid = 0;


### PR DESCRIPTION
- mips: Fix R31 write to update c->dwarf.ip
- mips: Handle R4/R5 as EH argument registers
- mips: Zero fpc_csr before setcontext to prevent spurious SIGFPE
- mips: Enable C++ exceptions