### PR TITLE
Enable C++ exception support in CI

### DIFF
--- a/.github/workflows/CI-freebsd.yml
+++ b/.github/workflows/CI-freebsd.yml
@@ -63,7 +63,7 @@ jobs:
 
             printf '\n Configuration \n'
             autoreconf -ifv
-            ./configure --enable-debug --enable-coredump
+            ./configure --enable-debug --enable-coredump --enable-cxx-exceptions
             
             printf '\n Build \n'
             make -j$(nproc)

--- a/.github/workflows/CI-linux-gnu.yml
+++ b/.github/workflows/CI-linux-gnu.yml
@@ -212,6 +212,98 @@ jobs:
           if-no-files-found: warn
 
 
+  build-gnu-native-meson:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20 # Anything more than about 20 minutes is likely a testsuite hang.
+    name: ${{ matrix.target.triple }} (meson) ${{ matrix.toolchain.compiler }} ${{ matrix.optimization.buildtype }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { arch: i686,   triple: i686-pc-linux-gnu   }
+          - { arch: x86_64, triple: x86_64-pc-linux-gnu }
+        toolchain:
+          - { compiler: gcc,   CC: gcc-14,   CXX: g++-14     }
+          - { compiler: clang, CC: clang-18, CXX: clang++-18 }
+        optimization:
+          - { buildtype: debugoptimized, optimization: '0' }
+          - { buildtype: release,        optimization: '3' }
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install ${{ matrix.target.triple }} Toolchain
+        run: |
+          if [ '${{ matrix.target.arch }}' = 'i686' ]; then
+            sudo dpkg --add-architecture i386
+          fi
+          sudo apt update
+          sudo apt install -y g++-14-multilib meson ninja-build abigail-tools \
+                               liblzma-dev zlib1g-dev
+          if [ '${{ matrix.target.arch }}' = 'i686' ]; then
+            sudo apt install -y liblzma-dev:i386 zlib1g-dev:i386
+          fi
+
+      - name: Configure with Meson
+        run: |
+          set -x
+          extra_cross_file=
+          if [ '${{ matrix.target.arch }}' = 'i686' ]; then
+            {
+              printf '[binaries]\n'
+              printf "c = '%s'\n"   "${{ matrix.toolchain.CC }}"
+              printf "cpp = '%s'\n" "${{ matrix.toolchain.CXX }}"
+              printf "ar = 'ar'\n"
+              printf "strip = 'strip'\n"
+              printf '\n[built-in options]\n'
+              printf "c_args = ['-m32']\n"
+              printf "cpp_args = ['-m32']\n"
+              printf "c_link_args = ['-m32']\n"
+              printf "cpp_link_args = ['-m32']\n"
+              printf '\n[host_machine]\n'
+              printf "system = 'linux'\n"
+              printf "cpu_family = 'x86'\n"
+              printf "cpu = 'i686'\n"
+              printf "endian = 'little'\n"
+              printf '\n[properties]\n'
+              printf 'needs_exe_wrapper = false\n'
+            } > /tmp/meson-ci-i686.ini
+            cat /tmp/meson-ci-i686.ini
+            extra_cross_file='--cross-file /tmp/meson-ci-i686.ini'
+          fi
+
+          meson setup build-meson \
+            --buildtype=${{ matrix.optimization.buildtype }} --optimization=${{ matrix.optimization.optimization }} \
+            -Ddebug_logs=true -Dminidebuginfo=enabled -Dzlibdebuginfo=enabled -Dcxx_exceptions=enabled \
+            $extra_cross_file
+        env:
+          CC: ${{ matrix.toolchain.CC }}
+          CXX: ${{ matrix.toolchain.CXX }}
+          CFLAGS: "-g -Wall -Wextra -fstrict-aliasing -Wstrict-aliasing -Werror=strict-aliasing"
+          CXXFLAGS: "-g -Wall -Wextra -fstrict-aliasing -Wstrict-aliasing -Werror=strict-aliasing"
+
+      - name: Build
+        run: meson compile -C build-meson -j$(nproc)
+
+      - name: Test
+        if: ${{ success() }}
+        run: |
+          set -x
+          sudo bash -c 'echo core.%p.%p > /proc/sys/kernel/core_pattern'
+          ulimit -c unlimited
+          meson test -C build-meson -j$(nproc) --print-errorlogs
+        env:
+          UNW_DEBUG_LEVEL: 4
+
+      - name: Upload Test Logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: logs-${{ matrix.target.triple }}-meson-${{ matrix.toolchain.compiler }}-${{ matrix.optimization.buildtype }}
+          path: build-meson/meson-logs/
+          if-no-files-found: warn
+
+
   build-gnu-cross-meson:
     runs-on: ubuntu-24.04
     container:

--- a/.github/workflows/CI-linux-gnu.yml
+++ b/.github/workflows/CI-linux-gnu.yml
@@ -229,6 +229,7 @@ jobs:
           - {host: arm-linux-gnueabihf,       qemu: arm,       gccver: 14, container: ubuntu:26.04, meson_cross: arm-linux-gnueabihf, dpkg_arch: armhf }
           - {host: arm-linux-gnueabi,         qemu: arm,       gccver: 14, container: ubuntu:26.04, meson_cross: arm-linux-gnueabi }
           - {host: hppa-linux-gnu,            qemu: hppa,      gccver: 14, container: ubuntu:26.04, meson_cross: hppa-linux-gnu }
+          - {host: loongarch64-linux-gnu,     qemu: loongarch64, gccver: 14, container: ubuntu:26.04, meson_cross: loongarch64-linux-gnu }
           - {host: mips64el-linux-gnuabi64,   qemu: mips64el,  gccver: 14, container: ubuntu:24.04, meson_cross: mips64el-unknown-linux-gnu }
           - {host: mips64-linux-gnuabi64,     qemu: mips64,    gccver: 14, container: ubuntu:24.04, meson_cross: mips64-unknown-linux-gnu }
           - {host: mips64el-linux-gnuabin32,  qemu: mipsn32el, gccver: 14, container: ubuntu:24.04, meson_cross: mipsn32el-unknown-linux-gnu,
@@ -246,6 +247,10 @@ jobs:
           - {host: powerpc-linux-gnu,         qemu: ppc,       gccver: 14, container: ubuntu:26.04, meson_cross: powerpc-unknown-linux-gnu }
           - {host: riscv64-linux-gnu,         qemu: riscv64,   gccver: 14, container: ubuntu:26.04, meson_cross: riscv64-unknown-linux-gnu, dpkg_arch: riscv64 }
           - {host: s390x-linux-gnu,           qemu: s390x,     gccver: 14, container: ubuntu:26.04, meson_cross: s390x-ibm-linux-gnu, dpkg_arch: s390x }
+          - {host: sh4-linux-gnu,             qemu: sh4,       gccver: 14, container: ubuntu:26.04, meson_cross: sh4-linux-gnu,
+             qemu_xfail: "Gtest-sig-context:Gtest-trace:Ltest-init-local-signal:Ltest-sig-context:Ltest-trace" }
+          - {host: sparc64-linux-gnu,         qemu: sparc64,   gccver: 14, container: ubuntu:26.04, meson_cross: sparc64-linux-gnu,
+             qemu_xfail: "Gtest-exc:Gtest-resume-sig:Gtest-resume-sig-rt:Ltest-cxx-exceptions:Ltest-exc:Ltest-resume-sig:Ltest-resume-sig-rt" }
 
     steps:
       - name: Install git

--- a/.github/workflows/CI-linux-gnu.yml
+++ b/.github/workflows/CI-linux-gnu.yml
@@ -113,10 +113,10 @@ jobs:
           - {target: ppc64,    host: powerpc64-linux-gnu,     qemu: ppc64,    gccver: 14, container: ubuntu:26.04, qemu_skip: &ppc64_qemu_skip "Gtest-bt:Gtest-concurrent:Gtest-resume-sig:Gtest-resume-sig-rt:Gtest-trace:Ltest-bt:Ltest-concurrent:Ltest-init-local-signal:Ltest-resume-sig:Ltest-resume-sig-rt:Ltest-sig-context:Ltest-trace:test-async-sig" }
           - {target: ppc64le,  host: powerpc64le-linux-gnu,   qemu: ppc64le,  gccver: 14, container: ubuntu:26.04, dpkg_arch: ppc64el,  qemu_skip: *ppc64_qemu_skip }
           - {target: ppc,      host: powerpc-linux-gnu,       qemu: ppc,      gccver: 14, container: ubuntu:26.04 }
-          - {target: riscv64,  host: riscv64-linux-gnu,       qemu: riscv64,  gccver: 14, container: ubuntu:26.04, dpkg_arch: riscv64  }
-          - {target: s390x,    host: s390x-linux-gnu,         qemu: s390x,    gccver: 14, container: ubuntu:26.04, dpkg_arch: s390x    }
-          - {target: sh4,      host: sh4-linux-gnu,           qemu: sh4,      gccver: 14, container: ubuntu:26.04, qemu_skip: "Gtest-sig-context:Gtest-trace:Ltest-init-local-signal:Ltest-sig-context:Ltest-trace" }
-          - {target: sparc64,  host: sparc64-linux-gnu,       qemu: sparc64,  gccver: 14, container: ubuntu:26.04, qemu_skip: "Gtest-exc:Gtest-resume-sig:Gtest-resume-sig-rt:Ltest-cxx-exceptions:Ltest-exc:Ltest-resume-sig:Ltest-resume-sig-rt" }
+          - {target: riscv64,  host: riscv64-linux-gnu,       qemu: riscv64,  gccver: 14, container: ubuntu:26.04, dpkg_arch: riscv64 }
+          - {target: s390x,    host: s390x-linux-gnu,         qemu: s390x,    gccver: 14, container: ubuntu:26.04, dpkg_arch: s390x }
+          - {target: sh4,      host: sh4-linux-gnu,           qemu: sh4,      gccver: 14, container: ubuntu:26.04, qemu_skip: &sh4_qemu_skip "Gtest-sig-context:Gtest-trace:Ltest-init-local-signal:Ltest-sig-context:Ltest-trace:test-async-sig" }
+          - {target: sparc64,  host: sparc64-linux-gnu,       qemu: sparc64,  gccver: 14, container: ubuntu:26.04, qemu_skip: &sparc64_qemu_skip "Gtest-exc:Gtest-resume-sig:Gtest-resume-sig-rt:Ltest-cxx-exceptions:Ltest-exc:Ltest-resume-sig:Ltest-resume-sig-rt" }
 
     steps:
       - name: Install git
@@ -340,9 +340,9 @@ jobs:
           - {host: riscv64-linux-gnu,         qemu: riscv64,   gccver: 14, container: ubuntu:26.04, meson_cross: riscv64-unknown-linux-gnu, dpkg_arch: riscv64 }
           - {host: s390x-linux-gnu,           qemu: s390x,     gccver: 14, container: ubuntu:26.04, meson_cross: s390x-ibm-linux-gnu, dpkg_arch: s390x }
           - {host: sh4-linux-gnu,             qemu: sh4,       gccver: 14, container: ubuntu:26.04, meson_cross: sh4-linux-gnu,
-             qemu_xfail: "Gtest-sig-context:Gtest-trace:Ltest-init-local-signal:Ltest-sig-context:Ltest-trace" }
+             qemu_xfail: *sh4_qemu_skip }
           - {host: sparc64-linux-gnu,         qemu: sparc64,   gccver: 14, container: ubuntu:26.04, meson_cross: sparc64-linux-gnu,
-             qemu_xfail: "Gtest-exc:Gtest-resume-sig:Gtest-resume-sig-rt:Ltest-cxx-exceptions:Ltest-exc:Ltest-resume-sig:Ltest-resume-sig-rt" }
+             qemu_xfail: *sparc64_qemu_skip }
 
     steps:
       - name: Install git

