### PR TITLE
Modernize FreeBSD CI

### DIFF
--- a/.github/workflows/CI-freebsd.yml
+++ b/.github/workflows/CI-freebsd.yml
@@ -19,11 +19,14 @@ on:
 jobs:
   build-freebsd:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: cpa.sh {0}
     timeout-minutes: 15 # Anything more than about 15 minutes is likely a testsuite hang.
     strategy:
       fail-fast: false
       matrix:
-        os_version: ['14.3', '15.0']
+        os_version: ['14.4', '15.1']
         compiler: [clang, gcc]
         architecture: [x86_64, aarch64]
         exclude:
@@ -34,8 +37,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Build and test on ${{ matrix.architecture }}-freebsd-${{ matrix.os_version }} using ${{ matrix.compiler }}
-        uses: cross-platform-actions/action@v1.0.0
+      - name: Start VM
+        uses: cross-platform-actions/action@v1.3.0
         env:
             IGNORE_OSVERSION: yes
         with:
@@ -43,6 +46,8 @@ jobs:
           version: ${{ matrix.os_version }}
           architecture: ${{ matrix.architecture }}
           memory: 8G
+
+      - name: Build and test on ${{ matrix.architecture }}-freebsd-${{ matrix.os_version }} using ${{ matrix.compiler }}
           run: |
             printf 'shell="%s"\n' $SHELL
             if [ "${{ matrix.compiler }}" = "gcc" ]; then


### PR DESCRIPTION
- Switch FreeBSD 14 job to 14.4, because 14.3 reached EoL
- Switch FreeBSD 15 job to 15.1, it is going EoL September
- Update cross-platform-actions to 1.3.0 and adjust the workflow accordingly