### PR TITLE
hppa: Enable C++ exception support

### DIFF
--- a/include/tdep-hppa/libunwind_i.h
+++ b/include/tdep-hppa/libunwind_i.h
@@ -259,7 +259,8 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
 
 #define tdep_get_as(c)                  ((c)->dwarf.as)
 #define tdep_get_as_arg(c)              ((c)->dwarf.as_arg)
-#define tdep_get_ip(c)                  ((c)->dwarf.ip)
+/* HPPA IAOQ stores privilege level in the low 2 bits; strip them. */
+#define tdep_get_ip(c)                  ((c)->dwarf.ip & ~(unw_word_t)3)
 #define tdep_big_endian(as)             1
 
 extern atomic_bool tdep_init_done;

--- a/src/hppa/Ginit.c
+++ b/src/hppa/Ginit.c
@@ -136,8 +136,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 
   if (write)
     {
-      memcpy ((void *) addr, val, sizeof(unw_word_t));
-      Debug (12, "%s <- %x\n", unw_regname (reg), *val);
+      unw_word_t wval = *val;
+      /* HPPA IAOQ encodes privilege level in the low 2 bits (3 = user mode). */
+      if (reg == UNW_HPPA_IP)
+        wval |= 3;
+      memcpy ((void *) addr, &wval, sizeof(unw_word_t));
+      Debug (12, "%s <- %x\n", unw_regname (reg), wval);
     }
   else
     {

--- a/src/hppa/Gregs.c
+++ b/src/hppa/Gregs.c
@@ -38,11 +38,15 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
     {
     case UNW_HPPA_IP:
       if (write)
-        c->dwarf.ip = *valp;            /* update the IP cache */
-      if (c->dwarf.pi_valid && (*valp < c->dwarf.pi.start_ip
-                                || *valp >= c->dwarf.pi.end_ip))
-        c->dwarf.pi_valid = 0;          /* new IP outside of current proc */
-      break;
+        {
+          c->dwarf.ip = *valp;
+          if (c->dwarf.pi_valid && (*valp < c->dwarf.pi.start_ip
+                                    || *valp >= c->dwarf.pi.end_ip))
+            c->dwarf.pi_valid = 0;
+        }
+      else
+        *valp = c->dwarf.ip;
+      return 0;
 
     case UNW_HPPA_CFA:
       if (write)

--- a/src/hppa/Gresume.c
+++ b/src/hppa/Gresume.c
@@ -74,6 +74,8 @@ hppa_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
   else
     {
       Debug (8, "resuming at ip=%x via setcontext()\n", c->dwarf.ip);
+      /* CFA after unw_step equals the frame's body SP on HPPA's upward-growing stack. */
+      uc->uc_mcontext.sc_gr[30] = c->dwarf.cfa;
       setcontext (uc);
     }
 #else

--- a/src/hppa/setcontext.S
+++ b/src/hppa/setcontext.S
@@ -36,6 +36,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 	.proc
 	.callinfo
 _Uhppa_setcontext:
+	ldw (LINUX_UC_MCONTEXT_OFF+LINUX_SC_IAOQ_OFF)(%r26),%r1	/* resume PC */
 	FILL (2)		/* return-pointer */
 	FILL (3)		/* frame pointer */
 	FILL (4)		/* 2nd-ary frame pointer */
@@ -54,6 +55,8 @@ _Uhppa_setcontext:
 	FILL (17)		/* preserved register */
 	FILL (18)		/* preserved register */
 	FILL (19)		/* linkage-table register */
+	FILL (20)		/* exception-handling arg 0 */
+	FILL (21)		/* exception-handling arg 1 */
 	FILL (27)		/* global-data pointer */
 	FILL (30)		/* stack pointer */
 
@@ -69,7 +72,7 @@ _Uhppa_setcontext:
 	fldds,ma 8(%r29), %fr20
 	fldds    8(%r29), %fr21
 
-	bv,n	%r0(%rp)
+	bv,n	%r0(%r1)
 	.procend
 #ifdef __linux__
 	/* We do not need executable stack.  */


### PR DESCRIPTION
- hppa: Strip privilege bits from IP register accesses
- hppa: Restore exception args and resume to cursor IP in setcontext
- hppa: Set landing pad SP from cursor CFA in local_resume
- hppa: Enable C++ exception support by default