### PR TITLE
tests: fix Ltest-mem-validate gating on x86_64 and s390x

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -117,8 +117,10 @@ endif
  noinst_PROGRAMS_cdep += forker Gperf-simple Lperf-simple \
 			Gperf-trace Lperf-trace
 
-# only enable Ltest-mem-validate on archs without conservative checks
-if !CONSERVATIVE_CHECKS
+# x86_64 and s390x only validate memory addresses while unwinding when
+# conservative checks are enabled, so the test can only pass there in that
+# configuration.  Every other arch validates unconditionally.
+if CONSERVATIVE_CHECKS
  check_PROGRAMS_cdep += Ltest-mem-validate
 else #CONSERVATIVE_CHECKS
 if !ARCH_X86_64

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -221,8 +221,10 @@ if not unw_remote_only
     )
     test(_exe.name(), _exe, env: _env)
 
-    # Only enable Ltest-mem-validate on archs without conservative checks.
-    if not cfg.has('CONSERVATIVE_CHECKS') or target_machine.cpu_family() not in [
+    # x86_64 and s390x only validate memory addresses while unwinding when
+    # conservative checks are enabled, so the test can only pass there in that
+    # configuration.  Every other arch validates unconditionally.
+    if cfg.has('CONSERVATIVE_CHECKS') or target_machine.cpu_family() not in [
         'x86_64',
         's390x',
     ]


### PR DESCRIPTION
Ltest-mem-validate mprotects a stack page PROT_NONE and expects the unwinder to stop gracefully instead of faulting. That only works if unw_step validates addresses before dereferencing them.

On x86_64 and s390x that validation is compiled out unless conservative checks are enabled: unw_step only calls dwarf_set_validate() inside #if CONSERVATIVE_CHECKS (src/x86_64/Gstep.c, src/s390x/Gstep.c), and access_mem() dereferences unvalidated addresses otherwise. Every other arch sets c->validate unconditionally in unw_step, so the test works there regardless.

The gating added in 998b2cf3 was therefore inverted: it built the test exactly when the support it needs was absent. On x86_64 with --disable-conservative-checks (-Dconservative_checks=false) the test segfaults in access_mem() and the suite fails.

Build it when conservative checks are enabled, or on the other arches, which validate regardless. Verified on x86_64 with both build systems: with conservative checks the test is built and passes; without, it is not built and the suite has no failures.