### PR TITLE
x86: Enable C++ exception support

### DIFF
--- a/include/tdep-hppa/libunwind_i.h
+++ b/include/tdep-hppa/libunwind_i.h
@@ -259,7 +259,8 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
 
 #define tdep_get_as(c)                  ((c)->dwarf.as)
 #define tdep_get_as_arg(c)              ((c)->dwarf.as_arg)
-#define tdep_get_ip(c)                  ((c)->dwarf.ip)
+/* HPPA IAOQ stores privilege level in the low 2 bits; strip them. */
+#define tdep_get_ip(c)                  ((c)->dwarf.ip & ~(unw_word_t)3)
 #define tdep_big_endian(as)             1
 
 extern atomic_bool tdep_init_done;

--- a/include/tdep-hppa/libunwind_i.h
+++ b/include/tdep-hppa/libunwind_i.h
@@ -84,10 +84,10 @@ struct MAY_ALIAS cursor
 # define DWARF_LOC(r, t)        ((dwarf_loc_t) { .val = (r) })
 # define DWARF_IS_REG_LOC(l)    0
 # define DWARF_REG_LOC(c,r)     (DWARF_LOC((unw_word_t)                      \
-                                 tdep_uc_addr((c)->as_arg, (r)), 0))
+                                 tdep_uc_addr(((struct cursor *)(c))->uc, (r)), 0))
 # define DWARF_MEM_LOC(c,m)     DWARF_LOC ((m), 0)
 # define DWARF_FPREG_LOC(c,r)   (DWARF_LOC((unw_word_t)                      \
-                                 tdep_uc_addr((c)->as_arg, (r)), 0))
+                                 tdep_uc_addr(((struct cursor *)(c))->uc, (r)), 0))
 
 static inline int
 dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)