--- a/.github/workflows/CI-linux-gnu.yml
+++ b/.github/workflows/CI-linux-gnu.yml
@@ -48,7 +48,7 @@ jobs:
           autoreconf -i
           mkdir build
           cd build
-          ../configure --build=x86_64-pc-linux-gnu --host=${{ matrix.target.triple }} --enable-debug --enable-coredump
+          ../configure --build=x86_64-pc-linux-gnu --host=${{ matrix.target.triple }} --enable-debug --enable-coredump --enable-cxx-exceptions
         env:
           CC: ${{ matrix.toolchain.CC }}
           CXX: ${{ matrix.toolchain.CXX }}
@@ -164,7 +164,7 @@ jobs:
           ../configure --build=$(config/config.guess) \
                        --host=${{ matrix.config.host }} \
                        --with-testdriver="$(pwd)/libtool execute $(pwd)/../scripts/qemu-test-driver" \
-                       --enable-debug --enable-coredump
+                       --enable-debug --enable-coredump --enable-cxx-exceptions
         env:
           CC: ${{ matrix.config.cc || format('{0}-gcc-{1}', matrix.config.host, matrix.config.gccver) }}
           CXX: ${{ matrix.config.cxx || format('{0}-g++-{1}', matrix.config.host, matrix.config.gccver) }}
