### PR TITLE
Fix test-ptrace on multilib x86 builds and stop faking an .eh_frame_hdr on the stack

### DIFF
--- a/.github/workflows/CI-linux-gnu.yml
+++ b/.github/workflows/CI-linux-gnu.yml
@@ -390,6 +390,7 @@ jobs:
           cc="${gcc_prefix}-gcc-${{ matrix.config.gccver }}"
           cxx="${gcc_prefix}-g++-${{ matrix.config.gccver }}"
           ar="${gcc_prefix}-ar"
+          nm="${gcc_prefix}-nm"
           strip_tool="${gcc_prefix}-strip"
 
           ew="['$PWD/scripts/meson-qemu-exe-wrapper', '--qemu=qemu-${{ matrix.config.qemu }}', '--gcc=${cc}'"
@@ -402,6 +403,7 @@ jobs:
             printf "c = '%s'\n"   "${cc}"
             printf "cpp = '%s'\n" "${cxx}"
             printf "ar = '%s'\n"  "${ar}"
+            printf "nm = '%s'\n"  "${nm}"
             printf "strip = '%s'\n" "${strip_tool}"
             printf "exe_wrapper = %s\n" "${ew}"
             if [ -n "${{ matrix.config.meson_c_args }}" ]; then

--- a/configure.ac
+++ b/configure.ac
@@ -266,6 +266,8 @@ AM_COND_IF([CONFIG_TESTS], [
                         [AC_SUBST([BACKTRACELIB],["$ac_cv_search_backtrace"])])])
   LIBS="$old_LIBS"
   AC_CONFIG_FILES([tests/Makefile])
+  dnl check-namespace.sh reads the built libraries with $NM, which libtool
+  dnl points at the nm that goes with the compiler.
   AC_CONFIG_FILES([tests/check-namespace.sh], [chmod +x tests/check-namespace.sh])
 ])
 AC_ARG_WITH([testdriver],
@@ -346,8 +348,23 @@ AC_MSG_RESULT([$target_arch])
 AC_MSG_CHECKING([for target operating system])
 AC_MSG_RESULT([$target_os])
 
-AM_CONDITIONAL([XFAIL_PTRACE_TEST], [echo $CFLAGS | grep -q '\-m32\>'])
-AM_CONDITIONAL([CROSS_BUILD], [test x$build != x$host])
+dnl A build for a different host is not necessarily one whose programs
+dnl cannot be run here: a multilib build (--host=i686-pc-linux-gnu with
+dnl CFLAGS=-m32 on an x86_64 machine, say) produces programs that run
+dnl natively, and binfmt_misc may take care of the rest.  The test suite
+dnl uses this to decide whether it can run the shell scripts that drive
+dnl the test programs directly.
+AC_CACHE_CHECK([whether programs built for $host can be run],
+  [libunwind_cv_run_host_binaries],
+  [AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],
+     [if ./conftest$EXEEXT >&AS_MESSAGE_LOG_FD 2>&1; then
+        libunwind_cv_run_host_binaries=yes
+      else
+        libunwind_cv_run_host_binaries=no
+      fi],
+     [libunwind_cv_run_host_binaries=no])])
+AM_CONDITIONAL([RUN_HOST_BINARIES],
+               [test x$libunwind_cv_run_host_binaries = xyes])
 AM_CONDITIONAL(REMOTE_ONLY, test x$target_arch != x$host_arch)
 AM_CONDITIONAL(ARCH_AARCH64, test x$target_arch = xaarch64)
 AM_CONDITIONAL(ARCH_ALPHA, test x$target_arch = xalpha)

--- a/cross/aarch64-unknown-linux-gnu.ini
+++ b/cross/aarch64-unknown-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'aarch64-unknown-linux-gnu-gcc'
 cpp = 'aarch64-unknown-linux-gnu-g++'
 ar = 'aarch64-unknown-linux-gnu-ar'