--- a/include/tdep-hppa/libunwind_i.h
+++ b/include/tdep-hppa/libunwind_i.h
@@ -61,6 +61,8 @@ struct MAY_ALIAS cursor
   {
     struct dwarf_cursor dwarf;          /* must be first */
 
+    ucontext_t *uc;
+
     /* Format of sigcontext structure and address at which it is
        stored: */
     enum
@@ -110,7 +112,11 @@ dwarf_get (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t *val)
 {
   if (!DWARF_GET_LOC (loc))
     return -1;
-  *val = *(unw_word_t *) DWARF_GET_LOC (loc);
+  unw_word_t addr = DWARF_GET_LOC (loc);
+  if (unlikely (((struct cursor *) c)->validate)
+      && unlikely (!unw_address_is_valid (addr, sizeof (unw_word_t))))
+    return -1;
+  *val = *(unw_word_t *) addr;
   return 0;
 }
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -379,7 +379,7 @@ if OS_LINUX
  libunwind_la_SOURCES_arm_os           = arm/Gos-linux.c
  libunwind_la_SOURCES_arm_os_local     = arm/Los-linux.c
  libunwind_la_SOURCES_x86_os           = x86/Gos-linux.c
- libunwind_la_SOURCES_x86_os_local     = x86/Los-linux.c x86/getcontext-linux.S
+ libunwind_la_SOURCES_x86_os_local     = x86/Los-linux.c x86/getcontext-linux.S x86/setcontext.S
  libunwind_la_SOURCES_x86_64_os        = x86_64/Gos-linux.c
  libunwind_la_SOURCES_x86_64_os_local  = x86_64/Los-linux.c
  libunwind_coredump_la_SOURCES += coredump/_UCD_access_reg_linux.c
@@ -1231,7 +1231,8 @@ libunwind_x86_la_SOURCES =                     \
 	x86/Gregs.c                            \
 	x86/Greg_states_iterate.c              \
 	x86/Gresume.c                          \
-	x86/Gstep.c
+	x86/Gstep.c                           \
+	x86/setcontext.S
 libunwind_x86_la_LDFLAGS =                     \
 	$(COMMON_SO_LDFLAGS)                   \
 	-version-info $(SOVERSION)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -386,7 +386,7 @@ if OS_LINUX
  libunwind_la_SOURCES_arm_os           = arm/Gos-linux.c
  libunwind_la_SOURCES_arm_os_local     = arm/Los-linux.c
  libunwind_la_SOURCES_x86_os           = x86/Gos-linux.c
- libunwind_la_SOURCES_x86_os_local     = x86/Los-linux.c x86/getcontext-linux.S
+ libunwind_la_SOURCES_x86_os_local     = x86/Los-linux.c x86/getcontext-linux.S x86/setcontext.S
  libunwind_la_SOURCES_x86_64_os        = x86_64/Gos-linux.c
  libunwind_la_SOURCES_x86_64_os_local  = x86_64/Los-linux.c
  libunwind_coredump_la_SOURCES += coredump/_UCD_access_reg_linux.c

--- a/src/abi/x86/linux-gnu/libunwind.abi
+++ b/src/abi/x86/linux-gnu/libunwind.abi
@@ -42,6 +42,7 @@
     <elf-symbol name='_Ux86_getcontext' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_Ux86_is_fpreg' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_Ux86_regname' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='_Ux86_setcontext' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='_Ux86_strerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='backtrace' type='func-type' binding='weak-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='unw_backtrace' type='func-type' binding='global-binding' visibility='default-visibility' alias='backtrace' is-defined='yes'/>

--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -27,7 +27,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
    (http://www.linuxbase.org/spec/).  */
 
 #include <stddef.h>
-#include <stdio.h>
 #include <limits.h>
 
 #include "dwarf_i.h"
@@ -663,13 +662,11 @@ dwarf_callback (struct dl_phdr_info *info, size_t size, void *ptr)
       a = unw_get_accessors_int (unw_local_addr_space);
       addr = (unw_word_t) (uintptr_t) (&hdr->eh_frame);
 
-      /* (Optionally) read eh_frame_ptr: */
       if ((ret = dwarf_read_encoded_pointer (unw_local_addr_space, a,
                                              &addr, hdr->eh_frame_ptr_enc, pi,
                                              &eh_frame_start, NULL)) < 0)
         return ret;
 
-      /* (Optionally) read fde_count: */
       if ((ret = dwarf_read_encoded_pointer (unw_local_addr_space, a,
                                              &addr, hdr->fde_count_enc, pi,
                                              &fde_count, NULL)) < 0)
@@ -795,8 +792,10 @@ dwarf_find_proc_info (unw_addr_space_t as, unw_word_t ip,
 
       /* search the table: */
       if (cb_data.di.format != -1)
+        {
 	ret = dwarf_search_unwind_table_int (as, ip, &cb_data.di,
 					     pi, need_unwind_info, arg);
+        }
       else
 	ret = -UNW_ENOINFO;
 

--- a/src/hppa/Ginit.c
+++ b/src/hppa/Ginit.c
@@ -136,8 +136,12 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
 
   if (write)
     {
-      memcpy ((void *) addr, val, sizeof(unw_word_t));
-      Debug (12, "%s <- %x\n", unw_regname (reg), *val);
+      unw_word_t wval = *val;
+      /* HPPA IAOQ encodes privilege level in the low 2 bits (3 = user mode). */
+      if (reg == UNW_HPPA_IP)
+        wval |= 3;
+      memcpy ((void *) addr, &wval, sizeof(unw_word_t));
+      Debug (12, "%s <- %x\n", unw_regname (reg), wval);
     }
   else
     {

--- a/src/hppa/Ginit.c
+++ b/src/hppa/Ginit.c
@@ -105,15 +105,13 @@ access_mem (unw_addr_space_t as, unw_word_t addr, unw_word_t *val, int write,
     }
   else
     {
-      /* validate address */
-      const struct cursor *c = (const struct cursor *)arg;
-
+      const struct cursor *c = (const struct cursor *) arg;
       if (likely (c != NULL) && unlikely (c->validate)
-          && unlikely (!unw_address_is_valid (addr, sizeof(unw_word_t)))) {
-        Debug (16, "mem[%x] -> invalid\n", addr);
-        return -1;
-      }
-
+          && unlikely (!unw_address_is_valid (addr, sizeof (unw_word_t))))
+        {
+          Debug (12, "mem[%x] -> invalid\n", addr);
+          return -1;
+        }
       memcpy (val, (void *) addr, sizeof(unw_word_t));
       Debug (12, "mem[%x] -> %x\n", addr, *val);
     }
@@ -125,7 +123,7 @@ access_reg (unw_addr_space_t as, unw_regnum_t reg, unw_word_t *val, int write,
             void *arg)
 {
   unw_word_t *addr;
-  ucontext_t *uc = arg;
+  ucontext_t *uc = ((struct cursor *) arg)->uc;
 
   if ((unsigned int) (reg - UNW_HPPA_FR) < 32)
     goto badreg;
@@ -159,7 +157,7 @@ static int
 access_fpreg (unw_addr_space_t as, unw_regnum_t reg, unw_fpreg_t *val,
               int write, void *arg)
 {
-  ucontext_t *uc = arg;
+  ucontext_t *uc = ((struct cursor *) arg)->uc;
   unw_fpreg_t *addr;
 
   if ((unsigned) (reg - UNW_HPPA_FR) > 32)

--- a/src/hppa/Ginit_local.c
+++ b/src/hppa/Ginit_local.c
@@ -47,9 +47,9 @@ unw_init_local_common (unw_cursor_t *cursor, ucontext_t *uc, unsigned use_prev_i
   Debug (1, "(cursor=%p)\n", c);
 
   c->dwarf.as = unw_local_addr_space;
-  c->dwarf.as_arg = cursor;
-  c->dwarf.as_arg = uc;
-  c->validate = 1;
+  c->uc = uc;
+  c->dwarf.as_arg = c;
+  c->validate = 0;
 
   return common_init (c, use_prev_instr);
 }

--- a/src/hppa/Ginit_remote.c
+++ b/src/hppa/Ginit_remote.c
@@ -44,7 +44,16 @@ unw_init_remote (unw_cursor_t *cursor, unw_addr_space_t as, void *as_arg)
   Debug (1, "(cursor=%p)\n", c);
 
   c->dwarf.as = as;
-  c->dwarf.as_arg = as_arg;
+  if (as == unw_local_addr_space)
+    {
+      c->uc = as_arg;
+      c->dwarf.as_arg = c;
+    }
+  else
+    {
+      c->uc = NULL;
+      c->dwarf.as_arg = as_arg;
+    }
   return common_init (c, 0);
 #endif /* !UNW_LOCAL_ONLY */
 }

--- a/src/hppa/Gregs.c
+++ b/src/hppa/Gregs.c
@@ -38,11 +38,15 @@ tdep_access_reg (struct cursor *c, unw_regnum_t reg, unw_word_t *valp,
     {
     case UNW_HPPA_IP:
       if (write)
-        c->dwarf.ip = *valp;            /* update the IP cache */
-      if (c->dwarf.pi_valid && (*valp < c->dwarf.pi.start_ip
-                                || *valp >= c->dwarf.pi.end_ip))
-        c->dwarf.pi_valid = 0;          /* new IP outside of current proc */
-      break;
+        {
+          c->dwarf.ip = *valp;
+          if (c->dwarf.pi_valid && (*valp < c->dwarf.pi.start_ip
+                                    || *valp >= c->dwarf.pi.end_ip))
+            c->dwarf.pi_valid = 0;
+        }
+      else
+        *valp = c->dwarf.ip;
+      return 0;
 
     case UNW_HPPA_CFA:
       if (write)

--- a/src/hppa/Gresume.c
+++ b/src/hppa/Gresume.c
@@ -55,7 +55,7 @@ hppa_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
 {
 #if defined(__linux__)
   struct cursor *c = (struct cursor *) cursor;
-  ucontext_t *uc = c->dwarf.as_arg;
+  ucontext_t *uc = c->uc;
 
   /* Ensure c->pi is up-to-date.  On PA-RISC, it's relatively common to be
      missing DWARF unwind info.  We don't want to fail in that case,

--- a/src/hppa/Gstep.c
+++ b/src/hppa/Gstep.c
@@ -187,11 +187,11 @@ unw_step (unw_cursor_t *cursor)
   if (unw_is_signal_frame (cursor) > 0)
     return hppa_handle_signal_frame (cursor);
 
-  /* Restore default memory validation state */
-  c->validate = validate;
-
   /* Try DWARF-based unwinding... */
   ret = dwarf_step (&c->dwarf);
+
+  /* Restore default memory validation state */
+  c->validate = validate;
 
   if (unlikely (ret == -UNW_ESTOPUNWIND))
     return ret;

--- a/src/hppa/setcontext.S
+++ b/src/hppa/setcontext.S
@@ -36,6 +36,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 	.proc
 	.callinfo
 _Uhppa_setcontext:
+	ldw (LINUX_UC_MCONTEXT_OFF+LINUX_SC_IAOQ_OFF)(%r26),%r1	/* resume PC */
 	FILL (2)		/* return-pointer */
 	FILL (3)		/* frame pointer */
 	FILL (4)		/* 2nd-ary frame pointer */
@@ -54,6 +55,8 @@ _Uhppa_setcontext:
 	FILL (17)		/* preserved register */
 	FILL (18)		/* preserved register */
 	FILL (19)		/* linkage-table register */
+	FILL (20)		/* exception-handling arg 0 */
+	FILL (21)		/* exception-handling arg 1 */
 	FILL (27)		/* global-data pointer */
 	FILL (30)		/* stack pointer */
 
@@ -69,7 +72,7 @@ _Uhppa_setcontext:
 	fldds,ma 8(%r29), %fr20
 	fldds    8(%r29), %fr21
 
-	bv,n	%r0(%rp)
+	bv,n	%r0(%r1)
 	.procend
 #ifdef __linux__
 	/* We do not need executable stack.  */

--- a/src/x86/Gos-linux.c
+++ b/src/x86/Gos-linux.c
@@ -293,7 +293,7 @@ x86_local_resume (unw_addr_space_t as UNUSED, unw_cursor_t *cursor, void *arg UN
 
   Debug (8, "resuming at ip=%x via setcontext()\n", c->dwarf.ip);
 #if !defined(__ANDROID__)
-  setcontext (uc);
+  _Ux86_setcontext (uc);
 #endif
   return -UNW_EINVAL;
 }

--- a/src/x86/setcontext.S
+++ b/src/x86/setcontext.S
@@ -1,0 +1,74 @@
+/* libunwind - a platform-independent unwind library
+   Copyright (C) 2026 libunwind contributors
+
+This file is part of libunwind.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#include "offsets.h"
+
+/*  int _Ux86_setcontext (const ucontext_t *ucp)
+
+  Restores the machine context provided.
+  Unlike the libc implementation, doesn't clobber %eax (exception object
+  pointer) or %edx (exception selector).
+*/
+
+	.global _Ux86_setcontext
+	.type _Ux86_setcontext, @function
+_Ux86_setcontext:
+	.cfi_startproc
+
+	/* EAX = ucp (argument) */
+	mov	4(%esp),%eax
+
+	/* Restore FP state */
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_FPSTATE_OFF)(%eax),%ecx
+	fldenv	(%ecx)
+
+	/* Stash new EIP at new_ESP - 4 so we can 'ret' to it after
+	   switching stacks.  Use ECX/EDX as scratch (caller-saved). */
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_ESP_OFF)(%eax),%ecx
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_EIP_OFF)(%eax),%edx
+	mov	%edx,-4(%ecx)
+
+	/* Restore callee-saved registers */
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_EBX_OFF)(%eax),%ebx
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_EBP_OFF)(%eax),%ebp
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_ESI_OFF)(%eax),%esi
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_EDI_OFF)(%eax),%edi
+
+	/* Restore EDX (exception selector) */
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_EDX_OFF)(%eax),%edx
+
+	/* Switch to new stack (EIP waiting at new_ESP - 4) */
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_ESP_OFF)(%eax),%esp
+	sub	$4,%esp
+
+	/* Restore EAX (exception object pointer) last — clobbers ucp */
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_EAX_OFF)(%eax),%eax
+
+	ret
+	.cfi_endproc
+
+	.size	_Ux86_setcontext, . - _Ux86_setcontext
+
+	/* We do not need executable stack.  */
+	.section	.note.GNU-stack,"",@progbits

