### PR TITLE
Fix overflow in ELF section table bounds check

### DIFF
--- a/src/elfxx.c
+++ b/src/elfxx.c
@@ -92,9 +92,8 @@ elf_w (section_table) (const struct elf_image *ei)
   table_size = (size_t) ehdr->e_shnum * ehdr->e_shentsize;
   if (soff > ei->size || table_size > ei->size - (size_t) soff)
     {
-      Debug (1, "section table outside of image? (%lu + %lu > %lu)\n",
-             (unsigned long) soff, (unsigned long) table_size,
-             (unsigned long) ei->size);
+      Debug (1, "section table outside of image? (%lu + %zu > %zu)\n",
+             (unsigned long) soff, table_size, ei->size);
       return NULL;
     }
 

--- a/src/elfxx.c
+++ b/src/elfxx.c
@@ -86,12 +86,14 @@ elf_w (section_table) (const struct elf_image *ei)
 {
   Elf_W (Ehdr) *ehdr = ei->image;
   Elf_W (Off) soff;
+  size_t table_size;
 
   soff = ehdr->e_shoff;
-  if (soff + ehdr->e_shnum * ehdr->e_shentsize > ei->size)
+  table_size = (size_t) ehdr->e_shnum * ehdr->e_shentsize;
+  if (soff > ei->size || table_size > ei->size - (size_t) soff)
     {
-      Debug (1, "section table outside of image? (%lu > %lu)\n",
-             (unsigned long) (soff + ehdr->e_shnum * ehdr->e_shentsize),
+      Debug (1, "section table outside of image? (%lu + %lu > %lu)\n",
+             (unsigned long) soff, (unsigned long) table_size,
              (unsigned long) ei->size);
       return NULL;
     }


### PR DESCRIPTION
The section count and entry size are 16-bit ELF fields, so integer promotion evaluates their product as int. Large values can overflow before the result is converted to the section offset type.

Calculate the product as `size_t` and compare it against the remaining image size. This also avoids overflow when adding the table size to the section offset.