@@ -319,6 +319,7 @@ jobs:
 
           meson setup build-meson \
             --optimization=g \
+            -Dcxx_exceptions=enabled \
             --cross-file cross/${{ matrix.config.meson_cross }}.ini \
             --cross-file /tmp/meson-ci-binaries.ini
 

--- a/.github/workflows/CI-linux-musl.yml
+++ b/.github/workflows/CI-linux-musl.yml
@@ -36,10 +36,11 @@ jobs:
           branch: edge
           arch: ${{ matrix.arch }}
           packages: >
-            autoconf 
-            automake 
-            build-base 
-            libtool 
+            autoconf
+            automake
+            build-base
+            g++
+            libtool
             libucontext-dev
             linux-headers
             xz-dev
@@ -50,7 +51,7 @@ jobs:
           set -x
           gcc --version
           autoreconf -i
-          ./configure --enable-debug --enable-coredump
+          ./configure --enable-debug --enable-coredump --enable-cxx-exceptions
         env:
           CFLAGS: -g -O0 -Wall -Wextra
           CXXFLAGS: -g -O0
@@ -101,6 +102,7 @@ jobs:
           arch: ${{ matrix.arch }}
           packages: >
             build-base
+            g++
             libucontext-dev
             linux-headers
             meson
@@ -111,7 +113,7 @@ jobs:
         run: >-
           meson setup
           --optimization=0