+nm = 'aarch64-unknown-linux-gnu-nm'
 strip = 'aarch64-unknown-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-aarch64', '--gcc=aarch64-unknown-linux-gnu-gcc']
 

--- a/cross/alpha-unknown-linux-gnu.ini
+++ b/cross/alpha-unknown-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'alpha-unknown-linux-gnu-gcc'
 cpp = 'alpha-unknown-linux-gnu-g++'
 ar = 'alpha-unknown-linux-gnu-ar'
+nm = 'alpha-unknown-linux-gnu-nm'
 strip = 'alpha-unknown-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-alpha', '--gcc=alpha-unknown-linux-gnu-gcc']
 

--- a/cross/arm-linux-gnueabi.ini
+++ b/cross/arm-linux-gnueabi.ini
@@ -2,6 +2,7 @@
 c = 'arm-linux-gnueabi-gcc'
 cpp = 'arm-linux-gnueabi-g++'
 ar = 'arm-linux-gnueabi-ar'
+nm = 'arm-linux-gnueabi-nm'
 strip = 'arm-linux-gnueabi-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-arm', '--gcc=arm-linux-gnueabi-gcc']
 

--- a/cross/arm-linux-gnueabihf.ini
+++ b/cross/arm-linux-gnueabihf.ini
@@ -2,6 +2,7 @@
 c = 'arm-linux-gnueabihf-gcc'
 cpp = 'arm-linux-gnueabihf-g++'
 ar = 'arm-linux-gnueabihf-ar'
+nm = 'arm-linux-gnueabihf-nm'
 strip = 'arm-linux-gnueabihf-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-arm', '--gcc=arm-linux-gnueabihf-gcc']
 

--- a/cross/hppa-linux-gnu.ini
+++ b/cross/hppa-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'hppa-linux-gnu-gcc'
 cpp = 'hppa-linux-gnu-g++'
 ar = 'hppa-linux-gnu-ar'
+nm = 'hppa-linux-gnu-nm'
 strip = 'hppa-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-hppa', '--gcc=hppa-linux-gnu-gcc']
 

--- a/cross/loongarch64-linux-gnu.ini
+++ b/cross/loongarch64-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'loongarch64-linux-gnu-gcc'
 cpp = 'loongarch64-linux-gnu-g++'
 ar = 'loongarch64-linux-gnu-ar'
+nm = 'loongarch64-linux-gnu-nm'
 strip = 'loongarch64-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-loongarch64', '--gcc=loongarch64-linux-gnu-gcc']
 

--- a/cross/mips-linux-gnu.ini
+++ b/cross/mips-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'mips-linux-gnu-gcc'
 cpp = 'mips-linux-gnu-g++'
 ar = 'mips-linux-gnu-ar'
+nm = 'mips-linux-gnu-nm'
 strip = 'mips-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-mips', '--gcc=mips-linux-gnu-gcc']
 

--- a/cross/mips64-unknown-linux-gnu.ini
+++ b/cross/mips64-unknown-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'mips64-unknown-linux-gnu-gcc'
 cpp = 'mips64-unknown-linux-gnu-g++'
 ar = 'mips64-unknown-linux-gnu-ar'
+nm = 'mips64-unknown-linux-gnu-nm'
 strip = 'mips64-unknown-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-mips64', '--gcc=mips64-unknown-linux-gnu-gcc']
 

--- a/cross/mips64el-unknown-linux-gnu.ini
+++ b/cross/mips64el-unknown-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'mips64el-unknown-linux-gnu-gcc'
 cpp = 'mips64el-unknown-linux-gnu-g++'
 ar = 'mips64el-unknown-linux-gnu-ar'
+nm = 'mips64el-unknown-linux-gnu-nm'
 strip = 'mips64el-unknown-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-mips64el', '--gcc=mips64el-unknown-linux-gnu-gcc']
 

--- a/cross/mipsel-linux-gnu.ini
+++ b/cross/mipsel-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'mipsel-linux-gnu-gcc'
 cpp = 'mipsel-linux-gnu-g++'
 ar = 'mipsel-linux-gnu-ar'