--- a/src/x86/setcontext.S
+++ b/src/x86/setcontext.S
@@ -1,0 +1,91 @@
+/* libunwind - a platform-independent unwind library
+   Copyright (C) 2026 libunwind contributors
+
+This file is part of libunwind.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#include "offsets.h"
+
+/*  int _Ux86_setcontext (const ucontext_t *ucp)
+
+  Restores the machine context provided.
+  Unlike the libc implementation, doesn't clobber %eax (exception object
+  pointer) or %edx (exception selector).
+*/
+
+#define SIG_SETMASK		2
+#define SYS_rt_sigprocmask	175
+#define SIGSET_BYTES		8	/* _NSIG / 8 */
+
+	.global _Ux86_setcontext
+	.type _Ux86_setcontext, @function
+_Ux86_setcontext:
+	.cfi_startproc
+
+	/* EDI = ucp (argument).  It is preserved across the syscall
+	   below and is restored from the context later on.  */
+	mov	4(%esp),%edi
+
+	/* Restore the signal mask:
+	     rt_sigprocmask (SIG_SETMASK, &ucp->uc_sigmask, NULL, 8)  */
+	mov	$SIG_SETMASK,%ebx
+	lea	LINUX_UC_SIGMASK_OFF(%edi),%ecx
+	xor	%edx,%edx
+	mov	$SIGSET_BYTES,%esi
+	mov	$SYS_rt_sigprocmask,%eax
+	int	$0x80
+
+	/* EAX = ucp */
+	mov	%edi,%eax
+
+	/* Restore FP state */
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_FPSTATE_OFF)(%eax),%ecx
+	fldenv	(%ecx)
+
+	/* Stash new EIP at new_ESP - 4 so we can 'ret' to it after
+	   switching stacks.  Use ECX/EDX as scratch (caller-saved). */
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_ESP_OFF)(%eax),%ecx
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_EIP_OFF)(%eax),%edx
+	mov	%edx,-4(%ecx)
+
+	/* Restore callee-saved registers */
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_EBX_OFF)(%eax),%ebx
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_EBP_OFF)(%eax),%ebp
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_ESI_OFF)(%eax),%esi
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_EDI_OFF)(%eax),%edi
+
+	/* Restore EDX (exception selector) */
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_EDX_OFF)(%eax),%edx
+
+	/* Switch to new stack (EIP waiting at new_ESP - 4) */
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_ESP_OFF)(%eax),%esp
+	sub	$4,%esp
+
+	/* Restore EAX (exception object pointer) last — clobbers ucp */
+	mov	(LINUX_UC_MCONTEXT_OFF+LINUX_SC_EAX_OFF)(%eax),%eax
+
+	ret
+	.cfi_endproc
+
+	.size	_Ux86_setcontext, . - _Ux86_setcontext
+
+	/* We do not need executable stack.  */
+	.section	.note.GNU-stack,"",@progbits

