### PR TITLE
ci: upgrade base packages before installing foreign-arch dev packages

### DIFF
--- a/.github/workflows/CI-linux-gnu.yml
+++ b/.github/workflows/CI-linux-gnu.yml
@@ -144,6 +144,11 @@ jobs:
             echo "deb [arch=$DPKG_ARCH] http://ports.ubuntu.com/ubuntu-ports $CODENAME-updates main restricted universe" \
               >> /etc/apt/sources.list.d/ports.list
             apt-get update
+            # zlib1g and friends are Multi-Arch: same, so the foreign-arch
+            # package must match the installed amd64 version exactly. The
+            # base image lags the archive, so upgrade before pulling in any
+            # :$DPKG_ARCH development packages.
+            apt-get upgrade -y
           fi
           apt-get install -y autoconf automake libtool make \
                              ${{ matrix.config.packages || format('g++-{0}-{1}', matrix.config.gccver, matrix.config.host) }} \
@@ -370,6 +375,11 @@ jobs:
             echo "deb [arch=$DPKG_ARCH] http://ports.ubuntu.com/ubuntu-ports $CODENAME-updates main restricted universe" \
               >> /etc/apt/sources.list.d/ports.list
             apt-get update
+            # zlib1g and friends are Multi-Arch: same, so the foreign-arch
+            # package must match the installed amd64 version exactly. The
+            # base image lags the archive, so upgrade before pulling in any
+            # :$DPKG_ARCH development packages.
+            apt-get upgrade -y
           fi
           apt-get install -y meson ninja-build \
                              ${{ matrix.config.packages || format('g++-{0}-{1}', matrix.config.gccver, matrix.config.host) }} \


### PR DESCRIPTION
The meson cross jobs that enable a foreign dpkg architecture (arm64, armhf, ppc64el, riscv64, s390x) fail while installing the toolchain:
```
  zlib1g-dev:riscv64 : Depends: zlib1g:riscv64 (= 1:1.3.dfsg+really1.3.1-1ubuntu3) but it is not going to be installed
  E: Broken packages
```
zlib1g is Multi-Arch: same, so zlib1g:$DPKG_ARCH must match the version of zlib1g:amd64 already installed in the container. The ubuntu:26.04 image ships 1:1.3.dfsg+really1.3.1-1ubuntu3 while the archive has moved on to -1ubuntu3.1 in resolute-updates, and apt refuses to reconcile the two, so the install aborts.

Run apt-get upgrade after adding the ports sources so the amd64 side is current before any :$DPKG_ARCH development package is requested. Do it in the autotools cross job too: it only escapes today because liblzma5 happens to have no pending update.