+nm = 'mipsel-linux-gnu-nm'
 strip = 'mipsel-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-mipsel', '--gcc=mipsel-linux-gnu-gcc']
 

--- a/cross/mipsn32-unknown-linux-gnu.ini
+++ b/cross/mipsn32-unknown-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'mips64-unknown-linux-gnu-gcc'
 cpp = 'mips64-unknown-linux-gnu-g++'
 ar = 'mips64-unknown-linux-gnu-ar'
+nm = 'mips64-unknown-linux-gnu-nm'
 strip = 'mips64-unknown-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-mipsn32', '--gcc=mips64-unknown-linux-gnu-gcc', '--gcc-flags=-mabi=n32']
 

--- a/cross/mipsn32el-unknown-linux-gnu.ini
+++ b/cross/mipsn32el-unknown-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'mips64el-unknown-linux-gnu-gcc'
 cpp = 'mips64el-unknown-linux-gnu-g++'
 ar = 'mips64el-unknown-linux-gnu-ar'
+nm = 'mips64el-unknown-linux-gnu-nm'
 strip = 'mips64el-unknown-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-mipsn32el', '--gcc=mips64el-unknown-linux-gnu-gcc', '--gcc-flags=-mabi=n32']
 

--- a/cross/powerpc-unknown-linux-gnu.ini
+++ b/cross/powerpc-unknown-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'powerpc-unknown-linux-gnu-gcc'
 cpp = 'powerpc-unknown-linux-gnu-g++'
 ar = 'powerpc-unknown-linux-gnu-ar'
+nm = 'powerpc-unknown-linux-gnu-nm'
 strip = 'powerpc-unknown-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-ppc', '--gcc=powerpc-unknown-linux-gnu-gcc']
 

--- a/cross/powerpc64-unknown-linux-gnu.ini
+++ b/cross/powerpc64-unknown-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'powerpc64-unknown-linux-gnu-gcc'
 cpp = 'powerpc64-unknown-linux-gnu-g++'
 ar = 'powerpc64-unknown-linux-gnu-ar'
+nm = 'powerpc64-unknown-linux-gnu-nm'
 strip = 'powerpc64-unknown-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-ppc64', '--gcc=powerpc64-unknown-linux-gnu-gcc', '--xfail=Gtest-bt:Gtest-concurrent:Gtest-resume-sig:Gtest-resume-sig-rt:Gtest-trace:Ltest-bt:Ltest-concurrent:Ltest-init-local-signal:Ltest-resume-sig:Ltest-resume-sig-rt:Ltest-sig-context:Ltest-trace']
 

--- a/cross/powerpc64le-unknown-linux-gnu.ini
+++ b/cross/powerpc64le-unknown-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'powerpc64le-unknown-linux-gnu-gcc'
 cpp = 'powerpc64le-unknown-linux-gnu-g++'
 ar = 'powerpc64le-unknown-linux-gnu-ar'
+nm = 'powerpc64le-unknown-linux-gnu-nm'
 strip = 'powerpc64le-unknown-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-ppc64le', '--gcc=powerpc64le-unknown-linux-gnu-gcc', '--xfail=Gtest-bt:Gtest-concurrent:Gtest-resume-sig:Gtest-resume-sig-rt:Gtest-trace:Ltest-bt:Ltest-concurrent:Ltest-init-local-signal:Ltest-resume-sig:Ltest-resume-sig-rt:Ltest-sig-context:Ltest-trace']
 

--- a/cross/riscv64-unknown-linux-gnu.ini
+++ b/cross/riscv64-unknown-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'riscv64-unknown-linux-gnu-gcc'
 cpp = 'riscv64-unknown-linux-gnu-g++'
 ar = 'riscv64-unknown-linux-gnu-ar'
+nm = 'riscv64-unknown-linux-gnu-nm'
 strip = 'riscv64-unknown-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-riscv64', '--gcc=riscv64-unknown-linux-gnu-gcc']
 

