### PR TITLE
loongarch64: Enable C++ exception support

### DIFF
--- a/include/libunwind-loongarch64.h
+++ b/include/libunwind-loongarch64.h
@@ -107,7 +107,7 @@ typedef enum
 
     UNW_TDEP_IP = UNW_LOONGARCH64_R1,
     UNW_TDEP_SP = UNW_LOONGARCH64_R3,
-    UNW_TDEP_EH = UNW_LOONGARCH64_R0   /* FIXME.  */
+    UNW_TDEP_EH = UNW_LOONGARCH64_R4
   }
 loongarch64_regnum_t;
 

--- a/src/loongarch64/Gregs.c
+++ b/src/loongarch64/Gregs.c
@@ -36,8 +36,15 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
   switch (reg)
     {
     case UNW_LOONGARCH64_R0:
-    case UNW_LOONGARCH64_R1:
     case UNW_LOONGARCH64_R2:
+      loc = c->dwarf.loc[reg - UNW_LOONGARCH64_R0];
+      break;
+
+    case UNW_LOONGARCH64_R1:
+      if (write)
+        c->dwarf.ip = *valp;
+      loc = c->dwarf.loc[UNW_LOONGARCH64_R1];
+      break;
 
     case UNW_LOONGARCH64_R4:
     case UNW_LOONGARCH64_R5:

--- a/src/loongarch64/Gregs.c
+++ b/src/loongarch64/Gregs.c
@@ -50,6 +50,25 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
     case UNW_LOONGARCH64_R5:
     case UNW_LOONGARCH64_R6:
     case UNW_LOONGARCH64_R7:
+      {
+        unsigned int n = reg - UNW_LOONGARCH64_R4;
+        unsigned int mask = 1 << n;
+        if (write)
+          {
+            c->dwarf.eh_args[n] = *valp;
+            c->dwarf.eh_valid_mask |= mask;
+            return 0;
+          }
+        else if ((c->dwarf.eh_valid_mask & mask) != 0)
+          {
+            *valp = c->dwarf.eh_args[n];
+            return 0;
+          }
+        else
+          loc = c->dwarf.loc[reg - UNW_LOONGARCH64_R0];
+      }
+      break;
+
     case UNW_LOONGARCH64_R8:
     case UNW_LOONGARCH64_R9:
     case UNW_LOONGARCH64_R10:

--- a/src/loongarch64/Gresume.c
+++ b/src/loongarch64/Gresume.c
@@ -106,6 +106,9 @@ establish_machine_state (struct cursor *c)
       if (tdep_access_reg (c, reg, &val, 0) >= 0)
         as->acc.access_reg (as, reg, &val, 1, arg);
     }
+
+  val = c->dwarf.ip;
+  as->acc.access_reg (as, UNW_LOONGARCH64_PC, &val, 1, arg);
 }
 
 int

--- a/src/loongarch64/Gresume.c
+++ b/src/loongarch64/Gresume.c
@@ -45,6 +45,10 @@ loongarch64_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
       asm volatile (
         "ld.d $ra, %0, 8\n"
         "ld.d $sp, %0, 3*8\n"
+        "ld.d $a0, %0, 4*8\n"
+        "ld.d $a1, %0, 5*8\n"
+        "ld.d $a2, %0, 6*8\n"
+        "ld.d $a3, %0, 7*8\n"
         "ld.d $fp, %0, 22*8\n"
         "ld.d $s0, %0, 23*8\n"
         "ld.d $s1, %0, 24*8\n"

--- a/src/loongarch64/init.h
+++ b/src/loongarch64/init.h
@@ -53,6 +53,7 @@ common_init (struct cursor *c, unsigned use_prev_instr)
   c->sigcontext_pc = 0;
 
   c->dwarf.args_size = 0;
+  c->dwarf.eh_valid_mask = 0;
   c->dwarf.stash_frames = 0;
   c->dwarf.use_prev_instr = use_prev_instr;
   c->dwarf.pi_valid = 0;


### PR DESCRIPTION
- loongarch64: fix R1 ($ra) write to update c->dwarf.ip
- loongarch64: handle a0-a3 (R4-R7) as EH argument registers
- loongarch64: Enable C++ exception support