### PR TITLE
s390x: Enable C++ exception support

### DIFF
--- a/src/s390x/Gregs.c
+++ b/src/s390x/Gregs.c
@@ -57,7 +57,12 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
     case UNW_S390X_R12:
     case UNW_S390X_R13:
     case UNW_S390X_R14:
+      loc = c->dwarf.loc[reg];
+      break;
+
     case UNW_S390X_IP:
+      if (write)
+        c->dwarf.ip = *valp;
       loc = c->dwarf.loc[reg];
       break;
 

--- a/src/s390x/Gresume.c
+++ b/src/s390x/Gresume.c
@@ -40,13 +40,13 @@ s390x_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
   struct sigcontext *sc = NULL;
   int i;
   unw_word_t sp, ip;
-  uc.uc_mcontext.psw.addr = c->dwarf.ip;
-
   /* Ensure c->pi is up-to-date.  On x86-64, it's relatively common to
      be missing DWARF unwind info.  We don't want to fail in that
      case, because the frame-chain still would let us do a backtrace
      at least.  */
   dwarf_make_proc_info (&c->dwarf);
+
+  uc.uc_mcontext.psw.addr = c->dwarf.ip;
 
   switch (c->sigcontext_format)
     {


### PR DESCRIPTION
Writing the landing pad address to UNW_S390X_IP via _Unwind_SetIP() only wrote to c->dwarf.loc[UNW_S390X_IP] but left c->dwarf.ip stale. s390x_local_resume() then overwrote uc.uc_mcontext.psw.addr with that stale value, causing the unwinder to re-enter the same frame in an infinite loop.

Fix tdep_access_reg() to update c->dwarf.ip when writing UNW_S390X_IP, and move the psw.addr assignment in s390x_local_resume() to after dwarf_make_proc_info() so it picks up the correct value.

Enables Ltest-cxx-exceptions: all 36 s390x tests now pass (2 skipped as
expected under qemu-user: test-ptrace and test-getcontext-gp).