--- a/cross/s390x-ibm-linux-gnu.ini
+++ b/cross/s390x-ibm-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 's390x-ibm-linux-gnu-gcc'
 cpp = 's390x-ibm-linux-gnu-g++'
 ar = 's390x-ibm-linux-gnu-ar'
+nm = 's390x-ibm-linux-gnu-nm'
 strip = 's390x-ibm-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-s390x', '--gcc=s390x-ibm-linux-gnu-gcc']
 

--- a/cross/sh4-linux-gnu.ini
+++ b/cross/sh4-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'sh4-linux-gnu-gcc'
 cpp = 'sh4-linux-gnu-g++'
 ar = 'sh4-linux-gnu-ar'
+nm = 'sh4-linux-gnu-nm'
 strip = 'sh4-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-sh4', '--gcc=sh4-linux-gnu-gcc']
 

--- a/cross/sparc64-linux-gnu.ini
+++ b/cross/sparc64-linux-gnu.ini
@@ -2,6 +2,7 @@
 c = 'sparc64-linux-gnu-gcc'
 cpp = 'sparc64-linux-gnu-g++'
 ar = 'sparc64-linux-gnu-ar'
+nm = 'sparc64-linux-gnu-nm'
 strip = 'sparc64-linux-gnu-strip'
 exe_wrapper = ['meson-qemu-exe-wrapper', '--qemu=qemu-sparc64', '--gcc=sparc64-linux-gnu-gcc']
 

--- a/src/dwarf/Gfind_proc_info-lsb.c
+++ b/src/dwarf/Gfind_proc_info-lsb.c
@@ -557,7 +557,7 @@ dwarf_callback (struct dl_phdr_info *info, size_t size, void *ptr)
   unw_accessors_t *a;
   long n;
   int found = 0;
-  struct dwarf_eh_frame_hdr synth_eh_frame_hdr;
+  Elf_W (Addr) eh_frame = 0;
 #ifdef CONFIG_DEBUG_FRAME
   unw_word_t start, end;
 #endif /* CONFIG_DEBUG_FRAME*/
@@ -611,24 +611,14 @@ dwarf_callback (struct dl_phdr_info *info, size_t size, void *ptr)
     }
   else
     {
-      Elf_W (Addr) eh_frame;
       Debug (1, "no .eh_frame_hdr section found\n");
       eh_frame = dwarf_find_eh_frame_section (info);
       if (eh_frame)
-        {
-          Debug (1, "using synthetic .eh_frame_hdr section for %s\n",
-                 info->dlpi_name);
-	  synth_eh_frame_hdr.version = DW_EH_VERSION;
-	  synth_eh_frame_hdr.eh_frame_ptr_enc = DW_EH_PE_absptr |
-	    ((sizeof(Elf_W (Addr)) == 4) ? DW_EH_PE_udata4 : DW_EH_PE_udata8);
-          synth_eh_frame_hdr.fde_count_enc = DW_EH_PE_omit;
-          synth_eh_frame_hdr.table_enc = DW_EH_PE_omit;
-	  synth_eh_frame_hdr.eh_frame = eh_frame;
-          hdr = &synth_eh_frame_hdr;
-        }
+        Debug (1, "using the .eh_frame section of %s directly\n",
+               info->dlpi_name);
     }
 