-          -Ddebug_logs=true -Dminidebuginfo=enabled -Dzlibdebuginfo=enabled
+          -Ddebug_logs=true -Dminidebuginfo=enabled -Dzlibdebuginfo=enabled -Dcxx_exceptions=enabled
           --warnlevel 2 --fatal-meson-warnings
           builddir
         shell: alpine.sh {0}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+    - name: Install build dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y liblzma-dev zlib1g-dev
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3.29.5
       with:

--- a/cross/loongarch64-linux-gnu.ini
+++ b/cross/loongarch64-linux-gnu.ini
@@ -1,0 +1,12 @@
+[binaries]
+c = 'loongarch64-linux-gnu-gcc'
+cpp = 'loongarch64-linux-gnu-g++'
+ar = 'loongarch64-linux-gnu-ar'
+strip = 'loongarch64-linux-gnu-strip'
+exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-loongarch64', '--gcc=loongarch64-linux-gnu-gcc']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'loongarch64'
+cpu = 'loongarch64'
+endian = 'little'

--- a/cross/sh4-linux-gnu.ini
+++ b/cross/sh4-linux-gnu.ini
@@ -1,0 +1,12 @@
+[binaries]
+c = 'sh4-linux-gnu-gcc'
+cpp = 'sh4-linux-gnu-g++'
+ar = 'sh4-linux-gnu-ar'
+strip = 'sh4-linux-gnu-strip'
+exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-sh4', '--gcc=sh4-linux-gnu-gcc']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'sh4'
+cpu = 'sh4'
+endian = 'little'

--- a/meson.build
+++ b/meson.build
@@ -324,24 +324,9 @@ build_setjmp = get_option('setjmp').require(
     unw_remote_only,
 ).allowed()
 
-# Determine whether we should support the C++ unwinding interface (_Unwind_*)
-# Matches configure.ac: disable for arches where the toolchain's libgcc provides
-# _Unwind_*, enable for arches where libunwind provides it (ppc64le, riscv64, etc.)
-support_cxx_exceptions = get_option('cxx_exceptions').require(
-    host_machine.cpu_family() not in [
-        'aarch64',
-        'alpha',
-        'arm',
-        'parisc',  # Meson cpu_family name for hppa
-        'mips',
-        'mips64',
-        'x86',
-        'x86_64',
-        's390x',
-        'loongarch64',
-    ],
-    error_message: 'not supported on this architecture',
-).allowed()
+# Determine whether we should support the C++ unwinding interface (_Unwind_*).
+# No arch restriction: opt-in only (default disabled), matching configure.ac.
+support_cxx_exceptions = get_option('cxx_exceptions').allowed()
 
 # Propagate other options through to the code as #defines
 if get_option('weak_backtrace')

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1468,6 +1468,17 @@ MAINTAINERCLEANFILES = Makefile.in
 
 abi_srcdir = "$(top_srcdir)/src/abi"
 abi_targetdir = "$(abi_srcdir)/$(arch)/$(target_os)"
