### PR TITLE
hppa: Zero sc_fr[0] before setcontext to prevent spurious FP fault

### DIFF
--- a/src/hppa/Gresume.c
+++ b/src/hppa/Gresume.c
@@ -74,6 +74,9 @@ hppa_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
   else
     {
       Debug (8, "resuming at ip=%x via setcontext()\n", c->dwarf.ip);
+      /* _Uhppa_getcontext doesn't save FR0 (the FPSR); a stale value
+         with cause+enable bits set would fault inside setcontext. */
+      uc->uc_mcontext.sc_fr[0] = 0;
       setcontext (uc);
     }
 #else


### PR DESCRIPTION
_Uhppa_getcontext is a minimal stub that saves only the callee-saved FP registers fr12–fr21.  It leaves uc_mcontext.sc_fr[0] uninitialized (whatever happens to be on the stack).  FR0 on PA-RISC is the FP Status Register (FPSR); glibc's setcontext restores all 32 FP registers including FR0 back to hardware.  If the uninitialized value has cause bits set alongside their enable bits, this raises an FP exception immediately -- before the landing pad executes a single instruction.

Zero sc_fr[0] in hppa_local_resume() before calling setcontext(), giving the FP unit a clean, exception-free state.