-  if (hdr)
+  if (hdr || eh_frame)
     {
       if (p_dynamic)
         {
@@ -651,6 +641,28 @@ dwarf_callback (struct dl_phdr_info *info, size_t size, void *ptr)
            absolute.  */
         di->gp = 0;
       pi->gp = di->gp;
+
+      if (hdr == NULL)
+        {
+          /* There is no .eh_frame_hdr section, hence no binary search
+             table: search the .eh_frame section linearly.  */
+          eh_frame_start = eh_frame;
+          eh_frame_end = max_load_addr; /* XXX can we do better? */
+          fde_count = ~0UL;
+
+          Debug (1, "eh_frame_start = %lx eh_frame_end = %lx\n",
+                 eh_frame_start, eh_frame_end);
+
+          found = linear_search (unw_local_addr_space, ip,
+                                 eh_frame_start, eh_frame_end, fde_count,
+                                 pi, need_unwind_info, NULL);
+          if (found != 1)
+            found = 0;
+          else
+            cb_data->single_fde = 1;
+
+          goto out;
+        }
 
       if (hdr->version != DW_EH_VERSION)
         {
@@ -734,6 +746,7 @@ dwarf_callback (struct dl_phdr_info *info, size_t size, void *ptr)
         }
     }
 
+out:
 #ifdef CONFIG_DEBUG_FRAME
   /* Find the start/end of the described region by parsing the phdr_info
      structure.  */

--- a/src/os-linux.c
+++ b/src/os-linux.c
@@ -34,8 +34,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "os-linux.h"
 
 #ifndef MAX_VDSO_SIZE
-/*Dont know what is the Max Size in my system it was 8192 or twice the page size*/
-# define MAX_VDSO_SIZE ((size_t) 2 * sysconf (_SC_PAGESIZE))
+/* An upper bound on the size of an anonymous mapping worth copying out of
+   the target in the hope that it is the vDSO.  Two pages was too small: the
+   32-bit vDSO of a current Linux kernel is mapped with three.  */
+# define MAX_VDSO_SIZE ((size_t) 8 * sysconf (_SC_PAGESIZE))
 #endif
 
 #ifndef MAP_32BIT

--- a/src/x86/Gstep.c
+++ b/src/x86/Gstep.c
@@ -58,7 +58,12 @@ unw_step (unw_cursor_t *cursor)
 
   if (unlikely (ret < 0))
     {
-      /* DWARF failed, let's see if we can follow the frame-chain */
+      /* DWARF failed, let's see if we can follow the frame-chain.  This is
+         guesswork: without unwind info there is nothing that says EBP holds
+         a frame pointer here, so a read that fails means the guess was
+         wrong, not that the target is broken.  Report the end of the stack
+         rather than an error in that case, as there is nowhere left to go
+         either way.  */
       struct dwarf_loc ebp_loc, eip_loc, esp_loc;
 
 
@@ -67,8 +72,9 @@ unw_step (unw_cursor_t *cursor)
       ret = dwarf_get (&c->dwarf, c->dwarf.loc[EBP], &c->dwarf.cfa);
       if (ret < 0)
         {
-          Debug (2, "returning %d\n", ret);
-          return ret;
+          Debug (13, "dwarf_get([EBP=0x%x]) failed\n", DWARF_GET_LOC (c->dwarf.loc[EBP]));
+          Debug (2, "returning 0\n");
+          return 0;
         }
 
       Debug (13, "[EBP=0x%x] = 0x%x\n", DWARF_GET_LOC (c->dwarf.loc[EBP]), c->dwarf.cfa);
@@ -98,8 +104,7 @@ unw_step (unw_cursor_t *cursor)
           if (ret < 0)
             {
               Debug (13, "dwarf_get([EIP=0x%x]) failed\n", DWARF_GET_LOC (c->dwarf.loc[EIP]));
-              Debug (2, "returning %d\n", ret);
-              return ret;
+              c->dwarf.ip = 0;
             }
           else
             {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -196,10 +196,15 @@ check_SCRIPTS =	$(check_SCRIPTS_common) $(check_SCRIPTS_cdep) \
 		$(check_SCRIPTS_arch)
 
 TESTS = $(check_PROGRAMS)
-if !CROSS_BUILD
- TESTS += $(check_SCRIPTS)
+# check-namespace.sh reads the built libraries with nm instead of running
+# them, so it is as useful in a cross build as in a native one.
+TESTS += $(check_SCRIPTS_common)
+if RUN_HOST_BINARIES
+ TESTS += $(check_SCRIPTS_cdep) $(check_SCRIPTS_arch)
 else
-# For cross builds, include coredump tests - they run under QEMU
+# The remaining test scripts run the test programs directly, so they are of
+# no use when those programs cannot be run here.  The coredump tests are the
+# exception: they invoke QEMU themselves.
 if BUILD_COREDUMP
 if OS_LINUX
  TESTS += run-coredump-unwind
@@ -233,13 +238,6 @@ endif
 
 if ARCH_SPARC64
 XFAIL_TESTS += $(XFAIL_TESTS_PTRACE_SINGLESTEP)
-endif
-
-# This is meant for multilib binaries, -m32.
-# ptrace gives EBADREG when testing,
-# but generally everything else works.
-if XFAIL_PTRACE_TEST
- XFAIL_TESTS += run-ptrace-mapper 
 endif
 
 noinst_PROGRAMS = $(noinst_PROGRAMS_common) $(noinst_PROGRAMS_cdep) \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -143,11 +143,7 @@ endif
 if BUILD_PTRACE
  check_SCRIPTS_cdep += run-ptrace-mapper run-ptrace-misc
  check_PROGRAMS_cdep += test-ptrace
- noinst_PROGRAMS_cdep += mapper test-ptrace-misc
-if ARCH_X86
- # https://github.com/libunwind/libunwind/issues/392
- XFAIL_TESTS += test-ptrace
-endif
+ noinst_PROGRAMS_cdep += mapper ptrace-tracee test-ptrace-misc
 endif
 
 if BUILD_SETJMP

--- a/tests/check-namespace.sh.in
+++ b/tests/check-namespace.sh.in
@@ -31,8 +31,26 @@ plat=@arch@
 os=@target_os@
 num_errors=0
 
+: ${NM:=@NM@}
 : ${LIBUNWIND:=../src/.libs/libunwind.so}
 : ${LIBUNWIND_GENERIC:=../src/.libs/libunwind-${plat}.so}
+
+#
+# The libraries are read, not run, so a cross build is checked just as well
+# as a native one, provided nm understands the target's object files.  A
+# build machine's nm pointed at a foreign object reports no symbols at all,
+# which would look like every symbol going missing: skip instead.
+#
+require_nm () {
+    filename=$1
+
+    if $NM -g $filename > /dev/null 2>&1; then
+	return
+    fi
+
+    echo "  SKIP: $NM cannot read $filename"
+    exit 77
+}
 
 fetch_symtab () {
     filename=$1
@@ -45,14 +63,16 @@ fetch_symtab () {
 	echo "Checking $filename..."
     fi
 
+    require_nm $filename
+
     #
     # Unfortunately, "nm --defined" is a GNU-extension.  For portability,
     # build the list of defined symbols by hand.
     #
-    symtab=`nm -g $filename`
+    symtab=`$NM -g $filename`
+    undef=`$NM -g -u $filename`
     saved_IFS="$IFS"
     IFS=""
-    undef=`nm -g -u $filename`
     for line in $undef; do
 	symtab=`echo "$symtab" | grep -v "^${line}"\$`
     done;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -833,11 +833,18 @@ if not unw_remote_only
     endif
 
     if build_ptrace
+        _tracee = executable(
+            'ptrace-tracee',
+            'ptrace-tracee.c',
+            include_directories: _inc,
+            dependencies: libc_deps,
+            override_options: _opts,
+        )
+
         test(
             _test_ptrace.name(),
             _test_ptrace,
-            # https://github.com/libunwind/libunwind/issues/392
-            should_fail: target_machine.cpu_family() == 'x86',
+            args: [_tracee],
             env: _env,
         )
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,12 @@
 sh = find_program('/bin/sh', 'sh', native: true)
 
+# check-namespace.sh reads the built libraries with nm rather than running
+# them, so it wants the nm that goes with the host compiler.  In a cross build
+# that is whatever the cross file names in [binaries]; with no entry there this
+# finds the build machine's nm, and the test skips itself if that nm cannot
+# read the libraries.
+nm = find_program('nm', required: false)
+
 _check_nms = configure_file(
     output: 'check-namespace.sh',
     input: 'check-namespace.sh.in',
@@ -10,6 +17,7 @@ _check_nms = configure_file(
         ),
         'arch': archnames[target_machine.cpu_family()],
         'target_os': target_machine.system(),
+        'NM': nm.found() ? nm.full_path() : 'nm',
         'CONFIG_WEAK_BACKTRACE_TRUE': get_option('weak_backtrace') ? '' : '# ',
         'enable_cxx_exceptions': support_cxx_exceptions ? 'yes' : 'no',
         'enable_debug_frame': cfg.has('CONFIG_DEBUG_FRAME') ? 'yes' : 'no',
@@ -91,21 +99,16 @@ if build_ptrace
 endif
 
 if not unw_remote_only
-    # Autotools only runs check_SCRIPTS (check-namespace.sh, run-ptrace-mapper,
-    # run-ptrace-misc) for non-cross builds; see tests/Makefile.am's TESTS
-    # assignment.
-    if not meson.is_cross_build()
-        test(
-            'check-namespace.sh',
-            sh,
-            args: [_check_nms, '-v'],
-            depends: [libunwind_lib, libunwind_generic_lib],
-            env: {
-                'LIBUNWIND': libunwind_lib.full_path(),
-                'LIBUNWIND_GENERIC': libunwind_generic_lib.full_path(),
-            },
-        )
-    endif
+    test(
+        'check-namespace.sh',
+        sh,
+        args: [_check_nms, '-v'],
+        depends: [libunwind_lib, libunwind_generic_lib],
+        env: {
+            'LIBUNWIND': libunwind_lib.full_path(),
+            'LIBUNWIND_GENERIC': libunwind_generic_lib.full_path(),
+        },
+    )
 
     _exe = executable(
         'Gtest-bt',
@@ -874,9 +877,9 @@ if not unw_remote_only
             override_options: _opts,
         )
 
-        # Autotools only runs check_SCRIPTS (run-ptrace-mapper, run-ptrace-misc)
-        # for non-cross builds; see tests/Makefile.am's TESTS assignment.
-        if not meson.is_cross_build()
+        # These drive test-ptrace directly, so they are only useful when
+        # programs built for the host can be run here.
+        if meson.can_run_host_binaries()
             test(
                 'run-ptrace-mapper',
                 _test_ptrace,

--- a/tests/ptrace-tracee.c
+++ b/tests/ptrace-tracee.c
@@ -1,0 +1,65 @@
+/* libunwind - a platform-independent unwind library
+
+This file is part of libunwind.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+/* The default tracee for test-ptrace.
+
+   It is built like the rest of the test suite so that the traced
+   process always has the word size the library was configured for: a
+   program taken from the host system does not, in a multilib build, and
+   a process of a different word size cannot be unwound.
+
+   It makes a few system calls and exits, giving test-ptrace something
+   to unwind at each syscall stop without taking long about it.  */
+
+#include <unistd.h>
+
+static void
+level3 (void)
+{
+  (void) getpid ();
+}
+
+static void
+level2 (void)
+{
+  level3 ();
+  (void) getppid ();
+}
+
+static void
+level1 (void)
+{
+  level2 ();
+  (void) getpid ();
+}
+
+int
+main (void)
+{
+  int i;
+
+  for (i = 0; i < 4; ++i)
+    level1 ();
+
+  return 0;
+}

--- a/tests/test-ptrace.c
+++ b/tests/test-ptrace.c
@@ -187,18 +187,22 @@ main (int argc, char **argv)
 
   if (argc == 1)
     {
-#ifdef HAVE_EXECVPE
-      static char *args[] = { "self", "ls", "/", NULL };
-#else
-      static char *args[] = { "self", "/bin/ls", "/", NULL };
-#endif
-      /* automated test case */
+      /* Automated test case: trace the tracee that was built alongside
+         this program.  A program from the host system may have a
+         different word size than the library was built for (a -m32 build
+         on an x86_64 machine, say), and a process of a different word
+         size cannot be unwound.  The test suite runs with the test
+         directory as the working directory; UNW_PTRACE_TRACEE overrides
+         the path for runs from elsewhere.  */
+      static char *args[] = { "self", NULL, NULL };
+      char *tracee = getenv ("UNW_PTRACE_TRACEE");
+
+      /* args[0] stands in for argv[0]; the program to trace is picked up
+         at argv[optind], which is 1 here.  */
+      args[1] = tracee != NULL ? tracee : "./ptrace-tracee";
       argv = args;
 
-      /* Unless the args array is 'walked' the child
-         process is unable to access it and dies with a segfault */
-      fprintf(stderr, "Automated test (%s,%s,%s,%s)\n",
-              args[0],args[1],args[2],args[3]);
+      fprintf (stderr, "Automated test (%s)\n", args[1]);
     }
   else if (argc > 1)
     while (argv[optind][0] == '-')


### PR DESCRIPTION
Three independent fixes, one per commit.

**dwarf: stop building a synthetic .eh_frame_hdr on the stack**

For an object with a .eh_frame section but no .eh_frame_hdr, `dwarf_callback()` filled in a `struct dwarf_eh_frame_hdr` on the stack and ran the ordinary header handling over it. That handling stores the header's address in `di->u.rti.segbase`, which for the synthetic header is the address of a local variable. The store is not reachable today, since the synthetic header sets `table_enc` to `DW_EH_PE_omit` and the linear-search path always wins, but that holds by accident. The fake header never carried anything the code did not already have, so the no-header case now goes straight to the linear search. Closes #650, reported by CodeQL.

**tests: give test-ptrace a tracee built alongside it**

With no arguments, test-ptrace traced `ls` from the host system. On a multilib build that program has the wrong word size, and a 32-bit libunwind cannot unwind a 64-bit process, so every unwind failed. This is why test-ptrace has been marked XFAIL on x86 since 2022; the ptrace register access it was blamed on is fine. Nothing from the host works here, and neither do most programs in the build tree: those linked against libunwind are libtool wrapper scripts, so exec runs /bin/sh.

The new `tests/ptrace-tracee` makes a few system calls and exits. It links nothing, so libtool builds a real executable, and it is built for the host like the rest of the test suite. `UNW_PTRACE_TRACEE` overrides the path for runs from outside the test directory. test-ptrace passes in an i686-pc-linux-gnu build on an x86_64 machine, so the expected failure is gone. Closes #392, and with it the last open item of #393.

**tests: run the test scripts whenever host programs can be run**

check-namespace.sh and the two run-ptrace-* scripts only ran when the build and host triplets matched. A multilib build has build != host yet produces programs that run natively, and binfmt_misc covers some other cases, so those builds lost the coverage for no reason. configure now links a trivial program for the host and tries to run it; meson uses `meson.can_run_host_binaries()`, which also accounts for a configured exe wrapper. Under an emulator without ptrace support the tests skip, as they do today. run-ptrace-mapper passes once it runs in a -m32 build, so its expected failure and the -m32 check behind it are dropped.

Tested on x86_64:

| build | result |
| --- | --- |
| autotools, `--host=i686-pc-linux-gnu CFLAGS=-m32` | 43 pass, 0 fail, 0 xfail, 0 xpass |
| autotools, x86_64 | 45 pass, 0 fail |
| meson, native | 44 ok, 0 fail |
| meson, cross to i686 with the CI cross file | 43 ok, 0 fail |

Each commit was configured, built, and tested on its own in the -m32 configuration, so the series stays bisectable. A real cross build (aarch64-unknown-linux-gnu) reports `whether programs built for aarch64-unknown-linux-gnu can be run... no` and keeps excluding the scripts; test-ptrace still skips there, since PTRACE_TRACEME fails under qemu-user.