+
+# The checked-in baselines are generated without --enable-cxx-exceptions, so
+# when it's on, additionally suppress reports about the extra _Unwind_*
+# symbols it adds -- they're expected, not a regression.
+if SUPPORT_CXX_EXCEPTIONS
+ABI_SUPPRESSIONS = --suppressions "$(abi_srcdir)/libunwind.supp" \
+                    --suppressions "$(abi_srcdir)/cxx-exceptions.supp"
+else
+ABI_SUPPRESSIONS = --suppressions "$(abi_srcdir)/libunwind.supp"
+endif
+
 .abi.abidiff:
 	$(AM_V_GEN)if test ! -f "$<"; then \
 		printf "(no ABI dump for %s, is libabigail installed?)\n" "$<"; \
@@ -1476,9 +1487,10 @@ abi_targetdir = "$(abi_srcdir)/$(arch)/$(target_os)"
 		printf "Create one with: make -C src %s && cp src/%s %s/\n" \
 		       "$<" "$<" "$(abi_targetdir)"; \
 	else \
-		$(ABIDIFF) --suppressions "$(abi_srcdir)/libunwind.supp" \
+		$(ABIDIFF) $(ABI_SUPPRESSIONS) \
 		           -l "$(abi_targetdir)/$<" "$<" >$@ 2>&1; \
-		if test -s $@; then \
+		abidiff_status=$$?; \
+		if test $$abidiff_status -ne 0; then \
 			cat $@; \
 			printf "%s does not match its ABI baseline in %s\n" "$<" "$(abi_targetdir)"; \
 			printf "If the change is intended, update the baseline with:\n"; \

--- a/src/abi/cxx-exceptions.supp
+++ b/src/abi/cxx-exceptions.supp
@@ -1,0 +1,16 @@
+# Abigail suppressions file
+#
+# The symbols below are only exported when libunwind is built with
+# --enable-cxx-exceptions / -Dcxx_exceptions=enabled. They are expected
+# additions on top of the arch's checked-in baseline (which is generated
+# without that option) on any arch where CI builds with the option on, so
+# suppress reports about them being *added* -- but not about them being
+# removed or changed, since that would still indicate a real regression.
+
+# _Unwind_* symbols are exported under an internal alias too
+# (__libunwind_Unwind_*). abidiff matches symbol_name_regexp against the
+# combined primary-name+aliases string, so this must stay unanchored -- an
+# anchored ^...$ pattern won't match past the first name in that string.
+[suppress_function]
+  change_kind = added-function
+  symbol_name_regexp = _Unwind_|_Read[SU]LEB

--- a/src/abi/meson.build
+++ b/src/abi/meson.build
@@ -21,7 +21,18 @@ _abi_cmd = [
     '--out-file',
     '@OUTPUT@',
 ]
-_abidiff_cmd = [abidiff, '--suppressions', files('libunwind.supp'), '-l']
+# The checked-in baselines are generated without cxx_exceptions, so when it's
+# enabled, additionally suppress reports about the extra _Unwind_* symbols it
+# adds -- they're expected, not a regression.
+_abi_suppressions = [files('libunwind.supp')]
+if support_cxx_exceptions
+    _abi_suppressions += files('cxx-exceptions.supp')
+endif
+_abidiff_cmd = [abidiff]
+foreach _supp : _abi_suppressions
+    _abidiff_cmd += ['--suppressions', _supp]
+endforeach
+_abidiff_cmd += ['-l']
 _abidiffs = []
 foreach _lib : _libs
     _abifn = 'lib@0@.abi'.format(_lib.name())