--- a/src/x86/unwind_i.h
+++ b/src/x86/unwind_i.h
@@ -56,6 +56,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 extern void x86_local_addr_space_init (void);
 extern int x86_local_resume (unw_addr_space_t as, unw_cursor_t *cursor,
                              void *arg);
+extern int _Ux86_setcontext (const ucontext_t *ucp);
 extern dwarf_loc_t x86_scratch_loc (struct cursor *c, unw_regnum_t reg);
 extern dwarf_loc_t x86_get_scratch_loc (struct cursor *c, unw_regnum_t reg);
 extern void *x86_r_uc_addr (ucontext_t *uc, int reg);

--- a/tests/check-namespace.sh.in
+++ b/tests/check-namespace.sh.in
@@ -202,6 +202,7 @@ check_local_unw_abi () {
 	    match _U${plat}_is_fpreg
 	    match _UL${plat}_dwarf_search_unwind_table
 	    match _UL${plat}_dwarf_find_unwind_table
+	    match _U${plat}_setcontext
 	    ;;
 	x86_64)
 	    match _U${plat}_getcontext


### PR DESCRIPTION
- x86: add _Ux86_setcontext to preserve EAX and EDX
- x86: use _Ux86_setcontext in x86_local_resume
- x86: Enable C++ exception support