--- a/src/loongarch64/Gresume.c
+++ b/src/loongarch64/Gresume.c
@@ -41,8 +41,8 @@ loongarch64_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
     {
       /* Since there are no signals involved here we restore EH and non scratch
          registers only.  */
-      register void *gregs asm("$t0") = uc->uc_mcontext.__gregs;
-      asm volatile (
+      register void *gregs __asm__("$t0") = uc->uc_mcontext.__gregs;
+      __asm__ volatile (
         "ld.d $ra, %0, 8\n"
         "ld.d $sp, %0, 3*8\n"
         "ld.d $a0, %0, 4*8\n"
@@ -77,7 +77,7 @@ loongarch64_local_resume (unw_addr_space_t as, unw_cursor_t *cursor, void *arg)
       Debug (8, "resuming at ip=0x%lx via sigreturn() (trampoline @ 0x%lx, sp @ 0x%lx)\n",
         c->dwarf.ip, c->sigcontext_pc, c->sigcontext_sp);
 
-      asm volatile (
+      __asm__ volatile (
         "move $sp, %0\n"
         "jr %1\n"
         : : "r" (c->sigcontext_sp), "r" (c->sigcontext_pc)

--- a/src/meson.build
+++ b/src/meson.build
@@ -62,6 +62,7 @@ if target_machine.system() == 'linux'
     _libunwind_srcs_x86_os_local = files(
         'x86/Los-linux.c',
         'x86/getcontext-linux.S',
+        'x86/setcontext.S',
     )
     _libunwind_srcs_x86_64_os = files('x86_64/Gos-linux.c')
     _libunwind_srcs_x86_64_os_local = files('x86_64/Los-linux.c')

--- a/src/sparc64/Ginit_local.c
+++ b/src/sparc64/Ginit_local.c
@@ -50,7 +50,7 @@ unw_init_local_common (unw_cursor_t *cursor, unw_context_t *uc, unsigned use_pre
      that DWARF-based unwinding can read I-registers from memory.  Without
      this, unspilled windows contain stale/garbage data and the unwind chain
      never terminates.  */
-  asm volatile ("flushw");
+  __asm__ volatile ("flushw");
 
   if (!atomic_load(&tdep_init_done))
     tdep_init ();

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -162,9 +162,10 @@ if USE_ELF64
  check_PROGRAMS_cdep += test-elf64-gnu-hash
 endif
 
-if SUPPORT_CXX_EXCEPTIONS
- check_PROGRAMS_cdep += Ltest-cxx-exceptions
-endif
+# Doesn't need SUPPORT_CXX_EXCEPTIONS (libunwind's own _Unwind_* API): this
+# just throws/catches via the toolchain's libgcc and checks that libunwind's
+# DWARF unwinder can walk the frames.
+check_PROGRAMS_cdep += Ltest-cxx-exceptions
 
 if ARCH_IA64
  check_PROGRAMS_cdep += Gtest-dyn1 Ltest-dyn1

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -55,7 +55,15 @@ if host_machine.system() != 'windows'
     )
     test(_exe.name(), _exe, env: _env)
 
-    if not unw_remote_only
+    # lzma_dep/zlib_dep are occasionally resolved to a shared object with no
+    # matching static archive (e.g. Ubuntu's liblzma-dev/zlib1g-dev), which
+    # -static can't link against. Probe for that instead of assuming it works.
+    if not unw_remote_only and cc.links(
+        'int main(void) { return 0; }',
+        args: ['-static'],
+        dependencies: [libc_deps, lzma_dep, zlib_dep],
+        name: 'fully static linking',
+    )
         _exe = executable(
             'test-static-link',
             'test-static-link-loc.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -892,21 +892,22 @@ if not unw_remote_only
         test(_exe.name(), _exe, env: _env)
     endif
 
-    if support_cxx_exceptions
-        _exe = executable(
-            'Ltest-cxx-exceptions',
-            'Ltest-cxx-exceptions.cxx',
-            link_with: libunwind_lib,
-            include_directories: _inc,
-            dependencies: [libc_deps],
-            override_options: _opts,
-        )
-        test(
-            _exe.name(),
-            _exe,
-            env: _env,
-        )
-    endif
+    # Doesn't need support_cxx_exceptions (libunwind's own _Unwind_* API):
+    # this just throws/catches via the toolchain's libgcc and checks that
+    # libunwind's DWARF unwinder can walk the frames.
+    _exe = executable(
+        'Ltest-cxx-exceptions',
+        'Ltest-cxx-exceptions.cxx',
+        link_with: libunwind_lib,
+        include_directories: _inc,
+        dependencies: [libc_deps],
+        override_options: _opts,
+    )
+    test(
+        _exe.name(),
+        _exe,
+        env: _env,
+    )
 
     if target_machine.system() == 'linux' and build_coredump
         _crasher = executable(


### PR DESCRIPTION
## Summary
- C++ exception support is disabled by default but we should still test it in CI
- Enable `--enable-cxx-exceptions` / `-Dcxx_exceptions=enabled` in the Linux GNU, Linux musl, and FreeBSD jobs
- Add `g++` to the Alpine package lists for the musl jobs, since `build-base` does not pull it in

## Test plan
- [x] CI passes on all affected jobs